### PR TITLE
feat: support adaptive speculative with per-seq validate pruning.

### DIFF
--- a/tests/core/runtime/CMakeLists.txt
+++ b/tests/core/runtime/CMakeLists.txt
@@ -95,6 +95,31 @@ if(EXISTS "$ENV{PYTORCH_INSTALL_PATH}/../torch.libs")
     "-Wl,-rpath-link,$ENV{PYTORCH_INSTALL_PATH}/../torch.libs")
 endif()
 
+cc_test(
+  NAME
+    adaptive_speculative_controller_test
+  SRCS
+    adaptive_speculative_controller_test.cpp
+    "${PROJECT_SOURCE_DIR}/xllm/core/framework/speculative/adaptive_speculative_controller.cpp"
+    "${PROJECT_SOURCE_DIR}/xllm/core/framework/speculative/speculative_profile_registry.cpp"
+  DEPS
+    torch
+    glog::glog
+    proto::xllm_proto
+    GTest::gtest_main
+)
+
+cc_test(
+  NAME
+    speculative_profile_registry_test
+  SRCS
+    speculative_profile_registry_test.cpp
+    "${PROJECT_SOURCE_DIR}/xllm/core/framework/speculative/speculative_profile_registry.cpp"
+  DEPS
+    glog::glog
+    GTest::gtest_main
+)
+
 if(USE_MLU)
   cc_test(
     NAME

--- a/tests/core/runtime/adaptive_speculative_controller_test.cpp
+++ b/tests/core/runtime/adaptive_speculative_controller_test.cpp
@@ -1,0 +1,125 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "core/framework/speculative/adaptive_speculative_controller.h"
+
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+
+#include <vector>
+
+#include "core/framework/speculative/speculative_profile_registry.h"
+#include "runtime/options.h"
+
+namespace xllm {
+namespace {
+
+runtime::Options make_options() {
+  runtime::Options options;
+  options.enable_adaptive_speculative_decode(true)
+      .num_speculative_tokens(4)
+      .speculative_algorithm("MTP")
+      .enable_graph(false)
+      .adaptive_speculative_min_gain(0.0);
+  return options;
+}
+
+void setup_registry() {
+  SpeculativeProfileRegistry::ValidateTimePredictor predictor;
+  predictor.intercept_ms = 1.0;
+  predictor.batch_ms = 0.1;
+  predictor.query_token_ms = 0.5;
+  predictor.query_prefix_ms = 0.001;
+  SpeculativeProfileRegistry::get_instance().set_validate_time_predictor(
+      predictor);
+}
+
+TEST(AdaptiveSpeculativeControllerTest, EnablesOnlyForMtpWithoutGraph) {
+  runtime::Options options = make_options();
+  AdaptiveSpeculativeController controller(options);
+  EXPECT_TRUE(controller.enabled());
+
+  options.speculative_algorithm("Eagle3");
+  AdaptiveSpeculativeController eagle_controller(options);
+  EXPECT_FALSE(eagle_controller.enabled());
+
+  options = make_options();
+  options.enable_graph(true);
+  AdaptiveSpeculativeController graph_controller(options);
+  EXPECT_FALSE(graph_controller.enabled());
+}
+
+TEST(AdaptiveSpeculativeControllerTest, SelectsPrunedPrefixesByPathProb) {
+  setup_registry();
+  AdaptiveSpeculativeController controller(make_options());
+  torch::Tensor probs = torch::tensor({
+      {0.95, 0.90, 0.20},
+      {0.80, 0.00, 0.10},
+  });
+  std::vector<double> per_seq_kv_lens = {100.0, 100.0};
+
+  const std::vector<int32_t> prefix_lengths =
+      controller.select_pruned_prefix_lengths(probs,
+                                              /*full_draft_time_ms=*/1.0,
+                                              /*target_step_time_ms=*/10.0,
+                                              per_seq_kv_lens);
+
+  ASSERT_EQ(prefix_lengths.size(), 2);
+  EXPECT_GE(prefix_lengths[0], 1);
+  EXPECT_GE(prefix_lengths[1], 0);
+}
+
+TEST(AdaptiveSpeculativeControllerTest, AllowsZeroPrefixWhenNoGain) {
+  setup_registry();
+  AdaptiveSpeculativeController controller(make_options());
+  torch::Tensor probs = torch::tensor({
+      {0.0, 0.0, 0.0},
+      {0.0, 0.0, 0.0},
+  });
+  std::vector<double> per_seq_kv_lens = {100.0, 100.0};
+
+  const std::vector<int32_t> prefix_lengths =
+      controller.select_pruned_prefix_lengths(probs,
+                                              /*full_draft_time_ms=*/1.0,
+                                              /*target_step_time_ms=*/100.0,
+                                              per_seq_kv_lens);
+
+  ASSERT_EQ(prefix_lengths.size(), 2);
+  EXPECT_EQ(prefix_lengths[0], 0);
+  EXPECT_EQ(prefix_lengths[1], 0);
+}
+
+TEST(AdaptiveSpeculativeControllerTest, ContinuesAfterNonImprovingCandidate) {
+  setup_registry();
+  AdaptiveSpeculativeController controller(make_options());
+  torch::Tensor probs = torch::tensor({
+      {0.99, 0.98},
+      {0.90, 0.00},
+  });
+  std::vector<double> per_seq_kv_lens = {100.0, 100.0};
+
+  const std::vector<int32_t> prefix_lengths =
+      controller.select_pruned_prefix_lengths(probs,
+                                              /*full_draft_time_ms=*/1.0,
+                                              /*target_step_time_ms=*/100.0,
+                                              per_seq_kv_lens);
+
+  ASSERT_EQ(prefix_lengths.size(), 2);
+  EXPECT_GE(prefix_lengths[0], 1);
+  EXPECT_GE(prefix_lengths[1], 0);
+}
+
+}  // namespace
+}  // namespace xllm

--- a/tests/core/runtime/adaptive_speculative_controller_test.cpp
+++ b/tests/core/runtime/adaptive_speculative_controller_test.cpp
@@ -39,7 +39,6 @@ runtime::Options make_options() {
 void setup_registry() {
   SpeculativeProfileRegistry::ValidateTimePredictor predictor;
   predictor.intercept_ms = 1.0;
-  predictor.batch_ms = 0.1;
   predictor.query_token_ms = 0.5;
   predictor.query_prefix_ms = 0.001;
   SpeculativeProfileRegistry::get_instance().set_validate_time_predictor(

--- a/tests/core/runtime/adaptive_speculative_controller_test.cpp
+++ b/tests/core/runtime/adaptive_speculative_controller_test.cpp
@@ -73,7 +73,6 @@ TEST(AdaptiveSpeculativeControllerTest, SelectsPrunedPrefixesByPathProb) {
   const std::vector<int32_t> prefix_lengths =
       controller.select_pruned_prefix_lengths(probs,
                                               /*full_draft_time_ms=*/1.0,
-                                              /*target_step_time_ms=*/10.0,
                                               per_seq_kv_lens);
 
   ASSERT_EQ(prefix_lengths.size(), 2);
@@ -93,7 +92,6 @@ TEST(AdaptiveSpeculativeControllerTest, AllowsZeroPrefixWhenNoGain) {
   const std::vector<int32_t> prefix_lengths =
       controller.select_pruned_prefix_lengths(probs,
                                               /*full_draft_time_ms=*/1.0,
-                                              /*target_step_time_ms=*/100.0,
                                               per_seq_kv_lens);
 
   ASSERT_EQ(prefix_lengths.size(), 2);
@@ -113,7 +111,6 @@ TEST(AdaptiveSpeculativeControllerTest, ContinuesAfterNonImprovingCandidate) {
   const std::vector<int32_t> prefix_lengths =
       controller.select_pruned_prefix_lengths(probs,
                                               /*full_draft_time_ms=*/1.0,
-                                              /*target_step_time_ms=*/100.0,
                                               per_seq_kv_lens);
 
   ASSERT_EQ(prefix_lengths.size(), 2);

--- a/tests/core/runtime/speculative_profile_registry_test.cpp
+++ b/tests/core/runtime/speculative_profile_registry_test.cpp
@@ -1,0 +1,63 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "core/framework/speculative/speculative_profile_registry.h"
+
+#include <gtest/gtest.h>
+
+#include <optional>
+
+namespace xllm {
+namespace {
+
+TEST(SpeculativeProfileRegistryTest, PredictsValidateTimeFromLinearTerms) {
+  SpeculativeProfileRegistry& registry =
+      SpeculativeProfileRegistry::get_instance();
+  registry.reset_validate_time_predictor();
+
+  SpeculativeProfileRegistry::ValidateTimePredictor predictor;
+  predictor.intercept_ms = 1.0;
+  predictor.batch_ms = 2.0;
+  predictor.query_token_ms = 3.0;
+  predictor.query_prefix_ms = 0.5;
+  registry.set_validate_time_predictor(predictor);
+
+  const std::optional<SpeculativeProfileRegistry::ValidateTimePredictor>
+      registered_predictor = registry.validate_time_predictor();
+  ASSERT_TRUE(registered_predictor.has_value());
+  EXPECT_DOUBLE_EQ(registered_predictor->query_prefix_ms, 0.5);
+
+  const double time_ms = registry.predict_validate_time_ms(
+      /*batch_size=*/4, /*query_len=*/3, /*avg_prefix_len=*/5.0);
+
+  EXPECT_DOUBLE_EQ(time_ms,
+                   1.0 + 2.0 * 4.0 + 3.0 * 4.0 * 3.0 + 0.5 * 4.0 * 3.0 * 5.0);
+  registry.reset_validate_time_predictor();
+}
+
+TEST(SpeculativeProfileRegistryTest, ReturnsZeroBeforeRegistration) {
+  SpeculativeProfileRegistry& registry =
+      SpeculativeProfileRegistry::get_instance();
+  registry.reset_validate_time_predictor();
+
+  EXPECT_DOUBLE_EQ(registry.predict_validate_time_ms(
+                       /*batch_size=*/4,
+                       /*query_len=*/3,
+                       /*avg_prefix_len=*/128.0),
+                   0.0);
+}
+
+}  // namespace
+}  // namespace xllm

--- a/tests/core/runtime/speculative_profile_registry_test.cpp
+++ b/tests/core/runtime/speculative_profile_registry_test.cpp
@@ -17,19 +17,20 @@ limitations under the License.
 
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <optional>
 
 namespace xllm {
 namespace {
 
-TEST(SpeculativeProfileRegistryTest, PredictsValidateTimeFromLinearTerms) {
+TEST(SpeculativeProfileRegistryTest, StoresAndRetrievesPredictor) {
   SpeculativeProfileRegistry& registry =
       SpeculativeProfileRegistry::get_instance();
   registry.reset_validate_time_predictor();
+  EXPECT_FALSE(registry.has_validate_time_predictor());
 
   SpeculativeProfileRegistry::ValidateTimePredictor predictor;
   predictor.intercept_ms = 1.0;
-  predictor.batch_ms = 2.0;
   predictor.query_token_ms = 3.0;
   predictor.query_prefix_ms = 0.5;
   registry.set_validate_time_predictor(predictor);
@@ -37,26 +38,32 @@ TEST(SpeculativeProfileRegistryTest, PredictsValidateTimeFromLinearTerms) {
   const std::optional<SpeculativeProfileRegistry::ValidateTimePredictor>
       registered_predictor = registry.validate_time_predictor();
   ASSERT_TRUE(registered_predictor.has_value());
+  EXPECT_DOUBLE_EQ(registered_predictor->intercept_ms, 1.0);
+  EXPECT_DOUBLE_EQ(registered_predictor->query_token_ms, 3.0);
   EXPECT_DOUBLE_EQ(registered_predictor->query_prefix_ms, 0.5);
-
-  const double time_ms = registry.predict_validate_time_ms(
-      /*batch_size=*/4, /*query_len=*/3, /*avg_prefix_len=*/5.0);
-
-  EXPECT_DOUBLE_EQ(time_ms,
-                   1.0 + 2.0 * 4.0 + 3.0 * 4.0 * 3.0 + 0.5 * 4.0 * 3.0 * 5.0);
   registry.reset_validate_time_predictor();
+  EXPECT_FALSE(registry.has_validate_time_predictor());
 }
 
-TEST(SpeculativeProfileRegistryTest, ReturnsZeroBeforeRegistration) {
+TEST(SpeculativeProfileRegistryTest,
+     SanitizesNonFiniteAndNegativeCoefficients) {
   SpeculativeProfileRegistry& registry =
       SpeculativeProfileRegistry::get_instance();
   registry.reset_validate_time_predictor();
 
-  EXPECT_DOUBLE_EQ(registry.predict_validate_time_ms(
-                       /*batch_size=*/4,
-                       /*query_len=*/3,
-                       /*avg_prefix_len=*/128.0),
-                   0.0);
+  SpeculativeProfileRegistry::ValidateTimePredictor predictor;
+  predictor.intercept_ms = -1.0;
+  predictor.query_token_ms = std::numeric_limits<double>::quiet_NaN();
+  predictor.query_prefix_ms = 0.5;
+  registry.set_validate_time_predictor(predictor);
+
+  const std::optional<SpeculativeProfileRegistry::ValidateTimePredictor> got =
+      registry.validate_time_predictor();
+  ASSERT_TRUE(got.has_value());
+  EXPECT_DOUBLE_EQ(got->intercept_ms, 0.0);
+  EXPECT_DOUBLE_EQ(got->query_token_ms, 0.0);
+  EXPECT_DOUBLE_EQ(got->query_prefix_ms, 0.5);
+  registry.reset_validate_time_predictor();
 }
 
 }  // namespace

--- a/xllm/core/common/global_flags.h
+++ b/xllm/core/common/global_flags.h
@@ -81,6 +81,9 @@ DECLARE_string(speculative_algorithm);
 DECLARE_bool(enable_opt_validate_probs);
 
 DECLARE_bool(enable_mtp_draft_body_tp1);
+DECLARE_bool(enable_adaptive_speculative_decode);
+
+DECLARE_double(adaptive_speculative_min_gain);
 
 DECLARE_int32(speculative_suffix_cache_max_depth);
 

--- a/xllm/core/common/options.cpp
+++ b/xllm/core/common/options.cpp
@@ -49,6 +49,9 @@ std::string Options::to_string() const {
      << ", speculative_suffix_use_tree_spec: "
      << speculative_suffix_use_tree_spec()
      << ", enable_mtp_draft_body_tp1: " << enable_mtp_draft_body_tp1()
+     << ", enable_adaptive_speculative_decode: "
+     << enable_adaptive_speculative_decode()
+     << ", adaptive_speculative_min_gain: " << adaptive_speculative_min_gain()
      << ", num_request_handling_threads: " << num_request_handling_threads()
      << ", communication_backend: " << communication_backend().value_or("null")
      << ", rank_tablefile: " << rank_tablefile().value_or("null")

--- a/xllm/core/common/options.h
+++ b/xllm/core/common/options.h
@@ -95,6 +95,9 @@ class Options {
   PROPERTY(bool, speculative_suffix_use_tree_spec) = false;
 
   PROPERTY(bool, enable_mtp_draft_body_tp1) = false;
+  PROPERTY(bool, enable_adaptive_speculative_decode) = false;
+
+  PROPERTY(double, adaptive_speculative_min_gain) = 0.0;
 
   // thread num to handle requests
   PROPERTY(size_t, num_request_handling_threads) = 4;

--- a/xllm/core/distributed_runtime/comm_channel.cpp
+++ b/xllm/core/distributed_runtime/comm_channel.cpp
@@ -91,6 +91,25 @@ bool CommChannel::allocate_kv_cache(const KVCacheShape& kv_cache_shape) {
   return true;
 }
 
+bool CommChannel::set_speculative_validate_time_predictor(
+    const SpeculativeProfileRegistry::ValidateTimePredictor& predictor) {
+  proto::SpeculativeValidateTimePredictor request;
+  request.set_intercept_ms(predictor.intercept_ms);
+  request.set_batch_ms(predictor.batch_ms);
+  request.set_query_token_ms(predictor.query_token_ms);
+  request.set_query_prefix_ms(predictor.query_prefix_ms);
+
+  proto::Status s;
+  brpc::Controller cntl;
+  stub_->SetSpeculativeValidateTimePredictor(&cntl, &request, &s, nullptr);
+  if (cntl.Failed() || !s.ok()) {
+    LOG(ERROR) << "SetSpeculativeValidateTimePredictor failed: "
+               << cntl.ErrorText();
+    return false;
+  }
+  return true;
+}
+
 bool CommChannel::get_cache_info(uint64_t& cluster_id,
                                  std::string& addr,
                                  uint16_t& port) {

--- a/xllm/core/distributed_runtime/comm_channel.cpp
+++ b/xllm/core/distributed_runtime/comm_channel.cpp
@@ -95,7 +95,6 @@ bool CommChannel::set_speculative_validate_time_predictor(
     const SpeculativeProfileRegistry::ValidateTimePredictor& predictor) {
   proto::SpeculativeValidateTimePredictor request;
   request.set_intercept_ms(predictor.intercept_ms);
-  request.set_batch_ms(predictor.batch_ms);
   request.set_query_token_ms(predictor.query_token_ms);
   request.set_query_prefix_ms(predictor.query_prefix_ms);
 

--- a/xllm/core/distributed_runtime/comm_channel.h
+++ b/xllm/core/distributed_runtime/comm_channel.h
@@ -24,6 +24,7 @@ limitations under the License.
 #include <vector>
 
 #include "common/types.h"
+#include "core/framework/speculative/speculative_profile_registry.h"
 #include "framework/kv_cache/kv_cache_shape.h"
 #include "framework/xtensor/xtensor.h"
 #include "runtime/forward_params.h"
@@ -42,6 +43,9 @@ class CommChannel {
   virtual bool hello();
 
   virtual bool allocate_kv_cache(const KVCacheShape& kv_cache_shape);
+
+  virtual bool set_speculative_validate_time_predictor(
+      const SpeculativeProfileRegistry::ValidateTimePredictor& predictor);
 
   virtual bool get_cache_info(uint64_t& cluster_id,
                               std::string& addr,

--- a/xllm/core/distributed_runtime/engine.h
+++ b/xllm/core/distributed_runtime/engine.h
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include <unordered_map>
 
+#include "core/framework/speculative/speculative_profile_registry.h"
 #include "framework/batch/batch.h"
 #include "framework/block/block_manager_pool.h"
 #include "framework/model/model_args.h"
@@ -54,6 +55,13 @@ class Engine {
 
   // return the model args
   virtual const ModelArgs& model_args() const { return args_; }
+
+  virtual const ModelArgs* draft_model_args() const { return nullptr; }
+
+  virtual bool set_speculative_validate_time_predictor(
+      const SpeculativeProfileRegistry::ValidateTimePredictor&) {
+    return false;
+  }
 
   // return the tokenizer args
   virtual const TokenizerArgs& tokenizer_args() const {

--- a/xllm/core/distributed_runtime/engine.h
+++ b/xllm/core/distributed_runtime/engine.h
@@ -56,8 +56,6 @@ class Engine {
   // return the model args
   virtual const ModelArgs& model_args() const { return args_; }
 
-  virtual const ModelArgs* draft_model_args() const { return nullptr; }
-
   virtual bool set_speculative_validate_time_predictor(
       const SpeculativeProfileRegistry::ValidateTimePredictor&) {
     return false;

--- a/xllm/core/distributed_runtime/llm_engine.cpp
+++ b/xllm/core/distributed_runtime/llm_engine.cpp
@@ -709,6 +709,20 @@ bool LLMEngine::allocate_kv_cache(const KVCacheCapacity& kv_cache_cap) {
   return true;
 }
 
+bool LLMEngine::set_speculative_validate_time_predictor(
+    const SpeculativeProfileRegistry::ValidateTimePredictor& predictor) {
+  bool success = true;
+  for (size_t i = 0; i < worker_clients_.size(); ++i) {
+    if (!worker_clients_[i]->set_speculative_validate_time_predictor(
+            predictor)) {
+      LOG(ERROR) << "Failed to set speculative validate predictor for worker "
+                 << i;
+      success = false;
+    }
+  }
+  return success;
+}
+
 bool LLMEngine::pull_kv_blocks(const int32_t src_dp_size,
                                const int32_t src_dp_rank,
                                const std::vector<uint64_t>& src_cluster_ids,

--- a/xllm/core/distributed_runtime/llm_engine.h
+++ b/xllm/core/distributed_runtime/llm_engine.h
@@ -59,6 +59,10 @@ class LLMEngine : public Engine {
 
   bool init(MasterStatus master_status) override;
 
+  bool set_speculative_validate_time_predictor(
+      const SpeculativeProfileRegistry::ValidateTimePredictor& predictor)
+      override;
+
   void update_last_step_result(std::vector<Batch>& batch) override;
 
   // return the active activation memory

--- a/xllm/core/distributed_runtime/master.cpp
+++ b/xllm/core/distributed_runtime/master.cpp
@@ -463,6 +463,9 @@ Master::Master(const Options& options, EngineType type)
             options_.speculative_suffix_max_cached_requests())
         .speculative_suffix_use_tree_spec(
             options_.speculative_suffix_use_tree_spec())
+        .enable_adaptive_speculative_decode(
+            options_.enable_adaptive_speculative_decode())
+        .adaptive_speculative_min_gain(options_.adaptive_speculative_min_gain())
         .task_type(options_.task_type())
         .enable_mla(options_.enable_mla())
         .npu_kernel_backend(options_.npu_kernel_backend())

--- a/xllm/core/distributed_runtime/remote_worker.cpp
+++ b/xllm/core/distributed_runtime/remote_worker.cpp
@@ -78,6 +78,11 @@ bool RemoteWorker::allocate_kv_cache(const KVCacheShape& kv_cache_shape) {
   return channel_->allocate_kv_cache(kv_cache_shape);
 }
 
+bool RemoteWorker::set_speculative_validate_time_predictor(
+    const SpeculativeProfileRegistry::ValidateTimePredictor& predictor) {
+  return channel_->set_speculative_validate_time_predictor(predictor);
+}
+
 void RemoteWorker::get_cache_info(uint64_t& cluster_id,
                                   std::string& addr,
                                   uint16_t& port) {

--- a/xllm/core/distributed_runtime/remote_worker.h
+++ b/xllm/core/distributed_runtime/remote_worker.h
@@ -55,6 +55,10 @@ class RemoteWorker : public WorkerClient {
 
   bool allocate_kv_cache(const KVCacheShape& kv_cache_shape) override;
 
+  bool set_speculative_validate_time_predictor(
+      const SpeculativeProfileRegistry::ValidateTimePredictor& predictor)
+      override;
+
   void get_cache_info(uint64_t& cluster_id,
                       std::string& addr,
                       uint16_t& port) override;

--- a/xllm/core/distributed_runtime/speculative_engine.cpp
+++ b/xllm/core/distributed_runtime/speculative_engine.cpp
@@ -164,13 +164,6 @@ bool SpeculativeEngine::allocate_kv_cache() {
          draft_engine_->allocate_kv_cache(draft_kv_cache_cap);
 }
 
-const ModelArgs* SpeculativeEngine::draft_model_args() const {
-  if (draft_engine_ == nullptr) {
-    return nullptr;
-  }
-  return &draft_engine_->model_args();
-}
-
 bool SpeculativeEngine::set_speculative_validate_time_predictor(
     const SpeculativeProfileRegistry::ValidateTimePredictor& predictor) {
   return engine_->set_speculative_validate_time_predictor(predictor);

--- a/xllm/core/distributed_runtime/speculative_engine.cpp
+++ b/xllm/core/distributed_runtime/speculative_engine.cpp
@@ -164,6 +164,18 @@ bool SpeculativeEngine::allocate_kv_cache() {
          draft_engine_->allocate_kv_cache(draft_kv_cache_cap);
 }
 
+const ModelArgs* SpeculativeEngine::draft_model_args() const {
+  if (draft_engine_ == nullptr) {
+    return nullptr;
+  }
+  return &draft_engine_->model_args();
+}
+
+bool SpeculativeEngine::set_speculative_validate_time_predictor(
+    const SpeculativeProfileRegistry::ValidateTimePredictor& predictor) {
+  return engine_->set_speculative_validate_time_predictor(predictor);
+}
+
 // TODO: support dp batches later
 ForwardOutput SpeculativeEngine::step(std::vector<Batch>& batches) {
   return engine_->step(batches);

--- a/xllm/core/distributed_runtime/speculative_engine.h
+++ b/xllm/core/distributed_runtime/speculative_engine.h
@@ -47,6 +47,12 @@ class SpeculativeEngine : public Engine {
 
   const ModelArgs& model_args() const override { return model_args_; }
 
+  const ModelArgs* draft_model_args() const override;
+
+  bool set_speculative_validate_time_predictor(
+      const SpeculativeProfileRegistry::ValidateTimePredictor& predictor)
+      override;
+
   const TokenizerArgs& tokenizer_args() const override {
     return engine_->tokenizer_args();
   }

--- a/xllm/core/distributed_runtime/speculative_engine.h
+++ b/xllm/core/distributed_runtime/speculative_engine.h
@@ -47,8 +47,6 @@ class SpeculativeEngine : public Engine {
 
   const ModelArgs& model_args() const override { return model_args_; }
 
-  const ModelArgs* draft_model_args() const override;
-
   bool set_speculative_validate_time_predictor(
       const SpeculativeProfileRegistry::ValidateTimePredictor& predictor)
       override;

--- a/xllm/core/distributed_runtime/worker_service.cpp
+++ b/xllm/core/distributed_runtime/worker_service.cpp
@@ -79,19 +79,6 @@ void record_speculative_metrics_from_output(const torch::Tensor& next_tokens,
     return;
   }
 
-  // MTP path records these metrics inside
-  // MTPWorkerImpl::record_validate_metrics with adaptive-pruning-aware draft
-  // counts. Skip here to avoid double-count.
-  std::string algorithm = options.speculative_algorithm();
-  std::transform(
-      algorithm.begin(),
-      algorithm.end(),
-      algorithm.begin(),
-      [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-  if (algorithm == "mtp") {
-    return;
-  }
-
   const int64_t batch_size = next_tokens.size(0);
   const int64_t token_width = next_tokens.size(1);
   const int64_t num_speculative_tokens = options.num_speculative_tokens();

--- a/xllm/core/distributed_runtime/worker_service.cpp
+++ b/xllm/core/distributed_runtime/worker_service.cpp
@@ -460,6 +460,24 @@ void WorkerService::AllocateKVCache(
   return;
 }
 
+void WorkerService::SetSpeculativeValidateTimePredictor(
+    ::google::protobuf::RpcController* controller,
+    const proto::SpeculativeValidateTimePredictor* request,
+    proto::Status* response,
+    ::google::protobuf::Closure* done) {
+  threadpool_->schedule([this, controller, request, response, done]() mutable {
+    brpc::ClosureGuard done_guard(done);
+    SpeculativeProfileRegistry::ValidateTimePredictor predictor;
+    predictor.intercept_ms = request->intercept_ms();
+    predictor.batch_ms = request->batch_ms();
+    predictor.query_token_ms = request->query_token_ms();
+    predictor.query_prefix_ms = request->query_prefix_ms();
+    response->set_ok(
+        worker_->set_speculative_validate_time_predictor(predictor));
+  });
+  return;
+}
+
 void WorkerService::AllocateKVCacheWithTransfer(
     ::google::protobuf::RpcController* controller,
     const proto::AllocateKVCacheRequest* req,

--- a/xllm/core/distributed_runtime/worker_service.cpp
+++ b/xllm/core/distributed_runtime/worker_service.cpp
@@ -79,6 +79,19 @@ void record_speculative_metrics_from_output(const torch::Tensor& next_tokens,
     return;
   }
 
+  // MTP path records these metrics inside
+  // MTPWorkerImpl::record_validate_metrics with adaptive-pruning-aware draft
+  // counts. Skip here to avoid double-count.
+  std::string algorithm = options.speculative_algorithm();
+  std::transform(
+      algorithm.begin(),
+      algorithm.end(),
+      algorithm.begin(),
+      [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  if (algorithm == "mtp") {
+    return;
+  }
+
   const int64_t batch_size = next_tokens.size(0);
   const int64_t token_width = next_tokens.size(1);
   const int64_t num_speculative_tokens = options.num_speculative_tokens();

--- a/xllm/core/distributed_runtime/worker_service.cpp
+++ b/xllm/core/distributed_runtime/worker_service.cpp
@@ -469,7 +469,6 @@ void WorkerService::SetSpeculativeValidateTimePredictor(
     brpc::ClosureGuard done_guard(done);
     SpeculativeProfileRegistry::ValidateTimePredictor predictor;
     predictor.intercept_ms = request->intercept_ms();
-    predictor.batch_ms = request->batch_ms();
     predictor.query_token_ms = request->query_token_ms();
     predictor.query_prefix_ms = request->query_prefix_ms();
     response->set_ok(

--- a/xllm/core/distributed_runtime/worker_service.h
+++ b/xllm/core/distributed_runtime/worker_service.h
@@ -64,6 +64,12 @@ class WorkerService : public proto::DistributeWorker {
                        proto::Status* response,
                        ::google::protobuf::Closure* done) override;
 
+  void SetSpeculativeValidateTimePredictor(
+      ::google::protobuf::RpcController* controller,
+      const proto::SpeculativeValidateTimePredictor* request,
+      proto::Status* response,
+      ::google::protobuf::Closure* done) override;
+
   void AllocateKVCacheWithTransfer(
       ::google::protobuf::RpcController* controller,
       const proto::AllocateKVCacheRequest* req,

--- a/xllm/core/framework/CMakeLists.txt
+++ b/xllm/core/framework/CMakeLists.txt
@@ -24,6 +24,7 @@ add_subdirectory(state_dict)
 add_subdirectory(tokenizer)
 add_subdirectory(eplb)
 add_subdirectory(dit_cache)
+add_subdirectory(speculative)
 
 
 cc_library(

--- a/xllm/core/framework/config/speculative_config.cpp
+++ b/xllm/core/framework/config/speculative_config.cpp
@@ -70,6 +70,16 @@ DEFINE_bool(enable_atb_spec_kernel,
             false,
             "Whether to use ATB speculative kernel.");
 
+DEFINE_bool(enable_adaptive_speculative_decode,
+            false,
+            "Whether to enable adaptive speculative length for MTP decode.");
+
+DEFINE_double(
+    adaptive_speculative_min_gain,
+    0.0,
+    "Minimum relative throughput gain required to include a draft token in "
+    "adaptive speculative validation.");
+
 namespace xllm {
 
 void SpeculativeConfig::from_flags() {
@@ -85,6 +95,8 @@ void SpeculativeConfig::from_flags() {
   XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_opt_validate_probs);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_mtp_draft_body_tp1);
   XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_atb_spec_kernel);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(enable_adaptive_speculative_decode);
+  XLLM_CONFIG_ASSIGN_FROM_FLAG(adaptive_speculative_min_gain);
 }
 
 void SpeculativeConfig::from_json(const JsonReader& json) {
@@ -100,6 +112,8 @@ void SpeculativeConfig::from_json(const JsonReader& json) {
   XLLM_CONFIG_ASSIGN_FROM_JSON(enable_opt_validate_probs);
   XLLM_CONFIG_ASSIGN_FROM_JSON(enable_mtp_draft_body_tp1);
   XLLM_CONFIG_ASSIGN_FROM_JSON(enable_atb_spec_kernel);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(enable_adaptive_speculative_decode);
+  XLLM_CONFIG_ASSIGN_FROM_JSON(adaptive_speculative_min_gain);
 }
 
 void SpeculativeConfig::append_config_json(
@@ -129,6 +143,10 @@ void SpeculativeConfig::append_config_json(
       config_json, default_config, enable_mtp_draft_body_tp1);
   APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
       config_json, default_config, enable_atb_spec_kernel);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, enable_adaptive_speculative_decode);
+  APPEND_CONFIG_JSON_VALUE_IF_NOT_DEFAULT(
+      config_json, default_config, adaptive_speculative_min_gain);
 }
 
 SpeculativeConfig& SpeculativeConfig::get_instance() {

--- a/xllm/core/framework/config/speculative_config.h
+++ b/xllm/core/framework/config/speculative_config.h
@@ -73,7 +73,9 @@ class SpeculativeConfig final {
          "speculative_suffix_use_tree_spec",
          "enable_opt_validate_probs",
          "enable_mtp_draft_body_tp1",
-         "enable_atb_spec_kernel"}};
+         "enable_atb_spec_kernel",
+         "enable_adaptive_speculative_decode",
+         "adaptive_speculative_min_gain"}};
     return kOptionCategory;
   }
 
@@ -100,6 +102,10 @@ class SpeculativeConfig final {
   PROPERTY(bool, enable_mtp_draft_body_tp1) = false;
 
   PROPERTY(bool, enable_atb_spec_kernel) = false;
+
+  PROPERTY(bool, enable_adaptive_speculative_decode) = false;
+
+  PROPERTY(double, adaptive_speculative_min_gain) = 0.0;
 };
 
 }  // namespace xllm

--- a/xllm/core/framework/speculative/CMakeLists.txt
+++ b/xllm/core/framework/speculative/CMakeLists.txt
@@ -1,0 +1,18 @@
+include(cc_library)
+
+cc_library(
+  NAME
+    speculative
+  HDRS
+    adaptive_speculative_controller.h
+    speculative_profile_registry.h
+    adaptive_pruning_helpers.h
+  SRCS
+    adaptive_speculative_controller.cpp
+    speculative_profile_registry.cpp
+    adaptive_pruning_helpers.cpp
+  DEPS
+    torch
+    glog::glog
+    proto::xllm_proto
+)

--- a/xllm/core/framework/speculative/adaptive_pruning_helpers.cpp
+++ b/xllm/core/framework/speculative/adaptive_pruning_helpers.cpp
@@ -1,0 +1,344 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "core/framework/speculative/adaptive_pruning_helpers.h"
+
+#include <glog/logging.h>
+
+namespace xllm {
+namespace adaptive_pruning {
+
+namespace {
+
+torch::Tensor make_cpu_int_tensor(const std::vector<int32_t>& values) {
+  return torch::tensor(values,
+                       torch::TensorOptions()
+                           .dtype(torch::kInt)
+                           .device(torch::kCPU)
+                           .pinned_memory(true));
+}
+
+void sync_pruned_boundary_logprobs(
+    SampleOutput& sample_output,
+    const ForwardOutput& target_output,
+    int32_t batch_size,
+    int32_t num_val_tokens,
+    int32_t num_speculative_tokens,
+    const std::vector<int32_t>& pruned_prefix_lengths) {
+  if (!sample_output.logprobs.defined()) {
+    return;
+  }
+
+  CHECK(target_output.sample_output.logprobs.defined())
+      << "target output logprobs are required for adaptive pruning";
+  CHECK_EQ(
+      target_output.sample_output.logprobs.numel(),
+      static_cast<int64_t>(batch_size) * static_cast<int64_t>(num_val_tokens))
+      << "target logprob count mismatch";
+  torch::Tensor prefix_lengths =
+      safe_to(make_cpu_int_tensor(pruned_prefix_lengths),
+              torch::TensorOptions()
+                  .dtype(torch::kLong)
+                  .device(sample_output.logprobs.device()),
+              /*non_blocking=*/true)
+          .clamp(0, num_speculative_tokens);
+  torch::Tensor positions =
+      torch::arange(num_val_tokens, prefix_lengths.options());
+  torch::Tensor cut_mask =
+      positions.unsqueeze(/*dim=*/0)
+          .eq(prefix_lengths.unsqueeze(/*dim=*/1))
+          .logical_and(
+              prefix_lengths.unsqueeze(/*dim=*/1).lt(num_speculative_tokens));
+  torch::Tensor target_logprobs = safe_to(
+      target_output.sample_output.logprobs.view({batch_size, num_val_tokens}),
+      sample_output.logprobs.options(),
+      /*non_blocking=*/true);
+  sample_output.logprobs =
+      torch::where(cut_mask, target_logprobs, sample_output.logprobs);
+}
+
+void sync_pruned_boundary_top_logprobs(
+    SampleOutput& sample_output,
+    const ForwardOutput& target_output,
+    int32_t batch_size,
+    int32_t num_val_tokens,
+    int32_t num_speculative_tokens,
+    const std::vector<int32_t>& pruned_prefix_lengths) {
+  if (!sample_output.top_tokens.defined()) {
+    return;
+  }
+
+  CHECK(sample_output.top_logprobs.defined())
+      << "top_logprobs must be defined when top_tokens are defined";
+  CHECK(target_output.sample_output.top_tokens.defined())
+      << "target top_tokens are required for adaptive pruning";
+  CHECK(target_output.sample_output.top_logprobs.defined())
+      << "target top_logprobs are required for adaptive pruning";
+  CHECK_EQ(
+      target_output.sample_output.top_tokens.size(0),
+      static_cast<int64_t>(batch_size) * static_cast<int64_t>(num_val_tokens))
+      << "target top_tokens count mismatch";
+  CHECK_EQ(
+      target_output.sample_output.top_logprobs.size(0),
+      static_cast<int64_t>(batch_size) * static_cast<int64_t>(num_val_tokens))
+      << "target top_logprobs count mismatch";
+
+  torch::Tensor prefix_lengths =
+      safe_to(make_cpu_int_tensor(pruned_prefix_lengths),
+              torch::TensorOptions()
+                  .dtype(torch::kLong)
+                  .device(sample_output.top_tokens.device()),
+              /*non_blocking=*/true)
+          .clamp(0, num_speculative_tokens);
+  torch::Tensor positions =
+      torch::arange(num_val_tokens, prefix_lengths.options());
+  torch::Tensor cut_mask =
+      positions.unsqueeze(/*dim=*/0)
+          .eq(prefix_lengths.unsqueeze(/*dim=*/1))
+          .logical_and(
+              prefix_lengths.unsqueeze(/*dim=*/1).lt(num_speculative_tokens))
+          .unsqueeze(/*dim=*/-1);
+  const int64_t top_k = sample_output.top_tokens.size(2);
+  CHECK_EQ(target_output.sample_output.top_tokens.size(1), top_k)
+      << "target top_tokens top_k mismatch";
+  CHECK_EQ(target_output.sample_output.top_logprobs.size(1), top_k)
+      << "target top_logprobs top_k mismatch";
+  torch::Tensor target_top_tokens = target_output.sample_output.top_tokens.view(
+      {batch_size, num_val_tokens, top_k});
+  torch::Tensor target_top_logprobs =
+      target_output.sample_output.top_logprobs.view(
+          {batch_size, num_val_tokens, top_k});
+  sample_output.top_tokens =
+      torch::where(cut_mask,
+                   safe_to(target_top_tokens,
+                           sample_output.top_tokens.options(),
+                           /*non_blocking=*/true),
+                   sample_output.top_tokens);
+  sample_output.top_logprobs =
+      torch::where(cut_mask.to(sample_output.top_logprobs.device()),
+                   safe_to(target_top_logprobs,
+                           sample_output.top_logprobs.options(),
+                           /*non_blocking=*/true),
+                   sample_output.top_logprobs);
+}
+
+}  // namespace
+
+torch::Tensor selected_probs_by_step(
+    const std::vector<ForwardOutput>& draft_outputs) {
+  CHECK(!draft_outputs.empty()) << "draft outputs must not be empty";
+  std::vector<torch::Tensor> probs_steps;
+  probs_steps.reserve(draft_outputs.size());
+  int64_t batch_size = -1;
+  for (const ForwardOutput& draft_output : draft_outputs) {
+    torch::Tensor probs = draft_output.sample_output.probs;
+    CHECK(probs.defined())
+        << "adaptive pruning requires selected draft probabilities";
+    CHECK(probs.dim() == 1 || probs.dim() == 2)
+        << "adaptive pruning expects draft probs [batch] or [batch,1], got "
+        << probs.sizes();
+    if (probs.dim() == 2) {
+      CHECK_EQ(probs.size(1), 1)
+          << "adaptive pruning expects draft probs [batch,1], got "
+          << probs.sizes();
+      probs = probs.squeeze(/*dim=*/1);
+    }
+    if (batch_size < 0) {
+      batch_size = probs.size(0);
+    }
+    CHECK_EQ(probs.size(0), batch_size)
+        << "adaptive pruning draft prob batch mismatch";
+    probs_steps.emplace_back(probs.view({-1, 1}));
+  }
+  return torch::cat(probs_steps, /*dim=*/1);
+}
+
+bool has_selected_probs_by_step(
+    const std::vector<ForwardOutput>& draft_outputs) {
+  if (draft_outputs.empty()) {
+    return false;
+  }
+  for (const ForwardOutput& draft_output : draft_outputs) {
+    const torch::Tensor& probs = draft_output.sample_output.probs;
+    if (!probs.defined()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void clamp_prefix_lengths(std::vector<int32_t>& prefix_lengths,
+                          int32_t batch_size,
+                          int32_t num_speculative_tokens) {
+  CHECK_EQ(prefix_lengths.size(), static_cast<size_t>(batch_size))
+      << "adaptive pruning prefix length batch mismatch";
+  for (int32_t& prefix_len : prefix_lengths) {
+    prefix_len = std::clamp(prefix_len, 0, num_speculative_tokens);
+  }
+}
+
+int32_t max_pruned_prefix_length(const std::vector<int32_t>& prefix_lengths,
+                                 int32_t num_speculative_tokens) {
+  if (prefix_lengths.empty()) {
+    return num_speculative_tokens;
+  }
+  const int32_t max_prefix_len =
+      *std::max_element(prefix_lengths.begin(), prefix_lengths.end());
+  return std::clamp(max_prefix_len, 0, num_speculative_tokens);
+}
+
+std::vector<ForwardOutput> truncate_draft_outputs(
+    const std::vector<ForwardOutput>& draft_outputs,
+    int32_t num_speculative_tokens) {
+  CHECK_GE(num_speculative_tokens, 0)
+      << "num_speculative_tokens must be non-negative";
+  CHECK_GE(draft_outputs.size(), static_cast<size_t>(num_speculative_tokens))
+      << "draft outputs are fewer than the requested validation width";
+  std::vector<ForwardOutput> truncated_outputs;
+  truncated_outputs.reserve(static_cast<size_t>(num_speculative_tokens));
+  for (int32_t i = 0; i < num_speculative_tokens; ++i) {
+    truncated_outputs.emplace_back(draft_outputs[static_cast<size_t>(i)]);
+  }
+  return truncated_outputs;
+}
+
+void apply_pruned_prefix_lengths(
+    SampleOutput& sample_output,
+    const torch::Tensor& target_next_tokens,
+    int32_t num_speculative_tokens,
+    const std::vector<int32_t>& pruned_prefix_lengths) {
+  CHECK(sample_output.next_tokens.defined())
+      << "validate output tokens are undefined";
+  CHECK_EQ(sample_output.next_tokens.dim(), 2)
+      << "validate output tokens should be [batch, width]";
+  const int32_t batch_size =
+      static_cast<int32_t>(sample_output.next_tokens.size(0));
+  const int32_t num_val_tokens = num_speculative_tokens + 1;
+  CHECK_EQ(sample_output.next_tokens.size(1), num_val_tokens)
+      << "validate output width mismatch";
+  CHECK_EQ(pruned_prefix_lengths.size(), static_cast<size_t>(batch_size))
+      << "adaptive pruning prefix length batch mismatch";
+  CHECK(target_next_tokens.defined())
+      << "target output tokens are required for adaptive pruning";
+  torch::Tensor target_next_tokens_view =
+      target_next_tokens.view({batch_size, num_val_tokens});
+  torch::Tensor prefix_lengths =
+      safe_to(make_cpu_int_tensor(pruned_prefix_lengths),
+              torch::TensorOptions()
+                  .dtype(torch::kLong)
+                  .device(sample_output.next_tokens.device()),
+              /*non_blocking=*/true)
+          .clamp(0, num_speculative_tokens);
+  torch::Tensor positions =
+      torch::arange(num_val_tokens, prefix_lengths.options());
+  torch::Tensor keep_mask =
+      positions.unsqueeze(/*dim=*/0).le(prefix_lengths.unsqueeze(/*dim=*/1));
+  torch::Tensor cut_mask =
+      positions.unsqueeze(/*dim=*/0)
+          .eq(prefix_lengths.unsqueeze(/*dim=*/1))
+          .logical_and(
+              prefix_lengths.unsqueeze(/*dim=*/1).lt(num_speculative_tokens));
+  torch::Tensor target_tokens = safe_to(target_next_tokens_view,
+                                        sample_output.next_tokens.options(),
+                                        /*non_blocking=*/true);
+  torch::Tensor next_tokens =
+      torch::where(cut_mask, target_tokens, sample_output.next_tokens);
+  sample_output.next_tokens =
+      torch::where(keep_mask, next_tokens, -torch::ones_like(next_tokens));
+
+  if (sample_output.logprobs.defined()) {
+    CHECK_EQ(sample_output.logprobs.dim(), 2)
+        << "validate output logprobs should be [batch, width]";
+    CHECK_EQ(sample_output.logprobs.size(0), batch_size)
+        << "validate logprob batch mismatch";
+    CHECK_EQ(sample_output.logprobs.size(1), num_val_tokens)
+        << "validate logprob width mismatch";
+    torch::Tensor output_logprobs = safe_to(sample_output.logprobs,
+                                            sample_output.logprobs.options(),
+                                            /*non_blocking=*/true);
+    sample_output.logprobs =
+        torch::where(keep_mask.to(sample_output.logprobs.device()),
+                     output_logprobs,
+                     torch::zeros_like(output_logprobs));
+  }
+
+  if (sample_output.top_tokens.defined()) {
+    CHECK(sample_output.top_logprobs.defined())
+        << "top_logprobs must be defined when top_tokens are defined";
+    CHECK_EQ(sample_output.top_tokens.dim(), 3)
+        << "validate top_tokens should be [batch, width, top_k]";
+    CHECK_EQ(sample_output.top_logprobs.dim(), 3)
+        << "validate top_logprobs should be [batch, width, top_k]";
+    CHECK_EQ(sample_output.top_tokens.size(0), batch_size)
+        << "validate top_tokens batch mismatch";
+    CHECK_EQ(sample_output.top_tokens.size(1), num_val_tokens)
+        << "validate top_tokens width mismatch";
+    CHECK_EQ(sample_output.top_logprobs.size(0), batch_size)
+        << "validate top_logprobs batch mismatch";
+    CHECK_EQ(sample_output.top_logprobs.size(1), num_val_tokens)
+        << "validate top_logprobs width mismatch";
+    torch::Tensor top_keep_mask =
+        keep_mask.to(sample_output.top_tokens.device()).unsqueeze(/*dim=*/-1);
+    sample_output.top_tokens =
+        torch::where(top_keep_mask,
+                     sample_output.top_tokens,
+                     torch::zeros_like(sample_output.top_tokens));
+    sample_output.top_logprobs =
+        torch::where(top_keep_mask.to(sample_output.top_logprobs.device()),
+                     sample_output.top_logprobs,
+                     torch::zeros_like(sample_output.top_logprobs));
+  }
+
+  if (!sample_output.embeddings.defined()) {
+    return;
+  }
+  CHECK_EQ(sample_output.embeddings.dim(), 3)
+      << "validate output embeddings should be [batch, width, hidden]";
+  CHECK_EQ(sample_output.embeddings.size(0), batch_size)
+      << "validate embedding batch mismatch";
+  CHECK_EQ(sample_output.embeddings.size(1), num_val_tokens)
+      << "validate embedding width mismatch";
+
+  torch::Tensor embedding_keep_mask =
+      keep_mask.to(sample_output.embeddings.device()).unsqueeze(/*dim=*/-1);
+  sample_output.embeddings =
+      torch::where(embedding_keep_mask,
+                   sample_output.embeddings,
+                   torch::zeros_like(sample_output.embeddings));
+}
+
+void sync_pruned_boundary_outputs(
+    SampleOutput& sample_output,
+    const ForwardOutput& target_output,
+    int32_t batch_size,
+    int32_t num_val_tokens,
+    int32_t num_speculative_tokens,
+    const std::vector<int32_t>& pruned_prefix_lengths) {
+  sync_pruned_boundary_logprobs(sample_output,
+                                target_output,
+                                batch_size,
+                                num_val_tokens,
+                                num_speculative_tokens,
+                                pruned_prefix_lengths);
+  sync_pruned_boundary_top_logprobs(sample_output,
+                                    target_output,
+                                    batch_size,
+                                    num_val_tokens,
+                                    num_speculative_tokens,
+                                    pruned_prefix_lengths);
+}
+
+}  // namespace adaptive_pruning
+}  // namespace xllm

--- a/xllm/core/framework/speculative/adaptive_pruning_helpers.cpp
+++ b/xllm/core/framework/speculative/adaptive_pruning_helpers.cpp
@@ -30,13 +30,11 @@ torch::Tensor make_cpu_int_tensor(const std::vector<int32_t>& values) {
                            .pinned_memory(true));
 }
 
-void sync_pruned_boundary_logprobs(
-    SampleOutput& sample_output,
-    const ForwardOutput& target_output,
-    int32_t batch_size,
-    int32_t num_val_tokens,
-    int32_t num_speculative_tokens,
-    const std::vector<int32_t>& pruned_prefix_lengths) {
+void sync_pruned_boundary_logprobs(SampleOutput& sample_output,
+                                   const ForwardOutput& target_output,
+                                   int32_t batch_size,
+                                   int32_t num_val_tokens,
+                                   const PrunedPrefixMasks& masks) {
   if (!sample_output.logprobs.defined()) {
     return;
   }
@@ -47,20 +45,7 @@ void sync_pruned_boundary_logprobs(
       target_output.sample_output.logprobs.numel(),
       static_cast<int64_t>(batch_size) * static_cast<int64_t>(num_val_tokens))
       << "target logprob count mismatch";
-  torch::Tensor prefix_lengths =
-      safe_to(make_cpu_int_tensor(pruned_prefix_lengths),
-              torch::TensorOptions()
-                  .dtype(torch::kLong)
-                  .device(sample_output.logprobs.device()),
-              /*non_blocking=*/true)
-          .clamp(0, num_speculative_tokens);
-  torch::Tensor positions =
-      torch::arange(num_val_tokens, prefix_lengths.options());
-  torch::Tensor cut_mask =
-      positions.unsqueeze(/*dim=*/0)
-          .eq(prefix_lengths.unsqueeze(/*dim=*/1))
-          .logical_and(
-              prefix_lengths.unsqueeze(/*dim=*/1).lt(num_speculative_tokens));
+  torch::Tensor cut_mask = masks.cut_mask.to(sample_output.logprobs.device());
   torch::Tensor target_logprobs = safe_to(
       target_output.sample_output.logprobs.view({batch_size, num_val_tokens}),
       sample_output.logprobs.options(),
@@ -69,13 +54,11 @@ void sync_pruned_boundary_logprobs(
       torch::where(cut_mask, target_logprobs, sample_output.logprobs);
 }
 
-void sync_pruned_boundary_top_logprobs(
-    SampleOutput& sample_output,
-    const ForwardOutput& target_output,
-    int32_t batch_size,
-    int32_t num_val_tokens,
-    int32_t num_speculative_tokens,
-    const std::vector<int32_t>& pruned_prefix_lengths) {
+void sync_pruned_boundary_top_logprobs(SampleOutput& sample_output,
+                                       const ForwardOutput& target_output,
+                                       int32_t batch_size,
+                                       int32_t num_val_tokens,
+                                       const PrunedPrefixMasks& masks) {
   if (!sample_output.top_tokens.defined()) {
     return;
   }
@@ -95,20 +78,8 @@ void sync_pruned_boundary_top_logprobs(
       static_cast<int64_t>(batch_size) * static_cast<int64_t>(num_val_tokens))
       << "target top_logprobs count mismatch";
 
-  torch::Tensor prefix_lengths =
-      safe_to(make_cpu_int_tensor(pruned_prefix_lengths),
-              torch::TensorOptions()
-                  .dtype(torch::kLong)
-                  .device(sample_output.top_tokens.device()),
-              /*non_blocking=*/true)
-          .clamp(0, num_speculative_tokens);
-  torch::Tensor positions =
-      torch::arange(num_val_tokens, prefix_lengths.options());
-  torch::Tensor cut_mask =
-      positions.unsqueeze(/*dim=*/0)
-          .eq(prefix_lengths.unsqueeze(/*dim=*/1))
-          .logical_and(
-              prefix_lengths.unsqueeze(/*dim=*/1).lt(num_speculative_tokens))
+  torch::Tensor cut_mask_broadcast =
+      masks.cut_mask.to(sample_output.top_tokens.device())
           .unsqueeze(/*dim=*/-1);
   const int64_t top_k = sample_output.top_tokens.size(2);
   CHECK_EQ(target_output.sample_output.top_tokens.size(1), top_k)
@@ -121,13 +92,13 @@ void sync_pruned_boundary_top_logprobs(
       target_output.sample_output.top_logprobs.view(
           {batch_size, num_val_tokens, top_k});
   sample_output.top_tokens =
-      torch::where(cut_mask,
+      torch::where(cut_mask_broadcast,
                    safe_to(target_top_tokens,
                            sample_output.top_tokens.options(),
                            /*non_blocking=*/true),
                    sample_output.top_tokens);
   sample_output.top_logprobs =
-      torch::where(cut_mask.to(sample_output.top_logprobs.device()),
+      torch::where(cut_mask_broadcast.to(sample_output.top_logprobs.device()),
                    safe_to(target_top_logprobs,
                            sample_output.top_logprobs.options(),
                            /*non_blocking=*/true),
@@ -135,6 +106,28 @@ void sync_pruned_boundary_top_logprobs(
 }
 
 }  // namespace
+
+PrunedPrefixMasks build_pruned_prefix_masks(
+    const std::vector<int32_t>& pruned_prefix_lengths,
+    int32_t num_speculative_tokens,
+    const torch::Device& device) {
+  const int32_t num_val_tokens = num_speculative_tokens + 1;
+  torch::Tensor prefix_lengths =
+      safe_to(make_cpu_int_tensor(pruned_prefix_lengths),
+              torch::TensorOptions().dtype(torch::kLong).device(device),
+              /*non_blocking=*/true)
+          .clamp(0, num_speculative_tokens);
+  torch::Tensor positions =
+      torch::arange(num_val_tokens, prefix_lengths.options());
+  PrunedPrefixMasks masks;
+  masks.keep_mask =
+      positions.unsqueeze(/*dim=*/0).le(prefix_lengths.unsqueeze(/*dim=*/1));
+  masks.cut_mask = positions.unsqueeze(/*dim=*/0)
+                       .eq(prefix_lengths.unsqueeze(/*dim=*/1))
+                       .logical_and(prefix_lengths.unsqueeze(/*dim=*/1).lt(
+                           num_speculative_tokens));
+  return masks;
+}
 
 torch::Tensor selected_probs_by_step(
     const std::vector<ForwardOutput>& draft_outputs) {
@@ -238,11 +231,10 @@ std::vector<ForwardOutput> truncate_draft_outputs(
   return truncated_outputs;
 }
 
-void apply_pruned_prefix_lengths(
-    SampleOutput& sample_output,
-    const torch::Tensor& target_next_tokens,
-    int32_t num_speculative_tokens,
-    const std::vector<int32_t>& pruned_prefix_lengths) {
+void apply_pruned_prefix_lengths(SampleOutput& sample_output,
+                                 const torch::Tensor& target_next_tokens,
+                                 int32_t num_speculative_tokens,
+                                 const PrunedPrefixMasks& masks) {
   CHECK(sample_output.next_tokens.defined())
       << "validate output tokens are undefined";
   CHECK_EQ(sample_output.next_tokens.dim(), 2)
@@ -252,28 +244,14 @@ void apply_pruned_prefix_lengths(
   const int32_t num_val_tokens = num_speculative_tokens + 1;
   CHECK_EQ(sample_output.next_tokens.size(1), num_val_tokens)
       << "validate output width mismatch";
-  CHECK_EQ(pruned_prefix_lengths.size(), static_cast<size_t>(batch_size))
-      << "adaptive pruning prefix length batch mismatch";
   CHECK(target_next_tokens.defined())
       << "target output tokens are required for adaptive pruning";
   torch::Tensor target_next_tokens_view =
       target_next_tokens.view({batch_size, num_val_tokens});
-  torch::Tensor prefix_lengths =
-      safe_to(make_cpu_int_tensor(pruned_prefix_lengths),
-              torch::TensorOptions()
-                  .dtype(torch::kLong)
-                  .device(sample_output.next_tokens.device()),
-              /*non_blocking=*/true)
-          .clamp(0, num_speculative_tokens);
-  torch::Tensor positions =
-      torch::arange(num_val_tokens, prefix_lengths.options());
   torch::Tensor keep_mask =
-      positions.unsqueeze(/*dim=*/0).le(prefix_lengths.unsqueeze(/*dim=*/1));
+      masks.keep_mask.to(sample_output.next_tokens.device());
   torch::Tensor cut_mask =
-      positions.unsqueeze(/*dim=*/0)
-          .eq(prefix_lengths.unsqueeze(/*dim=*/1))
-          .logical_and(
-              prefix_lengths.unsqueeze(/*dim=*/1).lt(num_speculative_tokens));
+      masks.cut_mask.to(sample_output.next_tokens.device());
   torch::Tensor target_tokens = safe_to(target_next_tokens_view,
                                         sample_output.next_tokens.options(),
                                         /*non_blocking=*/true);
@@ -293,7 +271,7 @@ void apply_pruned_prefix_lengths(
                                             sample_output.logprobs.options(),
                                             /*non_blocking=*/true);
     sample_output.logprobs =
-        torch::where(keep_mask.to(sample_output.logprobs.device()),
+        torch::where(masks.keep_mask.to(sample_output.logprobs.device()),
                      output_logprobs,
                      torch::zeros_like(output_logprobs));
   }
@@ -314,7 +292,8 @@ void apply_pruned_prefix_lengths(
     CHECK_EQ(sample_output.top_logprobs.size(1), num_val_tokens)
         << "validate top_logprobs width mismatch";
     torch::Tensor top_keep_mask =
-        keep_mask.to(sample_output.top_tokens.device()).unsqueeze(/*dim=*/-1);
+        masks.keep_mask.to(sample_output.top_tokens.device())
+            .unsqueeze(/*dim=*/-1);
     sample_output.top_tokens =
         torch::where(top_keep_mask,
                      sample_output.top_tokens,
@@ -336,32 +315,23 @@ void apply_pruned_prefix_lengths(
       << "validate embedding width mismatch";
 
   torch::Tensor embedding_keep_mask =
-      keep_mask.to(sample_output.embeddings.device()).unsqueeze(/*dim=*/-1);
+      masks.keep_mask.to(sample_output.embeddings.device())
+          .unsqueeze(/*dim=*/-1);
   sample_output.embeddings =
       torch::where(embedding_keep_mask,
                    sample_output.embeddings,
                    torch::zeros_like(sample_output.embeddings));
 }
 
-void sync_pruned_boundary_outputs(
-    SampleOutput& sample_output,
-    const ForwardOutput& target_output,
-    int32_t batch_size,
-    int32_t num_val_tokens,
-    int32_t num_speculative_tokens,
-    const std::vector<int32_t>& pruned_prefix_lengths) {
-  sync_pruned_boundary_logprobs(sample_output,
-                                target_output,
-                                batch_size,
-                                num_val_tokens,
-                                num_speculative_tokens,
-                                pruned_prefix_lengths);
-  sync_pruned_boundary_top_logprobs(sample_output,
-                                    target_output,
-                                    batch_size,
-                                    num_val_tokens,
-                                    num_speculative_tokens,
-                                    pruned_prefix_lengths);
+void sync_pruned_boundary_outputs(SampleOutput& sample_output,
+                                  const ForwardOutput& target_output,
+                                  int32_t batch_size,
+                                  int32_t num_val_tokens,
+                                  const PrunedPrefixMasks& masks) {
+  sync_pruned_boundary_logprobs(
+      sample_output, target_output, batch_size, num_val_tokens, masks);
+  sync_pruned_boundary_top_logprobs(
+      sample_output, target_output, batch_size, num_val_tokens, masks);
 }
 
 }  // namespace adaptive_pruning

--- a/xllm/core/framework/speculative/adaptive_pruning_helpers.cpp
+++ b/xllm/core/framework/speculative/adaptive_pruning_helpers.cpp
@@ -260,10 +260,15 @@ void apply_pruned_prefix_lengths(SampleOutput& sample_output,
   torch::Tensor target_tokens = safe_to(target_next_tokens_view,
                                         sample_output.next_tokens.options(),
                                         /*non_blocking=*/true);
+  // Boundary token: replace at cut positions with the target's resample.
+  // `torch::where(cond, src, dst)` is unavoidable here because the fill is a
+  // tensor, not a scalar. Downstream keep-mask fills use masked_fill_ to
+  // avoid the zeros_like/-ones_like scratch tensors.
   torch::Tensor next_tokens =
       torch::where(cut_mask, target_tokens, sample_output.next_tokens);
-  sample_output.next_tokens =
-      torch::where(keep_mask, next_tokens, -torch::ones_like(next_tokens));
+  const torch::Tensor drop_mask = keep_mask.logical_not();
+  next_tokens.masked_fill_(drop_mask, -1);
+  sample_output.next_tokens = next_tokens;
 
   if (sample_output.logprobs.defined()) {
     CHECK_EQ(sample_output.logprobs.dim(), 2)
@@ -272,13 +277,8 @@ void apply_pruned_prefix_lengths(SampleOutput& sample_output,
         << "validate logprob batch mismatch";
     CHECK_EQ(sample_output.logprobs.size(1), num_val_tokens)
         << "validate logprob width mismatch";
-    torch::Tensor output_logprobs = safe_to(sample_output.logprobs,
-                                            sample_output.logprobs.options(),
-                                            /*non_blocking=*/true);
-    sample_output.logprobs =
-        torch::where(masks.keep_mask.to(sample_output.logprobs.device()),
-                     output_logprobs,
-                     torch::zeros_like(output_logprobs));
+    sample_output.logprobs.masked_fill_(
+        drop_mask.to(sample_output.logprobs.device()), 0);
   }
 
   if (sample_output.top_tokens.defined()) {
@@ -296,17 +296,11 @@ void apply_pruned_prefix_lengths(SampleOutput& sample_output,
         << "validate top_logprobs batch mismatch";
     CHECK_EQ(sample_output.top_logprobs.size(1), num_val_tokens)
         << "validate top_logprobs width mismatch";
-    torch::Tensor top_keep_mask =
-        masks.keep_mask.to(sample_output.top_tokens.device())
-            .unsqueeze(/*dim=*/-1);
-    sample_output.top_tokens =
-        torch::where(top_keep_mask,
-                     sample_output.top_tokens,
-                     torch::zeros_like(sample_output.top_tokens));
-    sample_output.top_logprobs =
-        torch::where(top_keep_mask.to(sample_output.top_logprobs.device()),
-                     sample_output.top_logprobs,
-                     torch::zeros_like(sample_output.top_logprobs));
+    const torch::Tensor top_drop_mask =
+        drop_mask.to(sample_output.top_tokens.device()).unsqueeze(/*dim=*/-1);
+    sample_output.top_tokens.masked_fill_(top_drop_mask, 0);
+    sample_output.top_logprobs.masked_fill_(
+        top_drop_mask.to(sample_output.top_logprobs.device()), 0);
   }
 
   if (!sample_output.embeddings.defined()) {
@@ -319,13 +313,9 @@ void apply_pruned_prefix_lengths(SampleOutput& sample_output,
   CHECK_EQ(sample_output.embeddings.size(1), num_val_tokens)
       << "validate embedding width mismatch";
 
-  torch::Tensor embedding_keep_mask =
-      masks.keep_mask.to(sample_output.embeddings.device())
-          .unsqueeze(/*dim=*/-1);
-  sample_output.embeddings =
-      torch::where(embedding_keep_mask,
-                   sample_output.embeddings,
-                   torch::zeros_like(sample_output.embeddings));
+  const torch::Tensor embedding_drop_mask =
+      drop_mask.to(sample_output.embeddings.device()).unsqueeze(/*dim=*/-1);
+  sample_output.embeddings.masked_fill_(embedding_drop_mask, 0);
 }
 
 void sync_pruned_boundary_outputs(SampleOutput& sample_output,

--- a/xllm/core/framework/speculative/adaptive_pruning_helpers.cpp
+++ b/xllm/core/framework/speculative/adaptive_pruning_helpers.cpp
@@ -149,13 +149,18 @@ torch::Tensor selected_probs_by_step(
       CHECK_EQ(logits.dim(), 2)
           << "adaptive pruning expects draft logits [batch,vocab], got "
           << logits.sizes();
-      torch::Tensor softmaxed =
-          torch::softmax(logits, /*dim=*/-1, /*dtype=*/torch::kFloat32);
-      probs =
-          softmaxed
+      // Compute p_selected = exp(logit_selected - logsumexp(logits)) without
+      // materializing the dense [batch, vocab] softmax. logsumexp is a
+      // reduction to [batch]; the gather picks one column of logits. This
+      // saves batch*vocab fp32 (≈39 MiB at batch=64, vocab=152k) per draft
+      // step, executed on every adaptive decode.
+      const torch::Tensor logits_f32 = logits.to(torch::kFloat32);
+      const torch::Tensor logsumexp = torch::logsumexp(logits_f32, /*dim=*/-1);
+      const torch::Tensor selected_logits =
+          logits_f32
               .gather(/*dim=*/-1, next_tokens.view({-1, 1}).to(torch::kLong))
-              .squeeze(/*dim=*/-1)
-              .to(logits.dtype());
+              .squeeze(/*dim=*/-1);
+      probs = torch::exp(selected_logits - logsumexp).to(logits.dtype());
     }
     CHECK(probs.dim() == 1 || probs.dim() == 2)
         << "adaptive pruning expects draft probs [batch] or [batch,1], got "

--- a/xllm/core/framework/speculative/adaptive_pruning_helpers.cpp
+++ b/xllm/core/framework/speculative/adaptive_pruning_helpers.cpp
@@ -144,8 +144,26 @@ torch::Tensor selected_probs_by_step(
   int64_t batch_size = -1;
   for (const ForwardOutput& draft_output : draft_outputs) {
     torch::Tensor probs = draft_output.sample_output.probs;
-    CHECK(probs.defined())
-        << "adaptive pruning requires selected draft probabilities";
+    if (!probs.defined()) {
+      // Fallback: compute selected probs from logits+next_tokens on the fly.
+      // This bypasses the sampler's greedy fast-path which skips probs
+      // assignment. Avoids triggering model-side kernel paths (e.g. Qwen3.5
+      // CausalConv1d) that a sampler-side return_probs=true would touch.
+      const torch::Tensor& logits = draft_output.logits;
+      const torch::Tensor& next_tokens = draft_output.sample_output.next_tokens;
+      CHECK(logits.defined() && next_tokens.defined())
+          << "adaptive pruning fallback needs draft logits and next_tokens";
+      CHECK_EQ(logits.dim(), 2)
+          << "adaptive pruning expects draft logits [batch,vocab], got "
+          << logits.sizes();
+      torch::Tensor softmaxed =
+          torch::softmax(logits, /*dim=*/-1, /*dtype=*/torch::kFloat32);
+      probs =
+          softmaxed
+              .gather(/*dim=*/-1, next_tokens.view({-1, 1}).to(torch::kLong))
+              .squeeze(/*dim=*/-1)
+              .to(logits.dtype());
+    }
     CHECK(probs.dim() == 1 || probs.dim() == 2)
         << "adaptive pruning expects draft probs [batch] or [batch,1], got "
         << probs.sizes();
@@ -172,7 +190,13 @@ bool has_selected_probs_by_step(
   }
   for (const ForwardOutput& draft_output : draft_outputs) {
     const torch::Tensor& probs = draft_output.sample_output.probs;
-    if (!probs.defined()) {
+    if (probs.defined()) {
+      continue;  // ok
+    }
+    // Fallback: selected_probs_by_step will compute from logits+next_tokens.
+    const torch::Tensor& logits = draft_output.logits;
+    const torch::Tensor& next_tokens = draft_output.sample_output.next_tokens;
+    if (!logits.defined() || !next_tokens.defined()) {
       return false;
     }
   }

--- a/xllm/core/framework/speculative/adaptive_pruning_helpers.h
+++ b/xllm/core/framework/speculative/adaptive_pruning_helpers.h
@@ -51,25 +51,42 @@ std::vector<ForwardOutput> truncate_draft_outputs(
     const std::vector<ForwardOutput>& draft_outputs,
     int32_t num_speculative_tokens);
 
+// Precomputed device-side masks derived from the per-seq pruning prefix
+// lengths. Built once per validate() so the three pruning helpers do not
+// each re-upload prefix_lengths and re-run arange+eq+logical_and.
+//
+// Shapes (with batch=B, num_val_tokens=W):
+//   keep_mask [B, W] — positions <= prefix_len (token kept).
+//   cut_mask  [B, W] — position == prefix_len && prefix_len < num_spec
+//                       (boundary position that switches to target token).
+struct PrunedPrefixMasks {
+  torch::Tensor keep_mask;
+  torch::Tensor cut_mask;
+};
+
+// Build keep_mask / cut_mask on `device`. Helpers below can then re-target
+// them to per-tensor devices with .to(...), which is a no-op if they match.
+PrunedPrefixMasks build_pruned_prefix_masks(
+    const std::vector<int32_t>& pruned_prefix_lengths,
+    int32_t num_speculative_tokens,
+    const torch::Device& device);
+
 // Apply per-seq pruning to rejection sampling output: mask positions beyond
 // each seq's prefix_len to -1, and replace the boundary position with the
 // target model's token (acting as bonus token for the truncated sequence).
-void apply_pruned_prefix_lengths(
-    SampleOutput& sample_output,
-    const torch::Tensor& target_next_tokens,
-    int32_t num_speculative_tokens,
-    const std::vector<int32_t>& pruned_prefix_lengths);
+void apply_pruned_prefix_lengths(SampleOutput& sample_output,
+                                 const torch::Tensor& target_next_tokens,
+                                 int32_t num_speculative_tokens,
+                                 const PrunedPrefixMasks& masks);
 
 // Correct logprobs/top_logprobs at pruning boundaries: replace the boundary
 // position's logprob with target model's logprob (since the token changed from
 // a potentially-accepted draft token to a target-resampled token).
-void sync_pruned_boundary_outputs(
-    SampleOutput& sample_output,
-    const ForwardOutput& target_output,
-    int32_t batch_size,
-    int32_t num_val_tokens,
-    int32_t num_speculative_tokens,
-    const std::vector<int32_t>& pruned_prefix_lengths);
+void sync_pruned_boundary_outputs(SampleOutput& sample_output,
+                                  const ForwardOutput& target_output,
+                                  int32_t batch_size,
+                                  int32_t num_val_tokens,
+                                  const PrunedPrefixMasks& masks);
 
 }  // namespace adaptive_pruning
 }  // namespace xllm

--- a/xllm/core/framework/speculative/adaptive_pruning_helpers.h
+++ b/xllm/core/framework/speculative/adaptive_pruning_helpers.h
@@ -1,0 +1,75 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <torch/torch.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+#include "runtime/forward_params.h"
+#include "util/tensor_helper.h"
+
+namespace xllm {
+namespace adaptive_pruning {
+
+// Extract per-step selected token probabilities from draft outputs into
+// a [batch, num_speculative_tokens] matrix for the pruning controller.
+torch::Tensor selected_probs_by_step(
+    const std::vector<ForwardOutput>& draft_outputs);
+
+// Check whether all draft outputs have defined probs (required for pruning).
+bool has_selected_probs_by_step(
+    const std::vector<ForwardOutput>& draft_outputs);
+
+// Clamp pruning prefix lengths to valid range [0, num_speculative_tokens].
+void clamp_prefix_lengths(std::vector<int32_t>& prefix_lengths,
+                          int32_t batch_size,
+                          int32_t num_speculative_tokens);
+
+// Get the maximum prefix length in the batch (determines padded validate
+// width).
+int32_t max_pruned_prefix_length(const std::vector<int32_t>& prefix_lengths,
+                                 int32_t num_speculative_tokens);
+
+// Truncate draft outputs to only the first num_speculative_tokens entries.
+std::vector<ForwardOutput> truncate_draft_outputs(
+    const std::vector<ForwardOutput>& draft_outputs,
+    int32_t num_speculative_tokens);
+
+// Apply per-seq pruning to rejection sampling output: mask positions beyond
+// each seq's prefix_len to -1, and replace the boundary position with the
+// target model's token (acting as bonus token for the truncated sequence).
+void apply_pruned_prefix_lengths(
+    SampleOutput& sample_output,
+    const torch::Tensor& target_next_tokens,
+    int32_t num_speculative_tokens,
+    const std::vector<int32_t>& pruned_prefix_lengths);
+
+// Correct logprobs/top_logprobs at pruning boundaries: replace the boundary
+// position's logprob with target model's logprob (since the token changed from
+// a potentially-accepted draft token to a target-resampled token).
+void sync_pruned_boundary_outputs(
+    SampleOutput& sample_output,
+    const ForwardOutput& target_output,
+    int32_t batch_size,
+    int32_t num_val_tokens,
+    int32_t num_speculative_tokens,
+    const std::vector<int32_t>& pruned_prefix_lengths);
+
+}  // namespace adaptive_pruning
+}  // namespace xllm

--- a/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
+++ b/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
@@ -1,0 +1,203 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "core/framework/speculative/adaptive_speculative_controller.h"
+
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <string>
+#include <utility>
+
+#include "core/framework/speculative/speculative_profile_registry.h"
+#include "util/tensor_helper.h"
+
+namespace xllm {
+namespace {
+
+bool is_mtp_algorithm(std::string algorithm) {
+  std::transform(
+      algorithm.begin(),
+      algorithm.end(),
+      algorithm.begin(),
+      [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return algorithm == "mtp";
+}
+
+struct PruneCandidate {
+  int32_t seq_id = 0;
+  int32_t prefix_len = 0;
+  double path_prob = 0.0;
+};
+
+}  // namespace
+
+AdaptiveSpeculativeController::AdaptiveSpeculativeController(
+    const runtime::Options& options)
+    : enabled_(options.enable_adaptive_speculative_decode() &&
+               options.num_speculative_tokens() > 1 &&
+               is_mtp_algorithm(options.speculative_algorithm()) &&
+               !options.enable_graph()),
+      min_gain_(options.adaptive_speculative_min_gain()) {}
+
+bool AdaptiveSpeculativeController::enabled() const { return enabled_; }
+
+// Greedy selection of per-seq validate prefix lengths.
+// Candidates (seq_id, position, path_prob) are sorted by path_prob descending.
+// Each candidate is accepted if it improves estimated throughput
+// (score = expected_tokens / estimated_time).
+std::vector<int32_t>
+AdaptiveSpeculativeController::select_pruned_prefix_lengths(
+    const torch::Tensor& selected_probs_by_step,
+    double full_draft_time_ms,
+    double target_step_time_ms,
+    const std::vector<double>& per_seq_kv_lens) const {
+  CHECK(selected_probs_by_step.defined())
+      << "adaptive pruning requires draft selected probabilities";
+  CHECK_EQ(selected_probs_by_step.dim(), 2)
+      << "adaptive pruning expects selected probs [batch, speculative_tokens], "
+      << "got " << selected_probs_by_step.sizes();
+
+  torch::Tensor probs =
+      safe_to(selected_probs_by_step, torch::kCPU).to(torch::kFloat64);
+  probs = probs.clamp(0.0, 1.0).contiguous();
+  const int32_t batch_size = static_cast<int32_t>(probs.size(0));
+  const int32_t num_speculative_tokens = static_cast<int32_t>(probs.size(1));
+  CHECK_GT(batch_size, 0) << "adaptive pruning batch size must be positive";
+  CHECK_GT(num_speculative_tokens, 0)
+      << "adaptive pruning speculative tokens must be positive";
+
+  std::vector<std::vector<double>> path_probs(
+      static_cast<size_t>(batch_size),
+      std::vector<double>(static_cast<size_t>(num_speculative_tokens), 0.0));
+  std::vector<PruneCandidate> candidates;
+  candidates.reserve(static_cast<size_t>(batch_size) *
+                     static_cast<size_t>(num_speculative_tokens));
+  const double* prob_data = probs.data_ptr<double>();
+  for (int32_t seq_id = 0; seq_id < batch_size; ++seq_id) {
+    double path_prob = 1.0;
+    for (int32_t token_idx = 0; token_idx < num_speculative_tokens;
+         ++token_idx) {
+      path_prob *= prob_data[seq_id * num_speculative_tokens + token_idx];
+      if (!std::isfinite(path_prob)) {
+        path_prob = 0.0;
+      }
+      path_prob = std::clamp(path_prob, 0.0, 1.0);
+      path_probs[static_cast<size_t>(seq_id)][static_cast<size_t>(token_idx)] =
+          path_prob;
+      candidates.push_back({seq_id, token_idx + 1, path_prob});
+    }
+  }
+
+  std::sort(candidates.begin(),
+            candidates.end(),
+            [](const PruneCandidate& lhs, const PruneCandidate& rhs) {
+              if (lhs.path_prob != rhs.path_prob) {
+                return lhs.path_prob > rhs.path_prob;
+              }
+              if (lhs.prefix_len != rhs.prefix_len) {
+                return lhs.prefix_len < rhs.prefix_len;
+              }
+              return lhs.seq_id < rhs.seq_id;
+            });
+
+  std::vector<int32_t> prefix_lengths(static_cast<size_t>(batch_size), 0);
+  double expected_accepted = 0.0;
+  double current_score = score_for_pruned_state(batch_size,
+                                                expected_accepted,
+                                                prefix_lengths,
+                                                per_seq_kv_lens,
+                                                full_draft_time_ms,
+                                                target_step_time_ms);
+  const double min_gain = std::max(min_gain_, 0.0);
+  for (const PruneCandidate& candidate : candidates) {
+    int32_t& prefix_len = prefix_lengths[static_cast<size_t>(candidate.seq_id)];
+    if (candidate.prefix_len <= prefix_len) {
+      continue;
+    }
+
+    double candidate_expected_accepted = expected_accepted;
+    const std::vector<double>& seq_path_probs =
+        path_probs[static_cast<size_t>(candidate.seq_id)];
+    for (int32_t token_idx = prefix_len; token_idx < candidate.prefix_len;
+         ++token_idx) {
+      candidate_expected_accepted +=
+          seq_path_probs[static_cast<size_t>(token_idx)];
+    }
+    const int32_t old_prefix_len = prefix_len;
+    prefix_len = candidate.prefix_len;
+    const double next_score =
+        score_for_pruned_state(batch_size,
+                               candidate_expected_accepted,
+                               prefix_lengths,
+                               per_seq_kv_lens,
+                               full_draft_time_ms,
+                               target_step_time_ms);
+    if (next_score <= current_score * (1.0 + min_gain)) {
+      prefix_len = old_prefix_len;
+      continue;
+    }
+
+    expected_accepted = candidate_expected_accepted;
+    current_score = next_score;
+  }
+
+  return prefix_lengths;
+}
+
+// score = expected_emitted / (draft_time + validate_time)
+// validate_time is estimated per-seq: sum of per-token costs from the profile.
+double AdaptiveSpeculativeController::score_for_pruned_state(
+    int32_t batch_size,
+    double expected_accepted,
+    const std::vector<int32_t>& prefix_lengths,
+    const std::vector<double>& per_seq_kv_lens,
+    double full_draft_time_ms,
+    double target_step_time_ms) const {
+  const double estimated_time =
+      std::max(full_draft_time_ms, 1.0e-6) +
+      std::max(estimate_validate_time(prefix_lengths, per_seq_kv_lens),
+               target_step_time_ms * 0.1);
+  const double expected_emitted =
+      static_cast<double>(batch_size) + expected_accepted;
+  return expected_emitted / estimated_time;
+}
+
+// Per-seq validate time: intercept + Σᵢ (batch_ms + query_token_ms * qᵢ +
+// query_prefix_ms * qᵢ * kvᵢ) where qᵢ = prefix_lengths[i] + 1. Coefficients
+// from ProfileManager's linear regression.
+double AdaptiveSpeculativeController::estimate_validate_time(
+    const std::vector<int32_t>& prefix_lengths,
+    const std::vector<double>& per_seq_kv_lens) const {
+  std::optional<SpeculativeProfileRegistry::ValidateTimePredictor> predictor =
+      SpeculativeProfileRegistry::get_instance().validate_time_predictor();
+  if (!predictor.has_value()) {
+    return 1.0;
+  }
+
+  double time = predictor->intercept_ms;
+  for (size_t i = 0; i < prefix_lengths.size(); ++i) {
+    const double q_i = static_cast<double>(prefix_lengths[i] + 1);
+    const double kv_i = i < per_seq_kv_lens.size() ? per_seq_kv_lens[i] : 0.0;
+    time += predictor->batch_ms;
+    time += predictor->query_token_ms * q_i;
+    time += predictor->query_prefix_ms * q_i * kv_i;
+  }
+  return std::max(time, 0.0);
+}
+
+}  // namespace xllm

--- a/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
+++ b/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
@@ -65,7 +65,6 @@ std::vector<int32_t>
 AdaptiveSpeculativeController::select_pruned_prefix_lengths(
     const torch::Tensor& selected_probs_by_step,
     double full_draft_time_ms,
-    double target_step_time_ms,
     const std::vector<double>& per_seq_kv_lens) const {
   CHECK(selected_probs_by_step.defined())
       << "adaptive pruning requires draft selected probabilities";
@@ -156,9 +155,7 @@ AdaptiveSpeculativeController::select_pruned_prefix_lengths(
     }
   }
   auto score_of = [&](double accepted, double vtime_raw) {
-    // Guard against a degenerate zero denominator; do NOT clamp to a fraction
-    // of target_step_time_ms — that is a self-calibration loop that silently
-    // suppresses pruning when vtime_raw is small.
+    // Keep the divisor strictly positive; a 1e-6 lower bound is enough.
     const double estimated_time =
         std::max(full_draft_time_ms, 1.0e-6) + std::max(vtime_raw, 1.0e-6);
     return (static_cast<double>(batch_size) + accepted) / estimated_time;

--- a/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
+++ b/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
@@ -18,26 +18,15 @@ limitations under the License.
 #include <glog/logging.h>
 
 #include <algorithm>
-#include <cctype>
 #include <cmath>
-#include <cstdlib>
 #include <string>
-#include <utility>
 
+#include "core/framework/config/speculative_config.h"
 #include "core/framework/speculative/speculative_profile_registry.h"
 #include "util/tensor_helper.h"
 
 namespace xllm {
 namespace {
-
-bool is_mtp_algorithm(std::string algorithm) {
-  std::transform(
-      algorithm.begin(),
-      algorithm.end(),
-      algorithm.begin(),
-      [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-  return algorithm == "mtp";
-}
 
 struct PruneCandidate {
   int32_t seq_id = 0;
@@ -51,7 +40,8 @@ AdaptiveSpeculativeController::AdaptiveSpeculativeController(
     const runtime::Options& options)
     : enabled_(options.enable_adaptive_speculative_decode() &&
                options.num_speculative_tokens() > 1 &&
-               is_mtp_algorithm(options.speculative_algorithm()) &&
+               SpeculativeConfig::is_mtp_algorithm(
+                   options.speculative_algorithm()) &&
                !options.enable_graph()),
       min_gain_(options.adaptive_speculative_min_gain()) {}
 
@@ -123,15 +113,7 @@ AdaptiveSpeculativeController::select_pruned_prefix_lengths(
   std::optional<SpeculativeProfileRegistry::ValidateTimePredictor> predictor =
       SpeculativeProfileRegistry::get_instance().validate_time_predictor();
   const bool has_predictor = predictor.has_value();
-  // Experiment knob: scale query_token_ms via env ADAPTIVE_QUERY_TOKEN_SCALE
-  // (default 1.0). Larger scale amplifies the per-token marginal validate cost
-  // in score's denominator, encouraging the greedy loop to prune more.
-  static const double query_token_scale = [] {
-    const char* s = std::getenv("ADAPTIVE_QUERY_TOKEN_SCALE");
-    return s != nullptr ? std::atof(s) : 1.0;
-  }();
-  const double query_token_ms =
-      has_predictor ? query_token_scale * predictor->query_token_ms : 0.0;
+  const double query_token_ms = has_predictor ? predictor->query_token_ms : 0.0;
   const double query_prefix_ms =
       has_predictor ? predictor->query_prefix_ms : 0.0;
 

--- a/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
+++ b/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
@@ -71,9 +71,13 @@ AdaptiveSpeculativeController::select_pruned_prefix_lengths(
   CHECK_GT(num_speculative_tokens, 0)
       << "adaptive pruning speculative tokens must be positive";
 
-  std::vector<std::vector<double>> path_probs(
-      static_cast<size_t>(batch_size),
-      std::vector<double>(static_cast<size_t>(num_speculative_tokens), 0.0));
+  // path_probs laid out as a single [batch * num_speculative_tokens] buffer
+  // indexed by `seq * num_speculative_tokens + token_idx` to avoid the
+  // per-step batch_size heap allocations of vector<vector<double>>.
+  std::vector<double> path_probs(
+      static_cast<size_t>(batch_size) *
+          static_cast<size_t>(num_speculative_tokens),
+      0.0);
   std::vector<PruneCandidate> candidates;
   candidates.reserve(static_cast<size_t>(batch_size) *
                      static_cast<size_t>(num_speculative_tokens));
@@ -87,8 +91,9 @@ AdaptiveSpeculativeController::select_pruned_prefix_lengths(
         path_prob = 0.0;
       }
       path_prob = std::clamp(path_prob, 0.0, 1.0);
-      path_probs[static_cast<size_t>(seq_id)][static_cast<size_t>(token_idx)] =
-          path_prob;
+      path_probs[static_cast<size_t>(seq_id) *
+                     static_cast<size_t>(num_speculative_tokens) +
+                 static_cast<size_t>(token_idx)] = path_prob;
       candidates.push_back({seq_id, token_idx + 1, path_prob});
     }
   }
@@ -152,12 +157,12 @@ AdaptiveSpeculativeController::select_pruned_prefix_lengths(
     }
 
     double candidate_expected_accepted = expected_accepted;
-    const std::vector<double>& seq_path_probs =
-        path_probs[static_cast<size_t>(candidate.seq_id)];
+    const size_t seq_base = static_cast<size_t>(candidate.seq_id) *
+                            static_cast<size_t>(num_speculative_tokens);
     for (int32_t token_idx = prefix_len; token_idx < candidate.prefix_len;
          ++token_idx) {
       candidate_expected_accepted +=
-          seq_path_probs[static_cast<size_t>(token_idx)];
+          path_probs[seq_base + static_cast<size_t>(token_idx)];
     }
     // Incremental validate_time: only this seq's qᵢ grows by (new - old).
     const double kv_i =

--- a/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
+++ b/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
@@ -177,9 +177,9 @@ double AdaptiveSpeculativeController::score_for_pruned_state(
   return expected_emitted / estimated_time;
 }
 
-// Per-seq validate time: intercept + Σᵢ (batch_ms + query_token_ms * qᵢ +
+// Per-seq validate time: intercept + Σᵢ (query_token_ms * qᵢ +
 // query_prefix_ms * qᵢ * kvᵢ) where qᵢ = prefix_lengths[i] + 1. Coefficients
-// from ProfileManager's linear regression.
+// from ProfileManager's linear regression (batch_ms term is not fitted).
 double AdaptiveSpeculativeController::estimate_validate_time(
     const std::vector<int32_t>& prefix_lengths,
     const std::vector<double>& per_seq_kv_lens) const {
@@ -193,7 +193,6 @@ double AdaptiveSpeculativeController::estimate_validate_time(
   for (size_t i = 0; i < prefix_lengths.size(); ++i) {
     const double q_i = static_cast<double>(prefix_lengths[i] + 1);
     const double kv_i = i < per_seq_kv_lens.size() ? per_seq_kv_lens[i] : 0.0;
-    time += predictor->batch_ms;
     time += predictor->query_token_ms * q_i;
     time += predictor->query_prefix_ms * q_i * kv_i;
   }

--- a/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
+++ b/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
@@ -115,14 +115,38 @@ AdaptiveSpeculativeController::select_pruned_prefix_lengths(
               return lhs.seq_id < rhs.seq_id;
             });
 
+  // Incremental greedy: maintain running expected_accepted and validate_time
+  // instead of recomputing the whole batch per candidate (was O(batch^2 * S)).
+  // validate_time = intercept + Σᵢ (query_token_ms·qᵢ +
+  // query_prefix_ms·qᵢ·kvᵢ), qᵢ = prefix_len_i + 1. Fetch the predictor once
+  // outside the loop.
+  std::optional<SpeculativeProfileRegistry::ValidateTimePredictor> predictor =
+      SpeculativeProfileRegistry::get_instance().validate_time_predictor();
+  const bool has_predictor = predictor.has_value();
+  const double query_token_ms = has_predictor ? predictor->query_token_ms : 0.0;
+  const double query_prefix_ms =
+      has_predictor ? predictor->query_prefix_ms : 0.0;
+
   std::vector<int32_t> prefix_lengths(static_cast<size_t>(batch_size), 0);
   double expected_accepted = 0.0;
-  double current_score = score_for_pruned_state(batch_size,
-                                                expected_accepted,
-                                                prefix_lengths,
-                                                per_seq_kv_lens,
-                                                full_draft_time_ms,
-                                                target_step_time_ms);
+  // Running raw validate_time for the current prefix_lengths (qᵢ = 0+1 = 1).
+  double validate_time_raw = 1.0;  // fallback when predictor is unavailable
+  if (has_predictor) {
+    validate_time_raw = predictor->intercept_ms;
+    for (int32_t seq_id = 0; seq_id < batch_size; ++seq_id) {
+      const double kv_i = static_cast<size_t>(seq_id) < per_seq_kv_lens.size()
+                              ? per_seq_kv_lens[static_cast<size_t>(seq_id)]
+                              : 0.0;
+      validate_time_raw += query_token_ms * 1.0 + query_prefix_ms * 1.0 * kv_i;
+    }
+  }
+  auto score_of = [&](double accepted, double vtime_raw) {
+    const double estimated_time =
+        std::max(full_draft_time_ms, 1.0e-6) +
+        std::max(std::max(vtime_raw, 0.0), target_step_time_ms * 0.1);
+    return (static_cast<double>(batch_size) + accepted) / estimated_time;
+  };
+  double current_score = score_of(expected_accepted, validate_time_raw);
   const double min_gain = std::max(min_gain_, 0.0);
   for (const PruneCandidate& candidate : candidates) {
     int32_t& prefix_len = prefix_lengths[static_cast<size_t>(candidate.seq_id)];
@@ -138,65 +162,30 @@ AdaptiveSpeculativeController::select_pruned_prefix_lengths(
       candidate_expected_accepted +=
           seq_path_probs[static_cast<size_t>(token_idx)];
     }
-    const int32_t old_prefix_len = prefix_len;
-    prefix_len = candidate.prefix_len;
+    // Incremental validate_time: only this seq's qᵢ grows by (new - old).
+    const double kv_i =
+        static_cast<size_t>(candidate.seq_id) < per_seq_kv_lens.size()
+            ? per_seq_kv_lens[static_cast<size_t>(candidate.seq_id)]
+            : 0.0;
+    const double delta_q =
+        static_cast<double>(candidate.prefix_len - prefix_len);
+    const double candidate_validate_time_raw =
+        has_predictor ? validate_time_raw + query_token_ms * delta_q +
+                            query_prefix_ms * delta_q * kv_i
+                      : validate_time_raw;
     const double next_score =
-        score_for_pruned_state(batch_size,
-                               candidate_expected_accepted,
-                               prefix_lengths,
-                               per_seq_kv_lens,
-                               full_draft_time_ms,
-                               target_step_time_ms);
+        score_of(candidate_expected_accepted, candidate_validate_time_raw);
     if (next_score <= current_score * (1.0 + min_gain)) {
-      prefix_len = old_prefix_len;
       continue;
     }
 
+    prefix_len = candidate.prefix_len;
     expected_accepted = candidate_expected_accepted;
+    validate_time_raw = candidate_validate_time_raw;
     current_score = next_score;
   }
 
   return prefix_lengths;
-}
-
-// score = expected_emitted / (draft_time + validate_time)
-// validate_time is estimated per-seq: sum of per-token costs from the profile.
-double AdaptiveSpeculativeController::score_for_pruned_state(
-    int32_t batch_size,
-    double expected_accepted,
-    const std::vector<int32_t>& prefix_lengths,
-    const std::vector<double>& per_seq_kv_lens,
-    double full_draft_time_ms,
-    double target_step_time_ms) const {
-  const double estimated_time =
-      std::max(full_draft_time_ms, 1.0e-6) +
-      std::max(estimate_validate_time(prefix_lengths, per_seq_kv_lens),
-               target_step_time_ms * 0.1);
-  const double expected_emitted =
-      static_cast<double>(batch_size) + expected_accepted;
-  return expected_emitted / estimated_time;
-}
-
-// Per-seq validate time: intercept + Σᵢ (query_token_ms * qᵢ +
-// query_prefix_ms * qᵢ * kvᵢ) where qᵢ = prefix_lengths[i] + 1. Coefficients
-// from ProfileManager's linear regression (batch_ms term is not fitted).
-double AdaptiveSpeculativeController::estimate_validate_time(
-    const std::vector<int32_t>& prefix_lengths,
-    const std::vector<double>& per_seq_kv_lens) const {
-  std::optional<SpeculativeProfileRegistry::ValidateTimePredictor> predictor =
-      SpeculativeProfileRegistry::get_instance().validate_time_predictor();
-  if (!predictor.has_value()) {
-    return 1.0;
-  }
-
-  double time = predictor->intercept_ms;
-  for (size_t i = 0; i < prefix_lengths.size(); ++i) {
-    const double q_i = static_cast<double>(prefix_lengths[i] + 1);
-    const double kv_i = i < per_seq_kv_lens.size() ? per_seq_kv_lens[i] : 0.0;
-    time += predictor->query_token_ms * q_i;
-    time += predictor->query_prefix_ms * q_i * kv_i;
-  }
-  return std::max(time, 0.0);
 }
 
 }  // namespace xllm

--- a/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
+++ b/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
@@ -20,6 +20,7 @@ limitations under the License.
 #include <algorithm>
 #include <cctype>
 #include <cmath>
+#include <cstdlib>
 #include <string>
 #include <utility>
 
@@ -123,16 +124,30 @@ AdaptiveSpeculativeController::select_pruned_prefix_lengths(
   std::optional<SpeculativeProfileRegistry::ValidateTimePredictor> predictor =
       SpeculativeProfileRegistry::get_instance().validate_time_predictor();
   const bool has_predictor = predictor.has_value();
-  const double query_token_ms = has_predictor ? predictor->query_token_ms : 0.0;
+  // Experiment knob: scale query_token_ms via env ADAPTIVE_QUERY_TOKEN_SCALE
+  // (default 1.0). Larger scale amplifies the per-token marginal validate cost
+  // in score's denominator, encouraging the greedy loop to prune more.
+  static const double query_token_scale = [] {
+    const char* s = std::getenv("ADAPTIVE_QUERY_TOKEN_SCALE");
+    return s != nullptr ? std::atof(s) : 1.0;
+  }();
+  const double query_token_ms =
+      has_predictor ? query_token_scale * predictor->query_token_ms : 0.0;
   const double query_prefix_ms =
       has_predictor ? predictor->query_prefix_ms : 0.0;
 
+  const double intercept_ms = has_predictor ? predictor->intercept_ms : 0.0;
+
   std::vector<int32_t> prefix_lengths(static_cast<size_t>(batch_size), 0);
   double expected_accepted = 0.0;
-  // Running raw validate_time for the current prefix_lengths (qᵢ = 0+1 = 1).
+  // Running validate_time for the current prefix_lengths (qᵢ = 0+1 = 1).
+  // We include intercept so that the marginal cost of adding a draft
+  // (query_token_ms·Δq + query_prefix_ms·Δq·kv) is weighed against the
+  // *full* estimated validate time. Excluding intercept overweights the
+  // marginal term and causes over-pruning when intercept dominates.
   double validate_time_raw = 1.0;  // fallback when predictor is unavailable
   if (has_predictor) {
-    validate_time_raw = predictor->intercept_ms;
+    validate_time_raw = intercept_ms;
     for (int32_t seq_id = 0; seq_id < batch_size; ++seq_id) {
       const double kv_i = static_cast<size_t>(seq_id) < per_seq_kv_lens.size()
                               ? per_seq_kv_lens[static_cast<size_t>(seq_id)]
@@ -141,13 +156,16 @@ AdaptiveSpeculativeController::select_pruned_prefix_lengths(
     }
   }
   auto score_of = [&](double accepted, double vtime_raw) {
+    // Guard against a degenerate zero denominator; do NOT clamp to a fraction
+    // of target_step_time_ms — that is a self-calibration loop that silently
+    // suppresses pruning when vtime_raw is small.
     const double estimated_time =
-        std::max(full_draft_time_ms, 1.0e-6) +
-        std::max(std::max(vtime_raw, 0.0), target_step_time_ms * 0.1);
+        std::max(full_draft_time_ms, 1.0e-6) + std::max(vtime_raw, 1.0e-6);
     return (static_cast<double>(batch_size) + accepted) / estimated_time;
   };
   double current_score = score_of(expected_accepted, validate_time_raw);
   const double min_gain = std::max(min_gain_, 0.0);
+
   for (const PruneCandidate& candidate : candidates) {
     int32_t& prefix_len = prefix_lengths[static_cast<size_t>(candidate.seq_id)];
     if (candidate.prefix_len <= prefix_len) {
@@ -175,7 +193,8 @@ AdaptiveSpeculativeController::select_pruned_prefix_lengths(
                       : validate_time_raw;
     const double next_score =
         score_of(candidate_expected_accepted, candidate_validate_time_raw);
-    if (next_score <= current_score * (1.0 + min_gain)) {
+    const bool accept = (next_score > current_score * (1.0 + min_gain));
+    if (!accept) {
       continue;
     }
 

--- a/xllm/core/framework/speculative/adaptive_speculative_controller.h
+++ b/xllm/core/framework/speculative/adaptive_speculative_controller.h
@@ -1,0 +1,57 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <torch/torch.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "runtime/options.h"
+
+namespace xllm {
+
+// Decides per-seq speculative validate prefix lengths based on draft token
+// path probabilities and profiled validate time. Greedy algorithm: candidates
+// sorted by path_prob descending, accepted if estimated throughput improves.
+class AdaptiveSpeculativeController final {
+ public:
+  explicit AdaptiveSpeculativeController(const runtime::Options& options);
+  ~AdaptiveSpeculativeController() = default;
+
+  bool enabled() const;
+  std::vector<int32_t> select_pruned_prefix_lengths(
+      const torch::Tensor& selected_probs_by_step,
+      double full_draft_time_ms,
+      double target_step_time_ms,
+      const std::vector<double>& per_seq_kv_lens) const;
+
+ private:
+  double score_for_pruned_state(int32_t batch_size,
+                                double expected_accepted,
+                                const std::vector<int32_t>& prefix_lengths,
+                                const std::vector<double>& per_seq_kv_lens,
+                                double full_draft_time_ms,
+                                double target_step_time_ms) const;
+  double estimate_validate_time(
+      const std::vector<int32_t>& prefix_lengths,
+      const std::vector<double>& per_seq_kv_lens) const;
+
+  bool enabled_ = false;
+  double min_gain_ = 0.0;
+};
+
+}  // namespace xllm

--- a/xllm/core/framework/speculative/adaptive_speculative_controller.h
+++ b/xllm/core/framework/speculative/adaptive_speculative_controller.h
@@ -36,7 +36,6 @@ class AdaptiveSpeculativeController final {
   std::vector<int32_t> select_pruned_prefix_lengths(
       const torch::Tensor& selected_probs_by_step,
       double full_draft_time_ms,
-      double target_step_time_ms,
       const std::vector<double>& per_seq_kv_lens) const;
 
  private:

--- a/xllm/core/framework/speculative/adaptive_speculative_controller.h
+++ b/xllm/core/framework/speculative/adaptive_speculative_controller.h
@@ -40,16 +40,6 @@ class AdaptiveSpeculativeController final {
       const std::vector<double>& per_seq_kv_lens) const;
 
  private:
-  double score_for_pruned_state(int32_t batch_size,
-                                double expected_accepted,
-                                const std::vector<int32_t>& prefix_lengths,
-                                const std::vector<double>& per_seq_kv_lens,
-                                double full_draft_time_ms,
-                                double target_step_time_ms) const;
-  double estimate_validate_time(
-      const std::vector<int32_t>& prefix_lengths,
-      const std::vector<double>& per_seq_kv_lens) const;
-
   bool enabled_ = false;
   double min_gain_ = 0.0;
 };

--- a/xllm/core/framework/speculative/speculative_profile_registry.cpp
+++ b/xllm/core/framework/speculative/speculative_profile_registry.cpp
@@ -1,0 +1,91 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "core/framework/speculative/speculative_profile_registry.h"
+
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <cmath>
+#include <mutex>
+
+namespace xllm {
+namespace {
+
+double sanitize_non_negative(double value) {
+  if (!std::isfinite(value)) {
+    return 0.0;
+  }
+  return std::max(value, 0.0);
+}
+
+}  // namespace
+
+SpeculativeProfileRegistry& SpeculativeProfileRegistry::get_instance() {
+  static SpeculativeProfileRegistry registry;
+  return registry;
+}
+
+void SpeculativeProfileRegistry::set_validate_time_predictor(
+    const ValidateTimePredictor& predictor) {
+  ValidateTimePredictor sanitized_predictor = predictor;
+  sanitized_predictor.intercept_ms =
+      sanitize_non_negative(predictor.intercept_ms);
+  sanitized_predictor.batch_ms = sanitize_non_negative(predictor.batch_ms);
+  sanitized_predictor.query_token_ms =
+      sanitize_non_negative(predictor.query_token_ms);
+  sanitized_predictor.query_prefix_ms =
+      sanitize_non_negative(predictor.query_prefix_ms);
+  std::lock_guard<std::mutex> lock(mutex_);
+  validate_time_predictor_ = sanitized_predictor;
+}
+
+void SpeculativeProfileRegistry::reset_validate_time_predictor() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  validate_time_predictor_.reset();
+}
+
+bool SpeculativeProfileRegistry::has_validate_time_predictor() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return validate_time_predictor_.has_value();
+}
+
+std::optional<SpeculativeProfileRegistry::ValidateTimePredictor>
+SpeculativeProfileRegistry::validate_time_predictor() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return validate_time_predictor_;
+}
+
+double SpeculativeProfileRegistry::predict_validate_time_ms(
+    int32_t batch_size,
+    int32_t query_len,
+    double avg_prefix_len) const {
+  std::optional<ValidateTimePredictor> predictor = validate_time_predictor();
+  if (!predictor.has_value() || batch_size <= 0 || query_len <= 0 ||
+      !std::isfinite(avg_prefix_len)) {
+    return 0.0;
+  }
+
+  const double batch = static_cast<double>(batch_size);
+  const double query = static_cast<double>(query_len);
+  const double prefix = std::max(avg_prefix_len, 0.0);
+  const double predicted_time =
+      predictor->intercept_ms + predictor->batch_ms * batch +
+      predictor->query_token_ms * batch * query +
+      predictor->query_prefix_ms * batch * query * prefix;
+  return sanitize_non_negative(predicted_time);
+}
+
+}  // namespace xllm

--- a/xllm/core/framework/speculative/speculative_profile_registry.cpp
+++ b/xllm/core/framework/speculative/speculative_profile_registry.cpp
@@ -43,7 +43,6 @@ void SpeculativeProfileRegistry::set_validate_time_predictor(
   ValidateTimePredictor sanitized_predictor = predictor;
   sanitized_predictor.intercept_ms =
       sanitize_non_negative(predictor.intercept_ms);
-  sanitized_predictor.batch_ms = sanitize_non_negative(predictor.batch_ms);
   sanitized_predictor.query_token_ms =
       sanitize_non_negative(predictor.query_token_ms);
   sanitized_predictor.query_prefix_ms =
@@ -66,26 +65,6 @@ std::optional<SpeculativeProfileRegistry::ValidateTimePredictor>
 SpeculativeProfileRegistry::validate_time_predictor() const {
   std::lock_guard<std::mutex> lock(mutex_);
   return validate_time_predictor_;
-}
-
-double SpeculativeProfileRegistry::predict_validate_time_ms(
-    int32_t batch_size,
-    int32_t query_len,
-    double avg_prefix_len) const {
-  std::optional<ValidateTimePredictor> predictor = validate_time_predictor();
-  if (!predictor.has_value() || batch_size <= 0 || query_len <= 0 ||
-      !std::isfinite(avg_prefix_len)) {
-    return 0.0;
-  }
-
-  const double batch = static_cast<double>(batch_size);
-  const double query = static_cast<double>(query_len);
-  const double prefix = std::max(avg_prefix_len, 0.0);
-  const double predicted_time =
-      predictor->intercept_ms + predictor->batch_ms * batch +
-      predictor->query_token_ms * batch * query +
-      predictor->query_prefix_ms * batch * query * prefix;
-  return sanitize_non_negative(predicted_time);
 }
 
 }  // namespace xllm

--- a/xllm/core/framework/speculative/speculative_profile_registry.h
+++ b/xllm/core/framework/speculative/speculative_profile_registry.h
@@ -1,0 +1,56 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <cstdint>
+#include <mutex>
+#include <optional>
+
+namespace xllm {
+
+// Thread-safe singleton storing the validate time predictor coefficients
+// fitted by ProfileManager. Used by AdaptiveSpeculativeController to estimate
+// per-seq validate cost. Also serves as the gate for enabling the adaptive
+// path: adaptive decode only activates after the predictor is set.
+class SpeculativeProfileRegistry final {
+ public:
+  struct ValidateTimePredictor {
+    double intercept_ms = 0.0;
+    double batch_ms = 0.0;
+    double query_token_ms = 0.0;
+    double query_prefix_ms = 0.0;
+  };
+
+  static SpeculativeProfileRegistry& get_instance();
+
+  void set_validate_time_predictor(const ValidateTimePredictor& predictor);
+  void reset_validate_time_predictor();
+
+  bool has_validate_time_predictor() const;
+  std::optional<ValidateTimePredictor> validate_time_predictor() const;
+
+  double predict_validate_time_ms(int32_t batch_size,
+                                  int32_t query_len,
+                                  double avg_prefix_len) const;
+
+ private:
+  SpeculativeProfileRegistry() = default;
+
+  mutable std::mutex mutex_;
+  std::optional<ValidateTimePredictor> validate_time_predictor_;
+};
+
+}  // namespace xllm

--- a/xllm/core/framework/speculative/speculative_profile_registry.h
+++ b/xllm/core/framework/speculative/speculative_profile_registry.h
@@ -29,7 +29,6 @@ class SpeculativeProfileRegistry final {
  public:
   struct ValidateTimePredictor {
     double intercept_ms = 0.0;
-    double batch_ms = 0.0;
     double query_token_ms = 0.0;
     double query_prefix_ms = 0.0;
   };
@@ -41,10 +40,6 @@ class SpeculativeProfileRegistry final {
 
   bool has_validate_time_predictor() const;
   std::optional<ValidateTimePredictor> validate_time_predictor() const;
-
-  double predict_validate_time_ms(int32_t batch_size,
-                                  int32_t query_len,
-                                  double avg_prefix_len) const;
 
  private:
   SpeculativeProfileRegistry() = default;

--- a/xllm/core/runtime/CMakeLists.txt
+++ b/xllm/core/runtime/CMakeLists.txt
@@ -87,6 +87,7 @@ cc_library(
     :platform
     :model_context
     :request
+    :speculative
     :encoder_cache
     :state_dict
     :dit_cache

--- a/xllm/core/runtime/eagle3_worker_impl.cpp
+++ b/xllm/core/runtime/eagle3_worker_impl.cpp
@@ -48,18 +48,14 @@ runtime::Options eagle3_draft_options(const runtime::Options& options) {
 Eagle3WorkerImpl::Eagle3WorkerImpl(const ParallelArgs& parallel_args,
                                    const torch::Device& device,
                                    const runtime::Options& options)
-    : MTPWorkerImpl(parallel_args,
-                    device,
-                    options,
-                    eagle3_main_options(options),
-                    eagle3_draft_options(options),
-                    ::xllm::SpeculativeConfig::get_instance()
-                        .enable_opt_validate_probs()) {
-  // EAGLE-3 drives the draft from the target's captured intermediate-layer
-  // aux hidden states. Context parallelism only exposes the lm_head-gathered
-  // final hidden (see llm_worker_impl.cpp), not the aux hidden, so the draft
-  // would silently receive the wrong tensor. Reject cp_size > 1 until
-  // aux-hidden plumbing under CP is implemented.
+    : MTPWorkerImpl(
+          parallel_args,
+          device,
+          options,
+          eagle3_main_options(options),
+          eagle3_draft_options(options),
+          ::xllm::SpeculativeConfig::get_instance().enable_opt_validate_probs(),
+          /*enable_adaptive_speculative_decode=*/false) {
   CHECK_LE(parallel_args.cp_size(), 1)
       << "EAGLE-3 speculative decoding does not support context parallelism "
          "(cp_size > 1).";

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -1575,8 +1575,6 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_adaptive_validate(
     const std::vector<ForwardOutput>& draft_outputs,
     ForwardInput& validate_input,
     int32_t num_speculative_tokens) {
-  const double target_step_time_ms =
-      adaptive_step_time_estimate(input, num_speculative_tokens);
   const int32_t batch_size = input.input_params.meta.num_sequences;
   std::vector<double> per_seq_kv_lens(static_cast<size_t>(batch_size), 0.0);
   const Slice<int32_t> kv_seq_lens =
@@ -1598,7 +1596,6 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_adaptive_validate(
     prefix_lengths = adaptive_spec_controller_->select_pruned_prefix_lengths(
         selected_probs_by_step(draft_outputs),
         /*full_draft_time_ms=*/0.0,
-        target_step_time_ms,
         per_seq_kv_lens);
   } else {
     prefix_lengths.assign(static_cast<size_t>(batch_size),
@@ -2191,47 +2188,6 @@ void MTPWorkerImpl::record_validate_metrics(
 bool MTPWorkerImpl::adaptive_enabled() const {
   return adaptive_spec_controller_ != nullptr &&
          adaptive_spec_controller_->enabled();
-}
-
-double MTPWorkerImpl::adaptive_step_time_estimate(
-    const ForwardInput& input,
-    int32_t max_speculative_tokens) const {
-  const int32_t batch_size = input.input_params.meta.num_sequences;
-  const Slice<int32_t> kv_seq_lens =
-      input.input_params.attention.host.kv_seq_lens;
-  if (batch_size <= 0 || max_speculative_tokens <= 0) {
-    return 1.0;
-  }
-#if defined(USE_NPU)
-  const size_t min_kv_seq_lens_size = static_cast<size_t>(batch_size);
-#else
-  const size_t min_kv_seq_lens_size = static_cast<size_t>(batch_size) + 1;
-#endif
-  if (kv_seq_lens.size() < min_kv_seq_lens_size) {
-    return 1.0;
-  }
-
-  double total_prefix_len = 0.0;
-  for (int32_t seq_id = 0; seq_id < batch_size; ++seq_id) {
-    total_prefix_len += static_cast<double>(
-        specBuilder::calc_kv_len(kv_seq_lens, seq_id, /*offset=*/0));
-  }
-  const double avg_prefix_len =
-      total_prefix_len / static_cast<double>(batch_size);
-
-  SpeculativeProfileRegistry& registry =
-      SpeculativeProfileRegistry::get_instance();
-  if (!registry.has_validate_time_predictor()) {
-    return 1.0;
-  }
-
-  const double max_speculative_target_time = registry.predict_validate_time_ms(
-      batch_size, max_speculative_tokens + 1, avg_prefix_len);
-  if (max_speculative_target_time <= 0.0 ||
-      !std::isfinite(max_speculative_target_time)) {
-    return 1.0;
-  }
-  return max_speculative_target_time;
 }
 
 void MTPWorkerImpl::process_draft_sample_output(SampleOutput& sample_output) {

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -59,6 +59,20 @@ constexpr uint64_t MBUF_SIZE = 128 * 1024 * 1024;
 
 namespace {
 
+// Qwen3.5 GDN conv_state history capacity (kernel_conv_size - 1). Values of
+// num_accepted_tokens beyond this describe history that has already rolled
+// out of conv_state; passing them to aclnnCausalConv1d makes tiling fail when
+// the current step's per_seq_val_tokens is small (e.g. adaptive prunes down
+// to 2 while nat=5). Callers clamp accepted-prefix lengths to this cap before
+// invoking the GDN spec-verify path.
+constexpr int32_t kGdnConvHistoryCap = 3;
+
+void clamp_gdn_conv_history(std::vector<int32_t>& accepted_prefix_lengths) {
+  for (int32_t& v : accepted_prefix_lengths) {
+    v = std::min(v, kGdnConvHistoryCap);
+  }
+}
+
 void broadcast_tokens_in_group(torch::Tensor& tokens,
                                ProcessGroup* process_group,
                                int32_t root_rank = 0) {
@@ -707,6 +721,16 @@ int64_t MTPWorkerImpl::get_embedding_placeholder_size() {
 }
 
 bool MTPWorkerImpl::supports_explicit_spec_verify_replay_update() const {
+  return target_spec_verify_mode_ ==
+         mtp_async::TargetSpecVerifyMode::QWEN3_5_EXPANDED_VERIFY;
+}
+
+bool MTPWorkerImpl::requires_uniform_validate_width() const {
+  // Currently only Qwen3.5's GDN spec-verify kernel requires uniform width;
+  // this happens to coincide with the QWEN3_5_EXPANDED_VERIFY mode used by
+  // supports_explicit_spec_verify_replay_update, but the two are semantically
+  // distinct capabilities (graph-update capability vs. per-seq varlen kernel
+  // support).
   return target_spec_verify_mode_ ==
          mtp_async::TargetSpecVerifyMode::QWEN3_5_EXPANDED_VERIFY;
 }
@@ -1420,26 +1444,6 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
 void MTPWorkerImpl::fill_validate_input_from_draft_outputs(
     const std::vector<ForwardOutput>& draft_outputs,
     ForwardInput& validate_input,
-    int32_t num_speculative_tokens,
-    Stream& compute_stream) {
-  const int32_t num_val_tokens = num_speculative_tokens + 1;
-  CHECK(validate_input.token_ids.defined())
-      << "validate token_ids must be prepared before draft token fill";
-  CHECK_EQ(validate_input.token_ids.dim(), 1)
-      << "validate token_ids must be flat";
-  CHECK_EQ(validate_input.token_ids.numel() % num_val_tokens, 0)
-      << "validate token_ids size must be divisible by validation width";
-  const int32_t num_sequences =
-      static_cast<int32_t>(validate_input.token_ids.numel() / num_val_tokens);
-  std::vector<int32_t> per_seq_val_tokens(static_cast<size_t>(num_sequences),
-                                          num_val_tokens);
-  fill_validate_input_from_draft_outputs(
-      draft_outputs, validate_input, per_seq_val_tokens, compute_stream);
-}
-
-void MTPWorkerImpl::fill_validate_input_from_draft_outputs(
-    const std::vector<ForwardOutput>& draft_outputs,
-    ForwardInput& validate_input,
     const std::vector<int32_t>& per_seq_val_tokens,
     Stream& compute_stream) {
   CHECK(!per_seq_val_tokens.empty()) << "per_seq_val_tokens must not be empty";
@@ -1622,7 +1626,6 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_adaptive_validate(
     std::vector<int32_t> nat = embedding_cache_->read_accepted_prefix_lengths(
         input.input_params.embedding.embedding_ids,
         input.input_params.embedding.request_ids);
-    constexpr int32_t kGdnConvHistoryCap = 3;
     int32_t max_nat = 0;
     for (int32_t v : nat) {
       max_nat = std::max(max_nat, std::min(v, kGdnConvHistoryCap));
@@ -1640,8 +1643,7 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_adaptive_validate(
   // when the controller decides to shrink), but every seq gets the same
   // validate width. On non-Qwen3.5 models we keep per-seq variable-length
   // tokens for maximum pruning benefit.
-  const bool require_uniform_val_tokens =
-      supports_explicit_spec_verify_replay_update();
+  const bool require_uniform_val_tokens = requires_uniform_validate_width();
   const int32_t uniform_val_tokens = effective_speculative_tokens + 1;
   for (int32_t i = 0; i < batch_size; ++i) {
     per_seq_val_tokens[static_cast<size_t>(i)] =
@@ -1788,8 +1790,6 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
                           num_speculative_tokens,
                           pruned_prefix_lengths);
   }
-  record_validate_metrics(
-      val_output, num_speculative_tokens, pruned_prefix_lengths);
   COUNTER_ADD(speculative_execution_latency_seconds_validation,
               timer.elapsed_seconds());
 
@@ -1806,6 +1806,11 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
     CHECK_EQ(ret, 0) << "failed to synchronize MTP compute stream, ret=" << ret;
     release_retained_inputs(target_output);
     val_output.next_tokens = val_output.next_tokens.to(torch::kCPU);
+    // Record adaptive-prune-aware draft/accept counts on the already-CPU
+    // next_tokens. Static path lets worker_service count on the async-handoff
+    // CPU tensor with no extra device sync.
+    record_validate_metrics(
+        val_output, num_speculative_tokens, pruned_prefix_lengths);
     write_target_context_to_cache(input, val_output, num_speculative_tokens);
 
     if (!enable_schedule_overlap() && !driver_ && !dp_driver_) {
@@ -2151,9 +2156,11 @@ void MTPWorkerImpl::record_validate_metrics(
   CHECK_EQ(validate_output.next_tokens.size(1), num_speculative_tokens + 1)
       << "validate output width mismatch";
 
-  torch::Tensor next_tokens_cpu = validate_output.next_tokens.to(torch::kCPU)
-                                      .to(torch::kInt64)
-                                      .contiguous();
+  CHECK(validate_output.next_tokens.device().is_cpu())
+      << "record_validate_metrics expects next_tokens already on CPU to avoid "
+         "a blocking device sync on the hot path";
+  torch::Tensor next_tokens_cpu =
+      validate_output.next_tokens.to(torch::kInt64).contiguous();
   const int64_t* token_data = next_tokens_cpu.const_data_ptr<int64_t>();
   int64_t num_draft_tokens = 0;
   int64_t accepted_count = 0;
@@ -2520,10 +2527,7 @@ void MTPWorkerImpl::prepare_validate_inputs(const ForwardInput& input,
     // makes tiling fail when the current step's per_seq_val_tokens is small
     // (e.g. adaptive prunes down to 2 while nat=5).
     if (supports_explicit_spec_verify_replay_update()) {
-      constexpr int32_t kGdnConvHistoryCap = 3;
-      for (int32_t& v : accepted_prefix_lengths) {
-        v = std::min(v, kGdnConvHistoryCap);
-      }
+      clamp_gdn_conv_history(accepted_prefix_lengths);
     }
     input_params.num_accepted_tokens_host.assign(
         accepted_prefix_lengths.begin(), accepted_prefix_lengths.end());
@@ -2855,10 +2859,7 @@ void MTPWorkerImpl::prepare_validate_inputs(
     // makes tiling fail when the current step's per_seq_val_tokens is small
     // (e.g. adaptive prunes down to 2 while nat=5).
     if (supports_explicit_spec_verify_replay_update()) {
-      constexpr int32_t kGdnConvHistoryCap = 3;
-      for (int32_t& v : accepted_prefix_lengths) {
-        v = std::min(v, kGdnConvHistoryCap);
-      }
+      clamp_gdn_conv_history(accepted_prefix_lengths);
     }
     input_params.num_accepted_tokens =
         torch::tensor(accepted_prefix_lengths, token_options);

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -1444,6 +1444,8 @@ void MTPWorkerImpl::fill_validate_input_from_draft_outputs(
     Stream& compute_stream) {
   CHECK(!per_seq_val_tokens.empty()) << "per_seq_val_tokens must not be empty";
   const int32_t num_sequences = static_cast<int32_t>(per_seq_val_tokens.size());
+  const int32_t max_val_tokens =
+      *std::max_element(per_seq_val_tokens.begin(), per_seq_val_tokens.end());
   CHECK(validate_input.token_ids.defined())
       << "validate token_ids must be prepared before draft token fill";
   CHECK_EQ(validate_input.token_ids.dim(), 1)
@@ -1463,7 +1465,7 @@ void MTPWorkerImpl::fill_validate_input_from_draft_outputs(
       validate_input.input_params.graph.input_tokens_override.defined() &&
       supports_explicit_spec_verify_replay_update() &&
       kernel::npu::tilelang::has_spec_verify_graph_update_specialization(
-          num_val_tokens, options_.block_size());
+          max_val_tokens, options_.block_size());
   if (use_fused_verify_token_update) {
     fused_draft_tokens.reserve(draft_outputs.size());
     for (const ForwardOutput& draft_output : draft_outputs) {
@@ -1481,8 +1483,6 @@ void MTPWorkerImpl::fill_validate_input_from_draft_outputs(
   }
 #endif
 
-  const int32_t max_val_tokens =
-      *std::max_element(per_seq_val_tokens.begin(), per_seq_val_tokens.end());
   const int32_t total_val_tokens =
       static_cast<int32_t>(validate_input.token_ids.numel());
   const bool is_uniform = (total_val_tokens == num_sequences * max_val_tokens);
@@ -1508,8 +1508,9 @@ void MTPWorkerImpl::fill_validate_input_from_draft_outputs(
     // Slow path: per-seq variable-length, group by draft step.
     std::vector<int64_t> dst_idx_vec;
     std::vector<int64_t> src_idx_vec;
-    std::vector<int32_t> step_vec;
+    std::vector<int64_t> step_vec;
     int32_t offset = 0;
+    int32_t max_draft_step = -1;
     for (int32_t seq_id = 0; seq_id < num_sequences; ++seq_id) {
       const int32_t seq_val_tokens =
           per_seq_val_tokens[static_cast<size_t>(seq_id)];
@@ -1518,13 +1519,32 @@ void MTPWorkerImpl::fill_validate_input_from_draft_outputs(
         dst_idx_vec.push_back(offset + draft_idx + 1);
         src_idx_vec.push_back(seq_id);
         step_vec.push_back(draft_idx);
+        max_draft_step = std::max(max_draft_step, draft_idx);
       }
       offset += seq_val_tokens;
     }
 
     if (!dst_idx_vec.empty()) {
-      const int32_t max_draft_step =
-          *std::max_element(step_vec.begin(), step_vec.end());
+      // Move all indices to device once (instead of a per-step H2D copy) and
+      // select each step's entries on-device via a boolean mask.
+      const torch::TensorOptions long_dev_opts =
+          torch::TensorOptions()
+              .dtype(torch::kLong)
+              .device(validate_input.token_ids.device());
+      torch::Tensor dst_idx_all =
+          safe_to(torch::tensor(dst_idx_vec,
+                                torch::TensorOptions().dtype(torch::kLong)),
+                  long_dev_opts,
+                  /*non_blocking=*/true);
+      torch::Tensor src_idx_all =
+          safe_to(torch::tensor(src_idx_vec,
+                                torch::TensorOptions().dtype(torch::kLong)),
+                  long_dev_opts,
+                  /*non_blocking=*/true);
+      torch::Tensor step_all = safe_to(
+          torch::tensor(step_vec, torch::TensorOptions().dtype(torch::kLong)),
+          long_dev_opts,
+          /*non_blocking=*/true);
       for (int32_t step = 0; step <= max_draft_step; ++step) {
         CHECK(static_cast<size_t>(step) < draft_outputs.size())
             << "draft_outputs index out of range for step " << step;
@@ -1535,29 +1555,14 @@ void MTPWorkerImpl::fill_validate_input_from_draft_outputs(
         torch::Tensor flat_tokens = safe_to(
             next_tokens.flatten(), token_options, /*non_blocking=*/true);
 
-        std::vector<int64_t> step_dst_indices;
-        std::vector<int64_t> step_src_indices;
-        for (size_t k = 0; k < step_vec.size(); ++k) {
-          if (step_vec[k] == step) {
-            step_dst_indices.push_back(dst_idx_vec[k]);
-            step_src_indices.push_back(src_idx_vec[k]);
-          }
-        }
-        if (step_dst_indices.empty()) {
+        torch::Tensor step_mask = step_all.eq(step);
+        torch::Tensor step_dst = dst_idx_all.masked_select(step_mask);
+        if (step_dst.numel() == 0) {
           continue;
         }
-        torch::Tensor dst_idx =
-            torch::tensor(step_dst_indices,
-                          torch::TensorOptions()
-                              .dtype(torch::kLong)
-                              .device(validate_input.token_ids.device()));
-        torch::Tensor src_idx =
-            torch::tensor(step_src_indices,
-                          torch::TensorOptions()
-                              .dtype(torch::kLong)
-                              .device(flat_tokens.device()));
-        torch::Tensor gathered = flat_tokens.index_select(/*dim=*/0, src_idx);
-        validate_input.token_ids.index_copy_(/*dim=*/0, dst_idx, gathered);
+        torch::Tensor step_src = src_idx_all.masked_select(step_mask);
+        torch::Tensor gathered = flat_tokens.index_select(/*dim=*/0, step_src);
+        validate_input.token_ids.index_copy_(/*dim=*/0, step_dst, gathered);
       }
     }
   }
@@ -1588,7 +1593,8 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_adaptive_validate(
   // The per-rank measured draft latency is NOT deterministic, so pruning is
   // driven purely by validate-time marginal cost (full_draft_time_ms = 0).
   std::vector<int32_t> prefix_lengths;
-  if (has_selected_probs_by_step(draft_outputs)) {
+  const bool has_probs = has_selected_probs_by_step(draft_outputs);
+  if (has_probs) {
     prefix_lengths = adaptive_spec_controller_->select_pruned_prefix_lengths(
         selected_probs_by_step(draft_outputs),
         /*full_draft_time_ms=*/0.0,
@@ -1605,20 +1611,65 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_adaptive_validate(
     effective_speculative_tokens = 1;
   }
 
+  // The Qwen3.5 GDN CausalConv1d kernel produces aivec errors when the
+  // per-seq validate segment length is smaller than num_accepted_tokens
+  // (the previous step's accepted count). The tiling validation would
+  // reject nat > lenI, but the underlying kernel itself is fragile at
+  // those boundaries. Floor effective_speculative_tokens by the batch's
+  // max num_accepted so uniform_val_tokens >= max(nat) + 1. Read from
+  // embedding_cache directly since input.num_accepted_tokens_host is
+  // populated by prepare_validate_inputs which hasn't run yet here.
+  if (supports_explicit_spec_verify_replay_update() &&
+      embedding_cache_ != nullptr &&
+      !input.input_params.embedding.embedding_ids.empty()) {
+    std::vector<int32_t> nat = embedding_cache_->read_accepted_prefix_lengths(
+        input.input_params.embedding.embedding_ids,
+        input.input_params.embedding.request_ids);
+    constexpr int32_t kGdnConvHistoryCap = 3;
+    int32_t max_nat = 0;
+    for (int32_t v : nat) {
+      max_nat = std::max(max_nat, std::min(v, kGdnConvHistoryCap));
+    }
+    effective_speculative_tokens =
+        std::max(effective_speculative_tokens, max_nat);
+    effective_speculative_tokens =
+        std::min(effective_speculative_tokens, num_speculative_tokens);
+  }
+
   std::vector<int32_t> per_seq_val_tokens(static_cast<size_t>(batch_size));
+  // Qwen3.5 GatedDeltaNet spec-verify path requires dense same-length validate
+  // tokens across sequences (see qwen3_gated_delta_net_base.cpp:405-408). On
+  // Qwen3.5 we still take the batch-max pruning benefit (effective_sl < max_sl
+  // when the controller decides to shrink), but every seq gets the same
+  // validate width. On non-Qwen3.5 models we keep per-seq variable-length
+  // tokens for maximum pruning benefit.
+  const bool require_uniform_val_tokens =
+      supports_explicit_spec_verify_replay_update();
+  const int32_t uniform_val_tokens = effective_speculative_tokens + 1;
   for (int32_t i = 0; i < batch_size; ++i) {
     per_seq_val_tokens[static_cast<size_t>(i)] =
-        std::max(prefix_lengths[static_cast<size_t>(i)], 1) + 1;
+        require_uniform_val_tokens
+            ? uniform_val_tokens
+            : std::max(prefix_lengths[static_cast<size_t>(i)], 1) + 1;
   }
   std::vector<ForwardOutput> pruned_draft_outputs =
       truncate_draft_outputs(draft_outputs, effective_speculative_tokens);
+  // If the controller did not actually prune any sequence, treat this as the
+  // static path: pass nullptr so run_validate takes the async handoff tail
+  // and skips the no-op pruned post-processing.
+  const bool has_actual_prune =
+      std::any_of(prefix_lengths.begin(),
+                  prefix_lengths.end(),
+                  [num_speculative_tokens](int32_t p) {
+                    return p < num_speculative_tokens;
+                  });
   prepare_validate_inputs(input, validate_input, per_seq_val_tokens);
   return run_validate(input,
                       pruned_draft_outputs,
                       validate_input,
                       effective_speculative_tokens,
                       per_seq_val_tokens,
-                      &prefix_lengths);
+                      has_actual_prune ? &prefix_lengths : nullptr);
 }
 
 std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
@@ -1751,8 +1802,7 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
     // Use the synchronous tail: unify tokens, then write target context inline.
     if (get_optimization_config().enable_spec_token_broadcast) {
       c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
-      broadcast_spec_tokens(val_output.next_tokens,
-                            spec_broadcast_group(parallel_args_));
+      broadcast_spec_tokens(val_output.next_tokens, parallel_args_);
     }
 
     const int32_t ret = compute_stream_->synchronize();
@@ -2328,7 +2378,7 @@ void MTPWorkerImpl::prepare_validate_inputs(const ForwardInput& input,
   torch::TensorOptions position_options = validate_input.positions.options();
 
   const int32_t num_sequences = input_params.meta.num_sequences;
-  const int32_t num_val_tokens = num_speculative_tokens + 1;
+  const int32_t num_val_tokens = options_.num_speculative_tokens() + 1;
   const int32_t total_num_val_tokens = num_sequences * num_val_tokens;
   const int32_t block_size = options_.block_size();
 #if defined(USE_NPU)
@@ -2385,7 +2435,8 @@ void MTPWorkerImpl::prepare_validate_inputs(const ForwardInput& input,
     }
 
     if (use_atb_spec_kernel) {
-      const int32_t kv_len_after_validation = kv_len + num_speculative_tokens;
+      const int32_t kv_len_after_validation =
+          kv_len + options_.num_speculative_tokens();
       specBuilder::update_kv_seq_lens_and_max(
           atb_kv_seq_lens_vec, kv_len_after_validation, atb_kv_max_seq_len);
       specBuilder::append_q_seq_len(
@@ -2506,6 +2557,17 @@ void MTPWorkerImpl::prepare_validate_inputs(const ForwardInput& input,
       accepted_prefix_lengths = embedding_cache_->read_accepted_prefix_lengths(
           input.input_params.embedding.embedding_ids,
           input.input_params.embedding.request_ids);
+    }
+    // Clamp num_accepted_tokens to Qwen3.5 GDN conv_state history capacity
+    // (kernel_conv_size - 1 = 3). Larger values describe history that has
+    // already rolled out of conv_state; passing them to aclnnCausalConv1d
+    // makes tiling fail when the current step's per_seq_val_tokens is small
+    // (e.g. adaptive prunes down to 2 while nat=5).
+    if (supports_explicit_spec_verify_replay_update()) {
+      constexpr int32_t kGdnConvHistoryCap = 3;
+      for (int32_t& v : accepted_prefix_lengths) {
+        v = std::min(v, kGdnConvHistoryCap);
+      }
     }
     input_params.num_accepted_tokens_host.assign(
         accepted_prefix_lengths.begin(), accepted_prefix_lengths.end());
@@ -2812,7 +2874,48 @@ void MTPWorkerImpl::prepare_validate_inputs(
     token_num = total_num_val_tokens;
   }
 
+  if (use_chunked_prefill_spec_verify_path()) {
+    input_params.embedding.input_embedding = torch::Tensor();
+    input_params.is_spec_verify = true;
+    if (!input_params.attention.host.q_seq_lens.empty()) {
+      std::vector<int32_t> q_cu_seq_lens_vec;
+      q_cu_seq_lens_vec.reserve(num_sequences + 1);
+      q_cu_seq_lens_vec.emplace_back(0);
+      for (int32_t q_len : input_params.attention.host.q_seq_lens) {
+        q_cu_seq_lens_vec.emplace_back(q_cu_seq_lens_vec.back() + q_len);
+      }
+      input_params.attention.host.q_cu_seq_lens = std::move(q_cu_seq_lens_vec);
+    }
+    std::vector<int32_t> accepted_prefix_lengths(num_sequences, 1);
+    if (embedding_cache_ != nullptr &&
+        !input.input_params.embedding.embedding_ids.empty()) {
+      accepted_prefix_lengths = embedding_cache_->read_accepted_prefix_lengths(
+          input.input_params.embedding.embedding_ids,
+          input.input_params.embedding.request_ids);
+    }
+    // Clamp num_accepted_tokens to Qwen3.5 GDN conv_state history capacity
+    // (kernel_conv_size - 1 = 3). Larger values describe history that has
+    // already rolled out of conv_state; passing them to aclnnCausalConv1d
+    // makes tiling fail when the current step's per_seq_val_tokens is small
+    // (e.g. adaptive prunes down to 2 while nat=5).
+    if (supports_explicit_spec_verify_replay_update()) {
+      constexpr int32_t kGdnConvHistoryCap = 3;
+      for (int32_t& v : accepted_prefix_lengths) {
+        v = std::min(v, kGdnConvHistoryCap);
+      }
+    }
+    input_params.num_accepted_tokens =
+        torch::tensor(accepted_prefix_lengths, token_options);
+    input_params.num_accepted_tokens_host.assign(
+        accepted_prefix_lengths.begin(), accepted_prefix_lengths.end());
+  }
+
   input_params.attention.rebuild_device_buffer(device_);
+#if defined(USE_NPU)
+  if (supports_explicit_spec_verify_replay_update()) {
+    build_expanded_spec_verify_graph_input(input_params, device_);
+  }
+#endif
   validate_input.device_tensors_ready = true;
   finish_metadata_prepare(*prepare_stream_, validate_input);
 }
@@ -2830,8 +2933,14 @@ void MTPWorkerImpl::prepare_draft_extend_inputs(
     prepare_stream_->wait_stream(*compute_stream_);
   }
   extend_input = base_input;
+  // Adaptive pruning needs draft selected-probs; force return_probs on so the
+  // sampler's greedy fast-path doesn't skip probs assignment. Skip Qwen3.5:
+  // its SSM (CausalConv1d) path fails when return_probs changes sampler
+  // routing; on Qwen3.5 the controller falls back to computing probs from
+  // logits (see adaptive_pruning_helpers.cpp).
   extend_input.sampling_params.return_probs =
-      !extend_input.sampling_params.all_greedy_sample;
+      !extend_input.sampling_params.all_greedy_sample ||
+      (adaptive_enabled() && !supports_explicit_spec_verify_replay_update());
   clear_ready_events(extend_input);
   extend_input.device_tensors_ready = false;
   auto& input_params = extend_input.input_params;
@@ -3068,8 +3177,14 @@ void MTPWorkerImpl::prepare_draft_inputs(const ForwardInput& input,
                                          int32_t position_offset) {
   c10::StreamGuard stream_guard = prepare_stream_->set_stream_guard();
   draft_input = input;
+  // Adaptive pruning needs draft selected-probs; force return_probs on so the
+  // sampler's greedy fast-path doesn't skip probs assignment. Skip Qwen3.5:
+  // its SSM (CausalConv1d) path fails when return_probs changes sampler
+  // routing; on Qwen3.5 the controller falls back to computing probs from
+  // logits (see adaptive_pruning_helpers.cpp).
   draft_input.sampling_params.return_probs =
-      !draft_input.sampling_params.all_greedy_sample;
+      !draft_input.sampling_params.all_greedy_sample ||
+      (adaptive_enabled() && !supports_explicit_spec_verify_replay_update());
   clear_ready_events(draft_input);
   draft_input.device_tensors_ready = false;
 
@@ -3184,11 +3299,8 @@ SampleOutput MTPWorkerImpl::validate(
           .index({"...", ISlice(num_val_tokens - 1, None, num_val_tokens)})
           .view({-1, 1});
 
-  // Greedy fast-path: skip full rejection sampling when all sequences are
-  // greedy and no logprobs needed. Disabled when adaptive pruning is active
-  // since pruning requires the full rejection sampling output format.
-  if (sampling_params.all_greedy_sample && !target_output.logprobs &&
-      pruned_prefix_lengths == nullptr) {
+  SampleOutput sample_output;
+  if (sampling_params.all_greedy_sample && !target_output.logprobs) {
     torch::Tensor target_token_ids =
         target_output.sample_output.next_tokens.view(
             {batch_size, num_val_tokens});
@@ -3202,39 +3314,38 @@ SampleOutput MTPWorkerImpl::validate(
             /*mask_out_rejected_tokens=*/true);
     (void)accepted_token_ids;
 
-    SampleOutput sample_output;
     sample_output.next_tokens = masked_accepted_token_ids;
     torch::Tensor embeddings = target_output.sample_output.embeddings;
     sample_output.embeddings =
         embeddings.view({batch_size, num_val_tokens, embeddings.size(-1)});
-    return sample_output;
+  } else {
+    torch::Tensor target_logits =
+        target_output.logits.view({batch_size, num_val_tokens, vocab_size});
+
+    // prepare input for rejection sampling
+    std::unique_ptr<RejectionSampler> rejection_sampler =
+        std::make_unique<RejectionSampler>(sampling_params.do_sample,
+                                           sampling_params.all_random_sample,
+                                           sampling_params.all_greedy_sample,
+                                           target_output.logprobs,
+                                           target_output.max_top_logprobs,
+                                           enable_fused_kernel_);
+
+    // get the accepted tokens
+    sample_output = rejection_sampler->forward(
+        draft_token_ids.to(bonus_token_ids),
+        draft_probs.defined() ? draft_probs.to(target_logits.device())
+                              : torch::Tensor(),
+        target_logits,
+        bonus_token_ids,
+        /*mask_out_rejected_tokens=*/true);
+
+    // process embedding
+    torch::Tensor embeddings = target_output.sample_output.embeddings;
+    sample_output.embeddings =
+        embeddings.view({batch_size, num_val_tokens, embeddings.size(-1)});
   }
 
-  torch::Tensor target_logits =
-      target_output.logits.view({batch_size, num_val_tokens, vocab_size});
-
-  // prepare input for rejection sampling
-  std::unique_ptr<RejectionSampler> rejection_sampler =
-      std::make_unique<RejectionSampler>(sampling_params.do_sample,
-                                         sampling_params.all_random_sample,
-                                         sampling_params.all_greedy_sample,
-                                         target_output.logprobs,
-                                         target_output.max_top_logprobs,
-                                         enable_fused_kernel_);
-
-  // get the accepted tokens
-  SampleOutput sample_output = rejection_sampler->forward(
-      draft_token_ids.to(bonus_token_ids),
-      draft_probs.defined() ? draft_probs.to(target_logits.device())
-                            : torch::Tensor(),
-      target_logits,
-      bonus_token_ids,
-      /*mask_out_rejected_tokens=*/true);
-
-  // process embedding
-  torch::Tensor embeddings = target_output.sample_output.embeddings;
-  sample_output.embeddings =
-      embeddings.view({batch_size, num_val_tokens, embeddings.size(-1)});
   if (pruned_prefix_lengths != nullptr) {
     sync_pruned_boundary_outputs(sample_output,
                                  target_output,

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -16,8 +16,15 @@ limitations under the License.
 #include "mtp_worker_impl.h"
 
 #include <glog/logging.h>
+#if defined(USE_NPU)
+#include <acl/acl.h>
+#include <torch_npu/csrc/core/npu/NPUStream.h>
+#endif
 
 #include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstdint>
 #include <exception>
 #include <memory>
 
@@ -36,6 +43,8 @@ limitations under the License.
 #if defined(USE_NPU)
 #include "core/kernels/npu/tilelang/tilelang_ops_api.h"
 #endif
+#include "core/framework/speculative/adaptive_pruning_helpers.h"
+#include "core/framework/speculative/speculative_profile_registry.h"
 #include "core/layers/common/dsa_topk_share_plan.h"
 #include "core/runtime/mtp_async_input_builder.h"
 #include "core/runtime/mtp_async_state.h"
@@ -535,29 +544,51 @@ bool is_qwen3_5_draft_model_type(const std::string& model_type) {
 
 }  // namespace
 
+using adaptive_pruning::apply_pruned_prefix_lengths;
+using adaptive_pruning::clamp_prefix_lengths;
+using adaptive_pruning::has_selected_probs_by_step;
+using adaptive_pruning::max_pruned_prefix_length;
+using adaptive_pruning::selected_probs_by_step;
+using adaptive_pruning::sync_pruned_boundary_outputs;
+using adaptive_pruning::truncate_draft_outputs;
+
 MTPWorkerImpl::MTPWorkerImpl(const ParallelArgs& parallel_args,
                              const torch::Device& device,
                              const runtime::Options& options)
-    : MTPWorkerImpl(parallel_args,
-                    device,
-                    options,
-                    MTPTargetOptions(options),
-                    mtp_draft_options(options),
-                    ::xllm::SpeculativeConfig::get_instance()
-                        .enable_opt_validate_probs()) {}
+    : MTPWorkerImpl(
+          parallel_args,
+          device,
+          options,
+          MTPTargetOptions(options),
+          mtp_draft_options(options),
+          ::xllm::SpeculativeConfig::get_instance().enable_opt_validate_probs(),
+          /*enable_adaptive_speculative_decode=*/true) {}
 
 MTPWorkerImpl::MTPWorkerImpl(const ParallelArgs& parallel_args,
                              const torch::Device& device,
                              const runtime::Options& options,
                              const runtime::Options& target_options,
                              const runtime::Options& draft_options,
-                             bool enable_opt_validate_probs)
+                             bool enable_opt_validate_probs,
+                             bool enable_adaptive_speculative_decode)
     : SpeculativeWorkerImpl(parallel_args, device, options, target_options),
       enable_opt_validate_probs_(enable_opt_validate_probs) {
   draft_impl_ = std::make_unique<LLMWorkerImpl>(
       MTPDraftParallelArgs(parallel_args, options),
       device,
       mtp_draft_options(draft_options));
+  const bool enable_parallel_adaptive_sl =
+      parallel_args.dp_size() <= 1 && parallel_args.ep_size() <= 1;
+  if (enable_adaptive_speculative_decode && enable_parallel_adaptive_sl) {
+    adaptive_spec_controller_ =
+        std::make_unique<AdaptiveSpeculativeController>(options);
+  } else if (enable_adaptive_speculative_decode &&
+             options.enable_adaptive_speculative_decode()) {
+    LOG(WARNING)
+        << "Adaptive speculative decode is disabled for DP/EP parallelism "
+        << "in v1. dp_size=" << parallel_args.dp_size()
+        << ", ep_size=" << parallel_args.ep_size();
+  }
 }
 
 bool MTPWorkerImpl::init_model(const std::string& model_weights_path,
@@ -1140,6 +1171,12 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
       device_context_ready_request_ids_.clear();
     }
   }
+  // Adaptive is enabled only after profile completes (registry has predictor),
+  // ensuring profiling warmup never triggers the adaptive HCCL broadcast.
+  const bool use_adaptive_speculative_decode =
+      adaptive_spec_controller_ != nullptr &&
+      adaptive_spec_controller_->enabled() && adaptive_enabled() &&
+      SpeculativeProfileRegistry::get_instance().has_validate_time_predictor();
 
   std::vector<ForwardOutput> draft_outputs;
   ForwardInput current_draft_input, validate_input, next_step_input;
@@ -1265,10 +1302,12 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
     metadata_template = input;
     prepare_draft_extend_inputs(input, last_states, current_draft_input);
   }
+
   draft_outputs.reserve(num_speculative_tokens);
   const bool reuse_mtp_topk_state = layer::is_mtp_dsa_topk_reuse_enabled(
       draft_impl_->context_.get_model_args());
   MtpTopkStatePtr mtp_topk_state;
+  timer.reset();
   for (int32_t draft_idx = 0; draft_idx < num_speculative_tokens; ++draft_idx) {
     const bool is_final_draft = draft_idx == num_speculative_tokens - 1;
     const bool static_graph_tasks_prepared =
@@ -1365,33 +1404,54 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
       // ordering replaces the same-stream EventRecord/EventWait pair.
     }
   }
+  const double draft_latency_ms = timer.elapsed_milliseconds();
   COUNTER_ADD(speculative_execution_latency_seconds_draft,
-              timer.elapsed_seconds());
-  return run_validate(input, draft_outputs, validate_input);
+              draft_latency_ms / 1000.0);
+
+  if (use_adaptive_speculative_decode) {
+    return run_adaptive_validate(
+        input, draft_outputs, validate_input, num_speculative_tokens);
+  }
+
+  return run_validate(
+      input, draft_outputs, validate_input, num_speculative_tokens);
 }
 
 void MTPWorkerImpl::fill_validate_input_from_draft_outputs(
     const std::vector<ForwardOutput>& draft_outputs,
     ForwardInput& validate_input,
+    int32_t num_speculative_tokens,
     Stream& compute_stream) {
-  const int32_t num_speculative_tokens = options_.num_speculative_tokens();
   const int32_t num_val_tokens = num_speculative_tokens + 1;
-  CHECK_EQ(draft_outputs.size(), static_cast<size_t>(num_speculative_tokens))
-      << "draft output count mismatch";
   CHECK(validate_input.token_ids.defined())
       << "validate token_ids must be prepared before draft token fill";
   CHECK_EQ(validate_input.token_ids.dim(), 1)
       << "validate token_ids must be flat";
   CHECK_EQ(validate_input.token_ids.numel() % num_val_tokens, 0)
       << "validate token_ids size must be divisible by validation width";
+  const int32_t num_sequences =
+      static_cast<int32_t>(validate_input.token_ids.numel() / num_val_tokens);
+  std::vector<int32_t> per_seq_val_tokens(static_cast<size_t>(num_sequences),
+                                          num_val_tokens);
+  fill_validate_input_from_draft_outputs(
+      draft_outputs, validate_input, per_seq_val_tokens, compute_stream);
+}
 
-  const int64_t total_num_val_tokens = validate_input.token_ids.numel();
-  const int64_t num_sequences = total_num_val_tokens / num_val_tokens;
-  const auto token_options = validate_input.token_ids.options();
+void MTPWorkerImpl::fill_validate_input_from_draft_outputs(
+    const std::vector<ForwardOutput>& draft_outputs,
+    ForwardInput& validate_input,
+    const std::vector<int32_t>& per_seq_val_tokens,
+    Stream& compute_stream) {
+  CHECK(!per_seq_val_tokens.empty()) << "per_seq_val_tokens must not be empty";
+  const int32_t num_sequences = static_cast<int32_t>(per_seq_val_tokens.size());
+  CHECK(validate_input.token_ids.defined())
+      << "validate token_ids must be prepared before draft token fill";
+  CHECK_EQ(validate_input.token_ids.dim(), 1)
+      << "validate token_ids must be flat";
+
+  const torch::TensorOptions token_options = validate_input.token_ids.options();
   c10::StreamGuard stream_guard = compute_stream.set_stream_guard();
   wait_metadata_ready_event(validate_input, compute_stream);
-  torch::Tensor validate_token_rows =
-      validate_input.token_ids.view({num_sequences, num_val_tokens});
 
   validate_input.device_tensors_ready = false;
   auto& fused_draft_tokens =
@@ -1420,47 +1480,245 @@ void MTPWorkerImpl::fill_validate_input_from_draft_outputs(
     return;
   }
 #endif
-  std::vector<torch::Tensor> draft_token_columns;
-  draft_token_columns.reserve(num_speculative_tokens);
-  for (int32_t i = 0; i < num_speculative_tokens; ++i) {
-    const torch::Tensor& next_tokens =
-        draft_outputs[i].sample_output.next_tokens;
-    CHECK(next_tokens.defined())
-        << "draft next_tokens must be defined for validate token fill";
-    torch::Tensor draft_tokens =
-        safe_to(next_tokens.flatten(), token_options, /*non_blocking=*/true);
-    CHECK_EQ(draft_tokens.numel(), num_sequences)
-        << "draft token count must match validate sequence count";
-    draft_token_columns.emplace_back(std::move(draft_tokens));
+
+  const int32_t max_val_tokens =
+      *std::max_element(per_seq_val_tokens.begin(), per_seq_val_tokens.end());
+  const int32_t total_val_tokens =
+      static_cast<int32_t>(validate_input.token_ids.numel());
+  const bool is_uniform = (total_val_tokens == num_sequences * max_val_tokens);
+
+  if (is_uniform) {
+    // Fast path: all seqs have same val_tokens, use vectorized view+copy.
+    const int32_t num_draft_tokens = max_val_tokens - 1;
+    torch::Tensor validate_token_rows = validate_input.token_ids.view(
+        {static_cast<int64_t>(num_sequences), max_val_tokens});
+    for (int32_t i = 0; i < num_draft_tokens; ++i) {
+      CHECK(static_cast<size_t>(i) < draft_outputs.size())
+          << "draft_outputs index out of range for step " << i;
+      const torch::Tensor& next_tokens =
+          draft_outputs[static_cast<size_t>(i)].sample_output.next_tokens;
+      CHECK(next_tokens.defined())
+          << "draft next_tokens must be defined for validate token fill";
+      torch::Tensor draft_tokens =
+          safe_to(next_tokens.flatten(), token_options, /*non_blocking=*/true);
+      validate_token_rows.select(/*dim=*/1, /*index=*/i + 1)
+          .copy_(draft_tokens, /*non_blocking=*/true);
+    }
+  } else {
+    // Slow path: per-seq variable-length, group by draft step.
+    std::vector<int64_t> dst_idx_vec;
+    std::vector<int64_t> src_idx_vec;
+    std::vector<int32_t> step_vec;
+    int32_t offset = 0;
+    for (int32_t seq_id = 0; seq_id < num_sequences; ++seq_id) {
+      const int32_t seq_val_tokens =
+          per_seq_val_tokens[static_cast<size_t>(seq_id)];
+      const int32_t seq_draft_tokens = seq_val_tokens - 1;
+      for (int32_t draft_idx = 0; draft_idx < seq_draft_tokens; ++draft_idx) {
+        dst_idx_vec.push_back(offset + draft_idx + 1);
+        src_idx_vec.push_back(seq_id);
+        step_vec.push_back(draft_idx);
+      }
+      offset += seq_val_tokens;
+    }
+
+    if (!dst_idx_vec.empty()) {
+      const int32_t max_draft_step =
+          *std::max_element(step_vec.begin(), step_vec.end());
+      for (int32_t step = 0; step <= max_draft_step; ++step) {
+        CHECK(static_cast<size_t>(step) < draft_outputs.size())
+            << "draft_outputs index out of range for step " << step;
+        const torch::Tensor& next_tokens =
+            draft_outputs[static_cast<size_t>(step)].sample_output.next_tokens;
+        CHECK(next_tokens.defined())
+            << "draft next_tokens must be defined for validate token fill";
+        torch::Tensor flat_tokens = safe_to(
+            next_tokens.flatten(), token_options, /*non_blocking=*/true);
+
+        std::vector<int64_t> step_dst_indices;
+        std::vector<int64_t> step_src_indices;
+        for (size_t k = 0; k < step_vec.size(); ++k) {
+          if (step_vec[k] == step) {
+            step_dst_indices.push_back(dst_idx_vec[k]);
+            step_src_indices.push_back(src_idx_vec[k]);
+          }
+        }
+        if (step_dst_indices.empty()) {
+          continue;
+        }
+        torch::Tensor dst_idx =
+            torch::tensor(step_dst_indices,
+                          torch::TensorOptions()
+                              .dtype(torch::kLong)
+                              .device(validate_input.token_ids.device()));
+        torch::Tensor src_idx =
+            torch::tensor(step_src_indices,
+                          torch::TensorOptions()
+                              .dtype(torch::kLong)
+                              .device(flat_tokens.device()));
+        torch::Tensor gathered = flat_tokens.index_select(/*dim=*/0, src_idx);
+        validate_input.token_ids.index_copy_(/*dim=*/0, dst_idx, gathered);
+      }
+    }
   }
-  torch::Tensor packed_draft_tokens =
-      torch::stack(draft_token_columns, /*dim=*/1);
-  validate_token_rows.slice(/*dim=*/1, /*start=*/1, /*end=*/num_val_tokens)
-      .copy_(packed_draft_tokens, /*non_blocking=*/true);
   validate_input.device_tensors_ready = true;
   record_metadata_ready_event(compute_stream, validate_input);
+}
+
+std::optional<ForwardOutput> MTPWorkerImpl::run_adaptive_validate(
+    const ForwardInput& input,
+    const std::vector<ForwardOutput>& draft_outputs,
+    ForwardInput& validate_input,
+    int32_t num_speculative_tokens) {
+  const double target_step_time_ms =
+      adaptive_step_time_estimate(input, num_speculative_tokens);
+  const int32_t batch_size = input.input_params.meta.num_sequences;
+  std::vector<double> per_seq_kv_lens(static_cast<size_t>(batch_size), 0.0);
+  const Slice<int32_t> kv_seq_lens =
+      input.input_params.attention.host.kv_seq_lens;
+  for (int32_t i = 0; i < batch_size; ++i) {
+    if (static_cast<size_t>(i) < kv_seq_lens.size()) {
+      per_seq_kv_lens[static_cast<size_t>(i)] = static_cast<double>(
+          specBuilder::calc_kv_len(kv_seq_lens, i, /*offset=*/0));
+    }
+  }
+
+  // All ranks compute pruning independently. Inputs must be deterministic
+  // across ranks so every rank derives the same effective validate width.
+  // The per-rank measured draft latency is NOT deterministic, so pruning is
+  // driven purely by validate-time marginal cost (full_draft_time_ms = 0).
+  std::vector<int32_t> prefix_lengths;
+  if (has_selected_probs_by_step(draft_outputs)) {
+    prefix_lengths = adaptive_spec_controller_->select_pruned_prefix_lengths(
+        selected_probs_by_step(draft_outputs),
+        /*full_draft_time_ms=*/0.0,
+        target_step_time_ms,
+        per_seq_kv_lens);
+  } else {
+    prefix_lengths.assign(static_cast<size_t>(batch_size),
+                          num_speculative_tokens);
+  }
+  clamp_prefix_lengths(prefix_lengths, batch_size, num_speculative_tokens);
+  int32_t effective_speculative_tokens =
+      max_pruned_prefix_length(prefix_lengths, num_speculative_tokens);
+  if (effective_speculative_tokens <= 0) {
+    effective_speculative_tokens = 1;
+  }
+
+  std::vector<int32_t> per_seq_val_tokens(static_cast<size_t>(batch_size));
+  for (int32_t i = 0; i < batch_size; ++i) {
+    per_seq_val_tokens[static_cast<size_t>(i)] =
+        std::max(prefix_lengths[static_cast<size_t>(i)], 1) + 1;
+  }
+  std::vector<ForwardOutput> pruned_draft_outputs =
+      truncate_draft_outputs(draft_outputs, effective_speculative_tokens);
+  prepare_validate_inputs(input, validate_input, per_seq_val_tokens);
+  return run_validate(input,
+                      pruned_draft_outputs,
+                      validate_input,
+                      effective_speculative_tokens,
+                      per_seq_val_tokens,
+                      &prefix_lengths);
 }
 
 std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
     const ForwardInput& input,
     const std::vector<ForwardOutput>& draft_outputs,
-    ForwardInput& validate_input) {
-  // run the target model to get the verification scores
+    ForwardInput& validate_input,
+    int32_t num_speculative_tokens,
+    const std::vector<int32_t>* pruned_prefix_lengths) {
+  const int32_t batch_size = input.input_params.meta.num_sequences;
+  const int32_t val_tokens = num_speculative_tokens + 1;
+  std::vector<int32_t> per_seq_val_tokens(static_cast<size_t>(batch_size),
+                                          val_tokens);
+  return run_validate(input,
+                      draft_outputs,
+                      validate_input,
+                      num_speculative_tokens,
+                      per_seq_val_tokens,
+                      pruned_prefix_lengths);
+}
+
+// Run target model validate with per-seq variable-length support.
+// When all seqs have the same val_tokens (uniform case), uses zero-copy view.
+// When variable-length, pads logits to [batch * max_val_tokens, vocab] for
+// RejectionSampler compatibility, with -inf at padding positions.
+std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
+    const ForwardInput& input,
+    const std::vector<ForwardOutput>& draft_outputs,
+    ForwardInput& validate_input,
+    int32_t num_speculative_tokens,
+    const std::vector<int32_t>& per_seq_val_tokens,
+    const std::vector<int32_t>* pruned_prefix_lengths) {
   Timer timer;
   ForwardInput target_prepared;
   fill_validate_input_from_draft_outputs(
-      draft_outputs, validate_input, *compute_stream_);
+      draft_outputs, validate_input, per_seq_val_tokens, *compute_stream_);
   ForwardOutput target_output = run_llm_no_sync_impl(*impl_,
                                                      validate_input,
                                                      *compute_stream_,
                                                      *compute_stream_,
                                                      target_prepared)
                                     .value();
+  const double target_latency_ms = timer.elapsed_milliseconds();
   COUNTER_ADD(speculative_execution_latency_seconds_target,
-              timer.elapsed_seconds());
+              target_latency_ms / 1000.0);
+
+  const int32_t batch_size = static_cast<int32_t>(per_seq_val_tokens.size());
+  const int32_t max_val_tokens = num_speculative_tokens + 1;
+  const int32_t total_tokens =
+      static_cast<int32_t>(target_output.logits.size(0));
+  const int32_t vocab_size =
+      static_cast<int32_t>(target_output.logits.size(-1));
+  const int64_t padded_total =
+      static_cast<int64_t>(batch_size) * max_val_tokens;
+
+  ForwardOutput padded_target_output = target_output;
+  if (total_tokens == static_cast<int32_t>(padded_total)) {
+    // Fast path: all seqs have the same val_tokens (= max), no padding needed.
+    padded_target_output.logits =
+        target_output.logits.view({padded_total, vocab_size});
+  } else {
+    // Slow path: per-seq variable-length, scatter into padded layout.
+    std::vector<int64_t> dst_indices_vec;
+    dst_indices_vec.reserve(static_cast<size_t>(total_tokens));
+    for (int32_t i = 0; i < batch_size; ++i) {
+      const int32_t seq_tokens = per_seq_val_tokens[static_cast<size_t>(i)];
+      for (int32_t j = 0; j < seq_tokens; ++j) {
+        dst_indices_vec.push_back(static_cast<int64_t>(i) * max_val_tokens + j);
+      }
+    }
+    torch::Tensor dst_indices =
+        torch::tensor(dst_indices_vec,
+                      torch::TensorOptions()
+                          .dtype(torch::kLong)
+                          .device(target_output.logits.device()));
+
+    torch::Tensor padded_logits = torch::full(
+        {padded_total, vocab_size}, -1e9, target_output.logits.options());
+    padded_logits.index_copy_(/*dim=*/0, dst_indices, target_output.logits);
+    padded_target_output.logits = padded_logits;
+
+    torch::Tensor padded_next_tokens = torch::zeros(
+        {padded_total}, target_output.sample_output.next_tokens.options());
+    padded_next_tokens.index_copy_(
+        /*dim=*/0, dst_indices, target_output.sample_output.next_tokens);
+    padded_target_output.sample_output.next_tokens = padded_next_tokens;
+
+    if (target_output.sample_output.embeddings.defined()) {
+      const int32_t hidden_size =
+          static_cast<int32_t>(target_output.sample_output.embeddings.size(-1));
+      torch::Tensor padded_embeddings =
+          torch::zeros({padded_total, hidden_size},
+                       target_output.sample_output.embeddings.options());
+      padded_embeddings.index_copy_(
+          /*dim=*/0, dst_indices, target_output.sample_output.embeddings);
+      padded_target_output.sample_output.embeddings = padded_embeddings;
+    }
+  }
 
   const bool prelaunch_next_first_draft =
-      can_use_combined_first_draft() &&
+      pruned_prefix_lengths == nullptr && can_use_combined_first_draft() &&
       device_target_context_ready_for_batch(input);
   ForwardInput next_first_draft_input;
   if (prelaunch_next_first_draft) {
@@ -1476,12 +1734,42 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
   SampleOutput val_output;
   {
     c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
-    val_output = validate(input.sampling_params, draft_outputs, target_output);
+    val_output = validate(input.sampling_params,
+                          draft_outputs,
+                          padded_target_output,
+                          num_speculative_tokens,
+                          pruned_prefix_lengths);
   }
+  record_validate_metrics(
+      val_output, num_speculative_tokens, pruned_prefix_lengths);
   COUNTER_ADD(speculative_execution_latency_seconds_validation,
               timer.elapsed_seconds());
 
-  const int64_t batch_size = val_output.next_tokens.size(0);
+  if (pruned_prefix_lengths != nullptr) {
+    // Adaptive pruning path: per-seq validate width is variable, which is
+    // incompatible with the async handoff's fixed-width base-state derivation.
+    // Use the synchronous tail: unify tokens, then write target context inline.
+    if (get_optimization_config().enable_spec_token_broadcast) {
+      c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
+      broadcast_spec_tokens(val_output.next_tokens,
+                            spec_broadcast_group(parallel_args_));
+    }
+
+    const int32_t ret = compute_stream_->synchronize();
+    CHECK_EQ(ret, 0) << "failed to synchronize MTP compute stream, ret=" << ret;
+    release_retained_inputs(target_output);
+    val_output.next_tokens = val_output.next_tokens.to(torch::kCPU);
+    write_target_context_to_cache(input, val_output, num_speculative_tokens);
+
+    if (!enable_schedule_overlap() && !driver_ && !dp_driver_) {
+      return std::nullopt;
+    }
+    clear_all_output_embeddings(target_output);
+    val_output.embeddings = torch::Tensor();
+    target_output.sample_output = val_output;
+    return target_output;
+  }
+
   const int64_t num_val_tokens = options_.num_speculative_tokens() + 1;
   CHECK_EQ(validate_input.positions.numel(), batch_size * num_val_tokens)
       << "validate positions must contain one row per speculative token";
@@ -1655,6 +1943,22 @@ void MTPWorkerImpl::flush_pending_target_context() {
   pending_target_context_ = PendingTargetContext();
 }
 
+void MTPWorkerImpl::write_target_context_to_cache(
+    const ForwardInput& input,
+    const SampleOutput& validate_output,
+    int32_t num_speculative_tokens) {
+  CHECK(embedding_cache_ != nullptr)
+      << "embedding_cache_ must be initialized before target cache write";
+  CHECK(!input.input_params.embedding.embedding_ids.empty())
+      << "target context cache write requires embedding ids";
+  embedding_cache_->write_target_context(
+      input.input_params.embedding.embedding_ids,
+      input.input_params.embedding.request_ids,
+      validate_output.next_tokens,
+      validate_output.embeddings,
+      num_speculative_tokens);
+}
+
 bool MTPWorkerImpl::supports_combined_first_draft_execution() const {
 #if defined(USE_NPU)
   if (draft_impl_ == nullptr ||
@@ -1785,6 +2089,99 @@ bool MTPWorkerImpl::pending_draft_context_matches(
              input.input_params.embedding.embedding_ids &&
          pending_draft_context_.request_ids ==
              input.input_params.embedding.request_ids;
+}
+
+void MTPWorkerImpl::record_validate_metrics(
+    const SampleOutput& validate_output,
+    int32_t num_speculative_tokens,
+    const std::vector<int32_t>* pruned_prefix_lengths) const {
+  CHECK(validate_output.next_tokens.defined())
+      << "validate output tokens are undefined";
+  CHECK_EQ(validate_output.next_tokens.dim(), 2)
+      << "validate output tokens should be [batch, width]";
+  const int32_t batch_size =
+      static_cast<int32_t>(validate_output.next_tokens.size(0));
+  CHECK_EQ(validate_output.next_tokens.size(1), num_speculative_tokens + 1)
+      << "validate output width mismatch";
+
+  torch::Tensor next_tokens_cpu = validate_output.next_tokens.to(torch::kCPU)
+                                      .to(torch::kInt64)
+                                      .contiguous();
+  const int64_t* token_data = next_tokens_cpu.const_data_ptr<int64_t>();
+  int64_t num_draft_tokens = 0;
+  int64_t accepted_count = 0;
+  for (int32_t seq_id = 0; seq_id < batch_size; ++seq_id) {
+    int32_t prefix_len = num_speculative_tokens;
+    if (pruned_prefix_lengths != nullptr) {
+      CHECK_EQ(pruned_prefix_lengths->size(), static_cast<size_t>(batch_size))
+          << "adaptive pruning prefix length batch mismatch";
+      prefix_len =
+          std::clamp((*pruned_prefix_lengths)[static_cast<size_t>(seq_id)],
+                     0,
+                     num_speculative_tokens);
+    }
+    num_draft_tokens += prefix_len;
+
+    const int64_t row_offset = static_cast<int64_t>(seq_id) *
+                               static_cast<int64_t>(num_speculative_tokens + 1);
+    int32_t emitted_len = 0;
+    for (int32_t token_idx = 0; token_idx <= num_speculative_tokens;
+         ++token_idx) {
+      if (token_data[row_offset + token_idx] < 0) {
+        break;
+      }
+      ++emitted_len;
+    }
+    accepted_count += std::min(prefix_len, std::max(emitted_len - 1, 0));
+  }
+  COUNTER_ADD(speculative_num_draft_tokens_total, num_draft_tokens);
+  COUNTER_ADD(speculative_num_accepted_tokens_total, accepted_count);
+}
+
+bool MTPWorkerImpl::adaptive_enabled() const {
+  return adaptive_spec_controller_ != nullptr &&
+         adaptive_spec_controller_->enabled();
+}
+
+double MTPWorkerImpl::adaptive_step_time_estimate(
+    const ForwardInput& input,
+    int32_t max_speculative_tokens) const {
+  const int32_t batch_size = input.input_params.meta.num_sequences;
+  const Slice<int32_t> kv_seq_lens =
+      input.input_params.attention.host.kv_seq_lens;
+  if (batch_size <= 0 || max_speculative_tokens <= 0) {
+    return 1.0;
+  }
+#if defined(USE_NPU)
+  const size_t min_kv_seq_lens_size = static_cast<size_t>(batch_size);
+#else
+  const size_t min_kv_seq_lens_size = static_cast<size_t>(batch_size) + 1;
+#endif
+  if (kv_seq_lens.size() < min_kv_seq_lens_size) {
+    return 1.0;
+  }
+
+  double total_prefix_len = 0.0;
+  for (int32_t seq_id = 0; seq_id < batch_size; ++seq_id) {
+    total_prefix_len += static_cast<double>(
+        specBuilder::calc_kv_len(kv_seq_lens, seq_id, /*offset=*/0));
+  }
+  const double avg_prefix_len =
+      total_prefix_len / static_cast<double>(batch_size);
+
+  SpeculativeProfileRegistry& registry =
+      SpeculativeProfileRegistry::get_instance();
+  if (!registry.has_validate_time_predictor()) {
+    return 1.0;
+  }
+
+  const double max_speculative_target_time = registry.predict_validate_time_ms(
+      batch_size, max_speculative_tokens + 1, avg_prefix_len);
+  if (max_speculative_target_time <= 0.0 ||
+      !std::isfinite(max_speculative_target_time)) {
+    return 1.0;
+  }
+  return max_speculative_target_time;
 }
 
 void MTPWorkerImpl::process_draft_sample_output(SampleOutput& sample_output) {
@@ -1930,7 +2327,6 @@ void MTPWorkerImpl::prepare_validate_inputs(const ForwardInput& input,
   torch::TensorOptions token_options = validate_input.token_ids.options();
   torch::TensorOptions position_options = validate_input.positions.options();
 
-  const int32_t num_speculative_tokens = options_.num_speculative_tokens();
   const int32_t num_sequences = input_params.meta.num_sequences;
   const int32_t num_val_tokens = num_speculative_tokens + 1;
   const int32_t total_num_val_tokens = num_sequences * num_val_tokens;
@@ -2289,6 +2685,138 @@ bool MTPWorkerImpl::prepare_static_mtp_graph_tasks_before_final_draft(
 #endif
 }
 
+// Per-seq variable-length validate input construction.
+// Each seq gets per_seq_val_tokens[i] tokens in the ATB kernel input,
+// reducing attention/FFN computation for seqs with fewer speculative tokens.
+void MTPWorkerImpl::prepare_validate_inputs(
+    const ForwardInput& input,
+    ForwardInput& validate_input,
+    const std::vector<int32_t>& per_seq_val_tokens) {
+  c10::StreamGuard stream_guard = prepare_stream_->set_stream_guard();
+  validate_input = input;
+  clear_ready_events(validate_input);
+  validate_input.device_tensors_ready = false;
+  auto& input_params = validate_input.input_params;
+  input_params.embedding.input_embedding = torch::Tensor();
+  torch::TensorOptions token_options = validate_input.token_ids.options();
+  torch::TensorOptions position_options = validate_input.positions.options();
+
+  const int32_t num_sequences = input_params.meta.num_sequences;
+  CHECK_EQ(per_seq_val_tokens.size(), static_cast<size_t>(num_sequences))
+      << "per_seq_val_tokens size mismatch with num_sequences";
+  int32_t total_num_val_tokens = 0;
+  int32_t max_val_tokens = 0;
+  for (int32_t i = 0; i < num_sequences; ++i) {
+    total_num_val_tokens += per_seq_val_tokens[static_cast<size_t>(i)];
+    max_val_tokens =
+        std::max(max_val_tokens, per_seq_val_tokens[static_cast<size_t>(i)]);
+  }
+  const int32_t block_size = options_.block_size();
+  specBuilder::DecodeRowContext row_ctx =
+      specBuilder::make_decode_row_context(input);
+  Slice<int32_t> token_ids = {
+      input.token_ids_host.data_ptr<int32_t>(),
+      static_cast<size_t>(input.token_ids_host.numel())};
+  Slice<int32_t> positions = {
+      input.positions_host.data_ptr<int32_t>(),
+      static_cast<size_t>(input.positions_host.numel())};
+  Slice<int32_t> kv_seq_lens = input.input_params.attention.host.kv_seq_lens;
+  const bool use_atb_spec_kernel =
+      ::xllm::SpeculativeConfig::get_instance().enable_atb_spec_kernel() ||
+      use_chunked_prefill_spec_verify_path();
+  specBuilder::DecodeBuildBuffers buf;
+  buf.out_token_ids.reserve(total_num_val_tokens);
+  buf.out_positions.reserve(total_num_val_tokens);
+  buf.out_new_cache_slots.reserve(total_num_val_tokens);
+  if (!use_atb_spec_kernel) {
+    buf.out_kv_seq_lens.reserve(total_num_val_tokens);
+    buf.out_q_seq_lens.reserve(total_num_val_tokens);
+    buf.out_q_cu_seq_lens.reserve(total_num_val_tokens);
+    buf.out_block_tables.reserve(static_cast<size_t>(total_num_val_tokens) *
+                                 row_ctx.block_table_stride);
+  }
+
+  std::vector<int32_t> atb_kv_seq_lens_vec;
+  std::vector<int32_t> atb_q_seq_lens_vec;
+  std::vector<int32_t> atb_q_cu_seq_lens_vec;
+  int32_t atb_kv_max_seq_len = 0;
+  for (int32_t seq_id = 0; seq_id < num_sequences; ++seq_id) {
+    const int32_t seq_val_tokens =
+        per_seq_val_tokens[static_cast<size_t>(seq_id)];
+    const int32_t start_position = positions[seq_id];
+    const int32_t kv_len =
+        specBuilder::calc_kv_len(kv_seq_lens, seq_id, /*offset=*/0);
+    CHECK_EQ(start_position + 1, kv_len)
+        << "validate position/kv_len mismatch, seq_id=" << seq_id
+        << ", start_position=" << start_position << ", kv_len=" << kv_len;
+
+    for (int32_t val_idx = 0; val_idx < seq_val_tokens; ++val_idx) {
+      specBuilder::RowSpec row;
+      row.seq_id = seq_id;
+      row.token_id = val_idx == 0 ? token_ids[seq_id] : -val_idx;
+      row.position_offset = val_idx;
+      row.append_kv_len = !use_atb_spec_kernel;
+      row.append_q_len_one = !use_atb_spec_kernel;
+      row.append_block_table = !use_atb_spec_kernel;
+      specBuilder::append_decode_row(row_ctx, row, block_size, buf);
+    }
+
+    if (use_atb_spec_kernel) {
+      const int32_t kv_len_after_validation = kv_len + seq_val_tokens - 1;
+      specBuilder::update_kv_seq_lens_and_max(
+          atb_kv_seq_lens_vec, kv_len_after_validation, atb_kv_max_seq_len);
+      specBuilder::append_q_seq_len(
+          atb_q_seq_lens_vec, atb_q_cu_seq_lens_vec, seq_val_tokens);
+    }
+  }
+
+  CHECK_EQ(buf.out_new_cache_slots.size(), buf.out_token_ids.size())
+      << "validate kv slots/tokens mismatch";
+  CHECK_EQ(buf.out_positions.size(), buf.out_token_ids.size())
+      << "validate positions/tokens mismatch";
+
+  specBuilder::set_token_position_tensors(validate_input,
+                                          buf.out_token_ids,
+                                          buf.out_positions,
+                                          token_options,
+                                          position_options);
+  if (!use_atb_spec_kernel) {
+    input_params.meta.num_sequences = total_num_val_tokens;
+    input_params.meta.batch_forward_type = BatchForwardType::DECODE;
+  } else {
+    input_params.meta.batch_forward_type = BatchForwardType::CHUNKED_PREFILL;
+  }
+  if (use_atb_spec_kernel) {
+    specBuilder::update_input_params(input_params,
+                                     buf,
+                                     max_val_tokens,
+                                     std::move(atb_q_seq_lens_vec),
+                                     std::move(atb_q_cu_seq_lens_vec),
+                                     atb_kv_max_seq_len,
+                                     std::move(atb_kv_seq_lens_vec));
+  } else {
+    specBuilder::update_input_params(input_params,
+                                     buf,
+                                     1,
+                                     std::move(buf.out_q_seq_lens),
+                                     std::move(buf.out_q_cu_seq_lens),
+                                     buf.meta.kv_max_seq_len,
+                                     std::move(buf.out_kv_seq_lens),
+                                     /*update_block_tables=*/true);
+  }
+
+  update_sampling_params(
+      validate_input.sampling_params, per_seq_val_tokens, total_num_val_tokens);
+
+  for (int32_t& token_num : input_params.parallel.dp_global_token_nums) {
+    token_num = total_num_val_tokens;
+  }
+
+  input_params.attention.rebuild_device_buffer(device_);
+  validate_input.device_tensors_ready = true;
+  finish_metadata_prepare(*prepare_stream_, validate_input);
+}
+
 void MTPWorkerImpl::prepare_draft_extend_inputs(
     const ForwardInput& base_input,
     const std::vector<EmbeddingCache::DecodeState>& last_states,
@@ -2600,10 +3128,12 @@ void MTPWorkerImpl::prepare_draft_inputs(const ForwardInput& input,
 SampleOutput MTPWorkerImpl::validate(
     const SamplingParameters& sampling_params,
     const std::vector<ForwardOutput>& draft_outputs,
-    const ForwardOutput& target_output) {
+    const ForwardOutput& target_output,
+    int32_t num_speculative_tokens,
+    const std::vector<int32_t>* pruned_prefix_lengths) {
   const int32_t num_target_tokens =
       target_output.sample_output.next_tokens.numel();
-  const int32_t num_val_tokens = options_.num_speculative_tokens() + 1;
+  const int32_t num_val_tokens = num_speculative_tokens + 1;
   CHECK_EQ(num_target_tokens % num_val_tokens, 0);
   const int32_t batch_size = num_target_tokens / num_val_tokens;
   const int32_t vocab_size = target_output.logits.size(/*dim=*/-1);
@@ -2612,12 +3142,12 @@ SampleOutput MTPWorkerImpl::validate(
   std::vector<torch::Tensor> draft_probs_steps;
   draft_token_ids_steps.reserve(draft_outputs.size());
   draft_probs_steps.reserve(draft_outputs.size());
-  for (const auto& draft_output : draft_outputs) {
+  for (const ForwardOutput& draft_output : draft_outputs) {
     draft_token_ids_steps.emplace_back(draft_output.sample_output.next_tokens);
     draft_probs_steps.emplace_back(draft_output.sample_output.probs);
   }
 
-  auto [draft_token_ids, draft_probs] =
+  std::pair<torch::Tensor, torch::Tensor> validate_tensors =
       specBuilder::draftProbs::build_validate_tensors(
           draft_token_ids_steps,
           draft_probs_steps,
@@ -2625,28 +3155,40 @@ SampleOutput MTPWorkerImpl::validate(
           vocab_size,
           enable_opt_validate_probs_,
           /*draft_probs_required=*/!sampling_params.all_greedy_sample);
-  return validate(sampling_params, draft_token_ids, draft_probs, target_output);
+  return validate(sampling_params,
+                  validate_tensors.first,
+                  validate_tensors.second,
+                  target_output,
+                  num_speculative_tokens,
+                  pruned_prefix_lengths);
 }
 
-SampleOutput MTPWorkerImpl::validate(const SamplingParameters& sampling_params,
-                                     const torch::Tensor& draft_token_ids,
-                                     const torch::Tensor& draft_probs,
-                                     const ForwardOutput& target_output) {
+SampleOutput MTPWorkerImpl::validate(
+    const SamplingParameters& sampling_params,
+    const torch::Tensor& draft_token_ids,
+    const torch::Tensor& draft_probs,
+    const ForwardOutput& target_output,
+    int32_t num_speculative_tokens,
+    const std::vector<int32_t>* pruned_prefix_lengths) {
   const int32_t num_target_tokens =
       target_output.sample_output.next_tokens.numel();
-  const int32_t num_val_tokens = options_.num_speculative_tokens() + 1;
+  const int32_t num_val_tokens = num_speculative_tokens + 1;
   CHECK_EQ(num_target_tokens % num_val_tokens, 0);
   const int32_t batch_size = num_target_tokens / num_val_tokens;
   const int32_t vocab_size = target_output.logits.size(/*dim=*/-1);
 
   using torch::indexing::None;
   using ISlice = torch::indexing::Slice;
-  auto bonus_token_ids =
+  torch::Tensor bonus_token_ids =
       target_output.sample_output.next_tokens
           .index({"...", ISlice(num_val_tokens - 1, None, num_val_tokens)})
           .view({-1, 1});
 
-  if (sampling_params.all_greedy_sample && !target_output.logprobs) {
+  // Greedy fast-path: skip full rejection sampling when all sequences are
+  // greedy and no logprobs needed. Disabled when adaptive pruning is active
+  // since pruning requires the full rejection sampling output format.
+  if (sampling_params.all_greedy_sample && !target_output.logprobs &&
+      pruned_prefix_lengths == nullptr) {
     torch::Tensor target_token_ids =
         target_output.sample_output.next_tokens.view(
             {batch_size, num_val_tokens});
@@ -2668,11 +3210,11 @@ SampleOutput MTPWorkerImpl::validate(const SamplingParameters& sampling_params,
     return sample_output;
   }
 
-  auto target_logits =
+  torch::Tensor target_logits =
       target_output.logits.view({batch_size, num_val_tokens, vocab_size});
 
   // prepare input for rejection sampling
-  auto rejection_sampler =
+  std::unique_ptr<RejectionSampler> rejection_sampler =
       std::make_unique<RejectionSampler>(sampling_params.do_sample,
                                          sampling_params.all_random_sample,
                                          sampling_params.all_greedy_sample,
@@ -2690,9 +3232,21 @@ SampleOutput MTPWorkerImpl::validate(const SamplingParameters& sampling_params,
       /*mask_out_rejected_tokens=*/true);
 
   // process embedding
-  auto embeddings = target_output.sample_output.embeddings;
+  torch::Tensor embeddings = target_output.sample_output.embeddings;
   sample_output.embeddings =
       embeddings.view({batch_size, num_val_tokens, embeddings.size(-1)});
+  if (pruned_prefix_lengths != nullptr) {
+    sync_pruned_boundary_outputs(sample_output,
+                                 target_output,
+                                 batch_size,
+                                 num_val_tokens,
+                                 num_speculative_tokens,
+                                 *pruned_prefix_lengths);
+    apply_pruned_prefix_lengths(sample_output,
+                                target_output.sample_output.next_tokens,
+                                num_speculative_tokens,
+                                *pruned_prefix_lengths);
+  }
 
   return sample_output;
 }

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -1491,21 +1491,32 @@ void MTPWorkerImpl::fill_validate_input_from_draft_outputs(
   const bool is_uniform = (total_val_tokens == num_sequences * max_val_tokens);
 
   if (is_uniform) {
-    // Fast path: all seqs have same val_tokens, use vectorized view+copy.
+    // Fast path: all seqs share the same val_tokens. Stack the draft-token
+    // columns once into a contiguous [batch, num_draft_tokens] tensor and
+    // issue a single strided slice-copy, instead of one device kernel per
+    // draft step. This is the static (non-adaptive) MTP baseline and runs
+    // every decode step; launch-bound NPU decode is measurably faster with
+    // one op than num_speculative_tokens ops writing the same bytes.
     const int32_t num_draft_tokens = max_val_tokens - 1;
     torch::Tensor validate_token_rows = validate_input.token_ids.view(
         {static_cast<int64_t>(num_sequences), max_val_tokens});
-    for (int32_t i = 0; i < num_draft_tokens; ++i) {
-      CHECK(static_cast<size_t>(i) < draft_outputs.size())
-          << "draft_outputs index out of range for step " << i;
-      const torch::Tensor& next_tokens =
-          draft_outputs[static_cast<size_t>(i)].sample_output.next_tokens;
-      CHECK(next_tokens.defined())
-          << "draft next_tokens must be defined for validate token fill";
-      torch::Tensor draft_tokens =
-          safe_to(next_tokens.flatten(), token_options, /*non_blocking=*/true);
-      validate_token_rows.select(/*dim=*/1, /*index=*/i + 1)
-          .copy_(draft_tokens, /*non_blocking=*/true);
+    if (num_draft_tokens > 0) {
+      std::vector<torch::Tensor> draft_token_columns;
+      draft_token_columns.reserve(static_cast<size_t>(num_draft_tokens));
+      for (int32_t i = 0; i < num_draft_tokens; ++i) {
+        CHECK(static_cast<size_t>(i) < draft_outputs.size())
+            << "draft_outputs index out of range for step " << i;
+        const torch::Tensor& next_tokens =
+            draft_outputs[static_cast<size_t>(i)].sample_output.next_tokens;
+        CHECK(next_tokens.defined())
+            << "draft next_tokens must be defined for validate token fill";
+        draft_token_columns.push_back(safe_to(
+            next_tokens.flatten(), token_options, /*non_blocking=*/true));
+      }
+      torch::Tensor packed_drafts =
+          torch::stack(draft_token_columns, /*dim=*/1);
+      validate_token_rows.slice(/*dim=*/1, /*start=*/1, /*end=*/max_val_tokens)
+          .copy_(packed_drafts, /*non_blocking=*/true);
     }
   } else {
     // Slow path: per-seq variable-length, group by draft step.
@@ -1723,13 +1734,16 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
   const int64_t padded_total =
       static_cast<int64_t>(batch_size) * max_val_tokens;
 
-  ForwardOutput padded_target_output = target_output;
-  if (total_tokens == static_cast<int32_t>(padded_total)) {
-    // Fast path: all seqs have the same val_tokens (= max), no padding needed.
-    padded_target_output.logits =
-        target_output.logits.view({padded_total, vocab_size});
-  } else {
+  // For the uniform fast path we only need to reinterpret target_output.logits
+  // as `[padded_total, vocab]` — no ForwardOutput copy required. Only the
+  // variable-length slow path materializes a separate padded output.
+  std::optional<ForwardOutput> padded_target_output_slow;
+  const bool needs_padding =
+      (total_tokens != static_cast<int32_t>(padded_total));
+  if (needs_padding) {
     // Slow path: per-seq variable-length, scatter into padded layout.
+    padded_target_output_slow.emplace(target_output);
+    ForwardOutput& padded_target_output = *padded_target_output_slow;
     std::vector<int64_t> dst_indices_vec;
     dst_indices_vec.reserve(static_cast<size_t>(total_tokens));
     for (int32_t i = 0; i < batch_size; ++i) {
@@ -1744,8 +1758,31 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
                           .dtype(torch::kLong)
                           .device(target_output.logits.device()));
 
-    torch::Tensor padded_logits = torch::full(
-        {padded_total, vocab_size}, -1e9, target_output.logits.options());
+    // Only the padding rows need the -inf sentinel; using empty + a targeted
+    // index_fill_ over the complement of dst_indices avoids paying vocab_size
+    // × padded_total writes when most rows will be overwritten by index_copy_.
+    torch::Tensor padded_logits = torch::empty({padded_total, vocab_size},
+                                               target_output.logits.options());
+    if (dst_indices_vec.size() < static_cast<size_t>(padded_total)) {
+      std::vector<bool> valid(static_cast<size_t>(padded_total), false);
+      for (int64_t idx : dst_indices_vec) {
+        valid[static_cast<size_t>(idx)] = true;
+      }
+      std::vector<int64_t> pad_indices_vec;
+      pad_indices_vec.reserve(static_cast<size_t>(padded_total) -
+                              dst_indices_vec.size());
+      for (int64_t i = 0; i < padded_total; ++i) {
+        if (!valid[static_cast<size_t>(i)]) {
+          pad_indices_vec.push_back(i);
+        }
+      }
+      torch::Tensor pad_indices =
+          torch::tensor(pad_indices_vec,
+                        torch::TensorOptions()
+                            .dtype(torch::kLong)
+                            .device(target_output.logits.device()));
+      padded_logits.index_fill_(/*dim=*/0, pad_indices, -1e9);
+    }
     padded_logits.index_copy_(/*dim=*/0, dst_indices, target_output.logits);
     padded_target_output.logits = padded_logits;
 
@@ -1797,6 +1834,17 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
       padded_target_output.sample_output.top_logprobs = padded_top_logprobs;
     }
   }
+  // Uniform fast path uses a scoped local ForwardOutput whose only diff is
+  // logits viewed to [padded_total, vocab]; slow path uses the materialized
+  // padded copy above. Both are const-ref'd into validate() below.
+  ForwardOutput uniform_target_view;
+  if (!needs_padding) {
+    uniform_target_view = target_output;
+    uniform_target_view.logits =
+        target_output.logits.view({padded_total, vocab_size});
+  }
+  const ForwardOutput& target_output_for_validate =
+      needs_padding ? *padded_target_output_slow : uniform_target_view;
 
   const bool prelaunch_next_first_draft =
       pruned_prefix_lengths == nullptr && can_use_combined_first_draft() &&
@@ -1817,7 +1865,7 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
     c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
     val_output = validate(input.sampling_params,
                           draft_outputs,
-                          padded_target_output,
+                          target_output_for_validate,
                           num_speculative_tokens,
                           pruned_prefix_lengths);
   }

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -3304,16 +3304,23 @@ SampleOutput MTPWorkerImpl::validate(
   }
 
   if (pruned_prefix_lengths != nullptr) {
+    // Build cut/keep masks once from pruned_prefix_lengths and reuse across
+    // both helpers below, so we avoid re-uploading prefix_lengths and
+    // rebuilding identical arange+eq+logical_and masks per call.
+    const adaptive_pruning::PrunedPrefixMasks pruning_masks =
+        adaptive_pruning::build_pruned_prefix_masks(
+            *pruned_prefix_lengths,
+            num_speculative_tokens,
+            sample_output.next_tokens.device());
     sync_pruned_boundary_outputs(sample_output,
                                  target_output,
                                  batch_size,
                                  num_val_tokens,
-                                 num_speculative_tokens,
-                                 *pruned_prefix_lengths);
+                                 pruning_masks);
     apply_pruned_prefix_lengths(sample_output,
                                 target_output.sample_output.next_tokens,
                                 num_speculative_tokens,
-                                *pruned_prefix_lengths);
+                                pruning_masks);
   }
 
   return sample_output;

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -1198,8 +1198,7 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
   // Adaptive is enabled only after profile completes (registry has predictor),
   // ensuring profiling warmup never triggers the adaptive HCCL broadcast.
   const bool use_adaptive_speculative_decode =
-      adaptive_spec_controller_ != nullptr &&
-      adaptive_spec_controller_->enabled() && adaptive_enabled() &&
+      adaptive_enabled() &&
       SpeculativeProfileRegistry::get_instance().has_validate_time_predictor();
 
   std::vector<ForwardOutput> draft_outputs;
@@ -1626,9 +1625,10 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_adaptive_validate(
     std::vector<int32_t> nat = embedding_cache_->read_accepted_prefix_lengths(
         input.input_params.embedding.embedding_ids,
         input.input_params.embedding.request_ids);
+    clamp_gdn_conv_history(nat);
     int32_t max_nat = 0;
     for (int32_t v : nat) {
-      max_nat = std::max(max_nat, std::min(v, kGdnConvHistoryCap));
+      max_nat = std::max(max_nat, v);
     }
     effective_speculative_tokens =
         std::max(effective_speculative_tokens, max_nat);
@@ -1765,6 +1765,37 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
           /*dim=*/0, dst_indices, target_output.sample_output.embeddings);
       padded_target_output.sample_output.embeddings = padded_embeddings;
     }
+
+    // Pad sampled logprobs / top_tokens / top_logprobs to [padded_total, ...]
+    // so downstream sync_pruned_boundary_{logprobs,top_logprobs} can safely
+    // view them as [batch, max_val_tokens]. Without this the shape CHECKs
+    // in the helpers abort on any actually-pruned adaptive step when the
+    // target sampler produced logprobs (non-Qwen3.5 targets + logprobs on).
+    if (target_output.sample_output.logprobs.defined()) {
+      torch::Tensor padded_logprobs = torch::zeros(
+          {padded_total}, target_output.sample_output.logprobs.options());
+      padded_logprobs.index_copy_(
+          /*dim=*/0, dst_indices, target_output.sample_output.logprobs);
+      padded_target_output.sample_output.logprobs = padded_logprobs;
+    }
+    if (target_output.sample_output.top_tokens.defined()) {
+      const int64_t top_k = target_output.sample_output.top_tokens.size(-1);
+      torch::Tensor padded_top_tokens =
+          torch::zeros({padded_total, top_k},
+                       target_output.sample_output.top_tokens.options());
+      padded_top_tokens.index_copy_(
+          /*dim=*/0, dst_indices, target_output.sample_output.top_tokens);
+      padded_target_output.sample_output.top_tokens = padded_top_tokens;
+    }
+    if (target_output.sample_output.top_logprobs.defined()) {
+      const int64_t top_k = target_output.sample_output.top_logprobs.size(-1);
+      torch::Tensor padded_top_logprobs =
+          torch::zeros({padded_total, top_k},
+                       target_output.sample_output.top_logprobs.options());
+      padded_top_logprobs.index_copy_(
+          /*dim=*/0, dst_indices, target_output.sample_output.top_logprobs);
+      padded_target_output.sample_output.top_logprobs = padded_top_logprobs;
+    }
   }
 
   const bool prelaunch_next_first_draft =
@@ -1797,7 +1828,10 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
     // Adaptive pruning path: per-seq validate width is variable, which is
     // incompatible with the async handoff's fixed-width base-state derivation.
     // Use the synchronous tail: unify tokens, then write target context inline.
-    if (get_optimization_config().enable_spec_token_broadcast) {
+    if (should_broadcast_spec_tokens(
+            parallel_args_,
+            get_optimization_config().enable_spec_token_broadcast,
+            input.sampling_params.all_greedy_sample)) {
       c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
       broadcast_spec_tokens(val_output.next_tokens, parallel_args_);
     }

--- a/xllm/core/runtime/mtp_worker_impl.h
+++ b/xllm/core/runtime/mtp_worker_impl.h
@@ -16,7 +16,9 @@ limitations under the License.
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "core/runtime/mtp_async_state.h"
@@ -25,6 +27,7 @@ limitations under the License.
 #if defined(USE_NPU)
 #include "framework/kv_cache_transfer/spec_kv_cache_transfer.h"
 #endif
+#include "core/framework/speculative/adaptive_speculative_controller.h"
 #include "runtime/speculative_worker_impl.h"
 
 namespace xllm {
@@ -54,7 +57,8 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
                 const runtime::Options& options,
                 const runtime::Options& target_options,
                 const runtime::Options& draft_options,
-                bool enable_opt_validate_probs = false);
+                bool enable_opt_validate_probs = false,
+                bool enable_adaptive_speculative_decode = false);
 
  public:
   bool init_model(const std::string& model_weights_path,
@@ -86,24 +90,52 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
   void fill_validate_input_from_draft_outputs(
       const std::vector<ForwardOutput>& draft_outputs,
       ForwardInput& validate_input,
+      int32_t num_speculative_tokens,
       Stream& compute_stream);
+  void fill_validate_input_from_draft_outputs(
+      const std::vector<ForwardOutput>& draft_outputs,
+      ForwardInput& validate_input,
+      const std::vector<int32_t>& per_seq_val_tokens,
+      Stream& compute_stream);
+  // Adaptive pruning path: compute per-seq prefix lengths, truncate draft
+  // outputs, and run variable-length validate.
+  std::optional<ForwardOutput> run_adaptive_validate(
+      const ForwardInput& input,
+      const std::vector<ForwardOutput>& draft_outputs,
+      ForwardInput& validate_input,
+      int32_t num_speculative_tokens);
   std::optional<ForwardOutput> run_validate(
       const ForwardInput& input,
       const std::vector<ForwardOutput>& draft_outputs,
-      ForwardInput& validate_input);
+      ForwardInput& validate_input,
+      int32_t num_speculative_tokens,
+      const std::vector<int32_t>* pruned_prefix_lengths = nullptr);
+  std::optional<ForwardOutput> run_validate(
+      const ForwardInput& input,
+      const std::vector<ForwardOutput>& draft_outputs,
+      ForwardInput& validate_input,
+      int32_t num_speculative_tokens,
+      const std::vector<int32_t>& per_seq_val_tokens,
+      const std::vector<int32_t>* pruned_prefix_lengths = nullptr);
 
-  virtual SampleOutput validate(const SamplingParameters& sampling_params,
-                                const std::vector<ForwardOutput>& draft_outputs,
-                                const ForwardOutput& target_output);
+  virtual SampleOutput validate(
+      const SamplingParameters& sampling_params,
+      const std::vector<ForwardOutput>& draft_outputs,
+      const ForwardOutput& target_output,
+      int32_t num_speculative_tokens,
+      const std::vector<int32_t>* pruned_prefix_lengths = nullptr);
 
   // Hook for algorithm-specific draft output post-processing during decode.
   // Default MTP behavior always compresses probs for cache storage.
   virtual void process_draft_sample_output(SampleOutput& sample_output);
 
-  SampleOutput validate(const SamplingParameters& sampling_params,
-                        const torch::Tensor& draft_token_ids,
-                        const torch::Tensor& draft_probs,
-                        const ForwardOutput& target_output);
+  SampleOutput validate(
+      const SamplingParameters& sampling_params,
+      const torch::Tensor& draft_token_ids,
+      const torch::Tensor& draft_probs,
+      const ForwardOutput& target_output,
+      int32_t num_speculative_tokens,
+      const std::vector<int32_t>* pruned_prefix_lengths = nullptr);
 
   // PD separation: placeholder size for empty embedding slot. Default: 1x
   // hidden_size. Eagle3 overrides to 3 * target_hidden_size.
@@ -125,6 +157,9 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
   void prepare_validate_inputs(const ForwardInput& inputs,
                                ForwardInput& validate_inputs,
                                bool static_graph_tasks_prepared = false);
+  void prepare_validate_inputs(const ForwardInput& inputs,
+                               ForwardInput& validate_inputs,
+                               const std::vector<int32_t>& per_seq_val_tokens);
   bool prepare_static_mtp_graph_tasks_before_final_draft(
       const ForwardInput& input);
 
@@ -188,6 +223,17 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
                                 ForwardInput combined_input);
   bool pending_draft_context_matches(const ForwardInput& input) const;
 
+  void write_target_context_to_cache(const ForwardInput& input,
+                                     const SampleOutput& validate_output,
+                                     int32_t num_speculative_tokens);
+  void record_validate_metrics(
+      const SampleOutput& validate_output,
+      int32_t num_speculative_tokens,
+      const std::vector<int32_t>* pruned_prefix_lengths = nullptr) const;
+  bool adaptive_enabled() const;
+  double adaptive_step_time_estimate(const ForwardInput& input,
+                                     int32_t max_speculative_tokens) const;
+
  protected:
   // Draft model worker
   std::unique_ptr<LLMWorkerImpl> draft_impl_;
@@ -214,6 +260,7 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
   // Whether validation directly uses selected-only draft_probs [B, S].
   // If false, selected-only cache values are restored to dense [B, S, V].
   bool enable_opt_validate_probs_ = false;
+  std::unique_ptr<AdaptiveSpeculativeController> adaptive_spec_controller_;
 
   // Classified once when the target model is loaded. Decode-path decisions
   // only read this closed policy and never traverse the model implementation.

--- a/xllm/core/runtime/mtp_worker_impl.h
+++ b/xllm/core/runtime/mtp_worker_impl.h
@@ -18,7 +18,6 @@ limitations under the License.
 #include <cstdint>
 #include <optional>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include "core/runtime/mtp_async_state.h"

--- a/xllm/core/runtime/mtp_worker_impl.h
+++ b/xllm/core/runtime/mtp_worker_impl.h
@@ -230,8 +230,6 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
       int32_t num_speculative_tokens,
       const std::vector<int32_t>* pruned_prefix_lengths = nullptr) const;
   bool adaptive_enabled() const;
-  double adaptive_step_time_estimate(const ForwardInput& input,
-                                     int32_t max_speculative_tokens) const;
 
  protected:
   // Draft model worker

--- a/xllm/core/runtime/mtp_worker_impl.h
+++ b/xllm/core/runtime/mtp_worker_impl.h
@@ -117,7 +117,11 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
       const std::vector<ForwardOutput>& draft_outputs,
       const ForwardOutput& target_output,
       int32_t num_speculative_tokens,
-      const std::vector<int32_t>* pruned_prefix_lengths = nullptr);
+      // No default: Google Style bans default args on virtuals — they resolve
+      // statically from the declared base type, so an override changing the
+      // default would silently diverge when called through a base reference.
+      // Callers must pass nullptr explicitly for the static path.
+      const std::vector<int32_t>* pruned_prefix_lengths);
 
   // Hook for algorithm-specific draft output post-processing during decode.
   // Default MTP behavior always compresses probs for cache storage.

--- a/xllm/core/runtime/mtp_worker_impl.h
+++ b/xllm/core/runtime/mtp_worker_impl.h
@@ -89,11 +89,6 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
   void fill_validate_input_from_draft_outputs(
       const std::vector<ForwardOutput>& draft_outputs,
       ForwardInput& validate_input,
-      int32_t num_speculative_tokens,
-      Stream& compute_stream);
-  void fill_validate_input_from_draft_outputs(
-      const std::vector<ForwardOutput>& draft_outputs,
-      ForwardInput& validate_input,
       const std::vector<int32_t>& per_seq_val_tokens,
       Stream& compute_stream);
   // Adaptive pruning path: compute per-seq prefix lengths, truncate draft
@@ -146,6 +141,13 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
   bool supports_explicit_spec_verify_replay_update() const;
   bool should_use_explicit_spec_verify_replay_update(
       const ForwardInput& input) const;
+  // Returns true when the target model's spec-verify kernel requires the
+  // validate width (val_tokens) to be identical across every sequence in the
+  // batch. Currently Qwen3.5 GDN's FusedRecurrentGatedDeltaRule spec-verify
+  // path has this constraint; other paths accept per-seq variable widths.
+  // Kept separate from supports_explicit_spec_verify_replay_update() so the
+  // two capabilities can diverge for future targets.
+  bool requires_uniform_validate_width() const;
   int64_t spec_verify_block_table_width(
       const torch::Tensor& block_tables) const;
   // Returns true when validation must use chunked-prefill to avoid the

--- a/xllm/core/runtime/options.h
+++ b/xllm/core/runtime/options.h
@@ -86,6 +86,10 @@ struct Options {
 
   PROPERTY(bool, speculative_suffix_use_tree_spec) = false;
 
+  PROPERTY(bool, enable_adaptive_speculative_decode) = false;
+
+  PROPERTY(double, adaptive_speculative_min_gain) = 0.0;
+
   // enable speculative decode
   PROPERTY(bool, enable_speculative_decode) = false;
 

--- a/xllm/core/runtime/speculative_worker_impl.cpp
+++ b/xllm/core/runtime/speculative_worker_impl.cpp
@@ -211,6 +211,40 @@ void SpeculativeWorkerImpl::update_sampling_params(
   TENSOR_REPEAT(sampling_params.do_sample, num_val_tokens);
 }
 
+void SpeculativeWorkerImpl::update_sampling_params(
+    SamplingParameters& sampling_params,
+    const std::vector<int32_t>& per_seq_val_tokens,
+    const int32_t total_num_val_tokens) {
+  std::vector<int32_t> selected_token_idxes_vec;
+  selected_token_idxes_vec.reserve(total_num_val_tokens);
+  for (int32_t i = 0; i < total_num_val_tokens; i++) {
+    selected_token_idxes_vec.emplace_back(i);
+  }
+  torch::Tensor selected_token_idxes = torch::tensor(selected_token_idxes_vec);
+  sampling_params.selected_token_idxes = selected_token_idxes.to(device_);
+  sampling_params.sample_idxes = selected_token_idxes.to(device_);
+
+  torch::Tensor repeats_tensor =
+      torch::tensor(std::vector<int64_t>(per_seq_val_tokens.begin(),
+                                         per_seq_val_tokens.end()),
+                    torch::kLong)
+          .to(device_);
+  auto repeat_per_seq = [&](torch::Tensor& tensor) {
+    if (!tensor.defined()) return;
+    tensor = tensor.repeat_interleave(repeats_tensor, /*dim=*/0);
+  };
+  repeat_per_seq(sampling_params.frequency_penalties);
+  repeat_per_seq(sampling_params.presence_penalties);
+  repeat_per_seq(sampling_params.repetition_penalties);
+  repeat_per_seq(sampling_params.temperatures);
+  repeat_per_seq(sampling_params.top_p);
+  repeat_per_seq(sampling_params.top_k);
+  repeat_per_seq(sampling_params.unique_token_ids);
+  repeat_per_seq(sampling_params.unique_token_counts);
+  repeat_per_seq(sampling_params.unique_token_ids_lens);
+  repeat_per_seq(sampling_params.do_sample);
+}
+
 void SpeculativeWorkerImpl::prepare_validate_inputs(
     const ForwardInput& input,
     ForwardInput& validate_input) {

--- a/xllm/core/runtime/speculative_worker_impl.cpp
+++ b/xllm/core/runtime/speculative_worker_impl.cpp
@@ -222,7 +222,9 @@ void SpeculativeWorkerImpl::update_sampling_params(
   }
   torch::Tensor selected_token_idxes = torch::tensor(selected_token_idxes_vec);
   sampling_params.selected_token_idxes = selected_token_idxes.to(device_);
-  sampling_params.sample_idxes = selected_token_idxes.to(device_);
+  // Alias sample_idxes to the already-uploaded device tensor rather than
+  // paying a second identical H2D copy.
+  sampling_params.sample_idxes = sampling_params.selected_token_idxes;
 
   torch::Tensor repeats_tensor =
       torch::tensor(std::vector<int64_t>(per_seq_val_tokens.begin(),
@@ -230,7 +232,9 @@ void SpeculativeWorkerImpl::update_sampling_params(
                     torch::kLong)
           .to(device_);
   auto repeat_per_seq = [&](torch::Tensor& tensor) {
-    if (!tensor.defined()) return;
+    if (!tensor.defined()) {
+      return;
+    }
     tensor = tensor.repeat_interleave(repeats_tensor, /*dim=*/0);
   };
   repeat_per_seq(sampling_params.frequency_penalties);

--- a/xllm/core/runtime/speculative_worker_impl.h
+++ b/xllm/core/runtime/speculative_worker_impl.h
@@ -128,6 +128,9 @@ class SpeculativeWorkerImpl : public WorkerImpl {
   void update_sampling_params(SamplingParameters& sampling_params,
                               const int32_t num_val_tokens,
                               const int32_t total_num_val_tokens);
+  void update_sampling_params(SamplingParameters& sampling_params,
+                              const std::vector<int32_t>& per_seq_val_tokens,
+                              const int32_t total_num_val_tokens);
 
   // prepare inputs for target model at Decode phase (validation).
   void prepare_validate_inputs(const ForwardInput& inputs,

--- a/xllm/core/runtime/worker.cpp
+++ b/xllm/core/runtime/worker.cpp
@@ -96,6 +96,13 @@ bool Worker::allocate_kv_cache(const KVCacheShape& kv_cache_shape) {
   return impl_->allocate_kv_cache(kv_cache_shape);
 }
 
+bool Worker::set_speculative_validate_time_predictor(
+    const SpeculativeProfileRegistry::ValidateTimePredictor& predictor) {
+  SpeculativeProfileRegistry::get_instance().set_validate_time_predictor(
+      predictor);
+  return true;
+}
+
 void Worker::get_cache_info(uint64_t& cluster_id,
                             std::string& addr,
                             uint16_t& port) {

--- a/xllm/core/runtime/worker.h
+++ b/xllm/core/runtime/worker.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <torch/torch.h>
 
 #include "common/types.h"
+#include "core/framework/speculative/speculative_profile_registry.h"
 #include "forward_params.h"
 #include "framework/kv_cache/kv_cache_shape.h"
 #include "framework/model/causal_lm.h"
@@ -69,6 +70,9 @@ class Worker {
 
   // allocate kv cache. blocking call
   bool allocate_kv_cache(const KVCacheShape& kv_cache_shape);
+
+  bool set_speculative_validate_time_predictor(
+      const SpeculativeProfileRegistry::ValidateTimePredictor& predictor);
 
   void get_cache_info(uint64_t& cluster_id, std::string& addr, uint16_t& port);
 

--- a/xllm/core/runtime/worker_client.cpp
+++ b/xllm/core/runtime/worker_client.cpp
@@ -42,6 +42,11 @@ bool WorkerClient::allocate_kv_cache(const KVCacheShape& kv_cache_shape) {
   return worker_->allocate_kv_cache(kv_cache_shape);
 }
 
+bool WorkerClient::set_speculative_validate_time_predictor(
+    const SpeculativeProfileRegistry::ValidateTimePredictor& predictor) {
+  return worker_->set_speculative_validate_time_predictor(predictor);
+}
+
 void WorkerClient::get_cache_info(uint64_t& cluster_id,
                                   std::string& addr,
                                   uint16_t& port) {

--- a/xllm/core/runtime/worker_client.h
+++ b/xllm/core/runtime/worker_client.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <torch/torch.h>
 
 #include "common/types.h"
+#include "core/framework/speculative/speculative_profile_registry.h"
 #include "forward_params.h"
 #include "framework/kv_cache/kv_cache_shape.h"
 #include "framework/model/causal_lm.h"
@@ -61,6 +62,9 @@ class WorkerClient {
 
   // allocate kv cache. blocking call
   virtual bool allocate_kv_cache(const KVCacheShape& kv_cache_shape);
+
+  virtual bool set_speculative_validate_time_predictor(
+      const SpeculativeProfileRegistry::ValidateTimePredictor& predictor);
 
   virtual void get_cache_info(uint64_t& cluster_id,
                               std::string& addr,

--- a/xllm/core/scheduler/profile/CMakeLists.txt
+++ b/xllm/core/scheduler/profile/CMakeLists.txt
@@ -14,6 +14,7 @@ cc_library(
     time_predictor.cpp
   DEPS
     :batch
+    :distributed_runtime
     :request
     :runtime
     glog::glog

--- a/xllm/core/scheduler/profile/profile_manager.cpp
+++ b/xllm/core/scheduler/profile/profile_manager.cpp
@@ -429,9 +429,14 @@ void ProfileManager::train_speculative_validate_time_predictor(
                       static_cast<double>(time_profiling_data.size()) * 100.0;
 
   for (int32_t i = 0; i < kNumCoefficients; ++i) {
-    if (coefficients(i) < 0.0) {
-      LOG(ERROR) << "Negative speculative validate coefficient: "
-                 << coefficients(i) << ", set it to 0.";
+    // NaN/Inf can escape a rank-deficient QR solve or slip in via a NaN
+    // latency sample; `NaN < 0.0` is false so a raw negative-only clamp
+    // would silently broadcast poison to workers. Sanitize non-finite
+    // and negative values consistently here (the local registry has the
+    // same sanitizer, but the RPC path sees the raw values).
+    if (!std::isfinite(coefficients(i)) || coefficients(i) < 0.0) {
+      LOG(ERROR) << "Invalid speculative validate coefficient[" << i
+                 << "]=" << coefficients(i) << ", clamping to 0.";
       coefficients(i) = 0.0;
     }
   }

--- a/xllm/core/scheduler/profile/profile_manager.cpp
+++ b/xllm/core/scheduler/profile/profile_manager.cpp
@@ -19,8 +19,11 @@ limitations under the License.
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 
+#include <Eigen/Dense>
 #include <algorithm>
+#include <cctype>
 #include <chrono>
+#include <cmath>
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
@@ -35,6 +38,7 @@ limitations under the License.
 #include "core/framework/config/service_config.h"
 #include "core/framework/config/speculative_config.h"
 #include "core/framework/model/mtp_utils.h"
+#include "core/framework/speculative/speculative_profile_registry.h"
 #include "framework/batch/batch_factory.h"
 #include "framework/request/request_state.h"
 #include "scheduler/profile/graph_warmup.h"
@@ -55,6 +59,7 @@ ProfileManager::ProfileManager(Engine* engine, const Options& options)
   if (options.enable_profile_step_time()) {
     LOG(INFO) << "Starting profiliing step time.";
     profile_step_time(false);
+    profile_speculative_validate_time();
     // test accuracy
     // eval_sequence_latency_prediction();
     // eval_batch_latency_prediction("only_prefill");
@@ -371,6 +376,178 @@ void ProfileManager::train_prefill_time_predictor(
 void ProfileManager::train_decode_time_predictor(
     std::vector<std::tuple<int32_t, int32_t, double>> time_profiling_data) {
   decode_time_predictor_->fit_for_decode(time_profiling_data);
+}
+
+void ProfileManager::train_speculative_validate_time_predictor(
+    const std::vector<std::tuple<int32_t, int32_t, int32_t, double>>&
+        time_profiling_data) {
+  if (time_profiling_data.empty()) {
+    return;
+  }
+
+  constexpr int32_t kNumCoefficients = 4;
+  Eigen::MatrixXd matrix(time_profiling_data.size(), kNumCoefficients);
+  Eigen::VectorXd target(time_profiling_data.size());
+  for (int32_t i = 0; i < static_cast<int32_t>(time_profiling_data.size());
+       ++i) {
+    const int32_t batch_size = std::get<0>(time_profiling_data[i]);
+    const int32_t query_len = std::get<1>(time_profiling_data[i]);
+    const int32_t prefix_len = std::get<2>(time_profiling_data[i]);
+    const double batch = static_cast<double>(batch_size);
+    const double query = static_cast<double>(query_len);
+    const double prefix = static_cast<double>(prefix_len);
+    matrix(i, 0) = 1.0;
+    matrix(i, 1) = batch;
+    matrix(i, 2) = batch * query;
+    matrix(i, 3) = batch * query * prefix;
+    target(i) = std::get<3>(time_profiling_data[i]);
+  }
+
+  Eigen::VectorXd coefficients = matrix.colPivHouseholderQr().solve(target);
+  double sum_abs_error = 0.0;
+  double sum_percentage_error = 0.0;
+  for (int32_t i = 0; i < static_cast<int32_t>(time_profiling_data.size());
+       ++i) {
+    const double actual = std::get<3>(time_profiling_data[i]);
+    const double prediction = matrix.row(i).dot(coefficients);
+    const double abs_error = std::abs(prediction - actual);
+    sum_abs_error += abs_error;
+    if (actual > 0.0) {
+      sum_percentage_error += abs_error / actual;
+    }
+  }
+  const double mae =
+      sum_abs_error / static_cast<double>(time_profiling_data.size());
+  const double mape = sum_percentage_error /
+                      static_cast<double>(time_profiling_data.size()) * 100.0;
+
+  for (int32_t i = 0; i < kNumCoefficients; ++i) {
+    if (coefficients(i) < 0.0) {
+      LOG(ERROR) << "Negative speculative validate coefficient: "
+                 << coefficients(i) << ", set it to 0.";
+      coefficients(i) = 0.0;
+    }
+  }
+
+  SpeculativeProfileRegistry::ValidateTimePredictor predictor;
+  predictor.intercept_ms = coefficients(0);
+  predictor.batch_ms = coefficients(1);
+  predictor.query_token_ms = coefficients(2);
+  predictor.query_prefix_ms = coefficients(3);
+  SpeculativeProfileRegistry::get_instance().set_validate_time_predictor(
+      predictor);
+  if (!engine_->set_speculative_validate_time_predictor(predictor)) {
+    LOG(WARNING)
+        << "Failed to broadcast speculative validate predictor to workers. "
+        << "Adaptive speculative decode will fallback to runtime EWMA on "
+        << "workers without the profile.";
+  }
+
+  LOG(INFO) << "Fitted speculative validate equation: time = "
+            << predictor.batch_ms << " * batch_size + "
+            << predictor.query_token_ms << " * batch_size * query_len + "
+            << predictor.query_prefix_ms
+            << " * batch_size * query_len * prefix_len + "
+            << predictor.intercept_ms << ", MAE: " << mae << ", MAPE: " << mape
+            << "%";
+}
+
+void ProfileManager::profile_speculative_validate_time() {
+  const SpeculativeConfig& speculative_config =
+      ::xllm::SpeculativeConfig::get_instance();
+  std::string speculative_algorithm =
+      speculative_config.speculative_algorithm();
+  std::transform(
+      speculative_algorithm.begin(),
+      speculative_algorithm.end(),
+      speculative_algorithm.begin(),
+      [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  if (speculative_config.num_speculative_tokens() <= 1 ||
+      speculative_algorithm != "mtp") {
+    return;
+  }
+  LOG(INFO) << "Starting speculative validate profile for MTP, "
+            << "adaptive_enabled="
+            << speculative_config.enable_adaptive_speculative_decode();
+
+  auto& model_args = engine_->model_args();
+  const int32_t max_context_len = model_args.max_position_embeddings();
+  const int32_t profile_max_prompt_length =
+      std::min(max_context_len, options_.profile_max_prompt_length());
+  if (profile_max_prompt_length <= 16) {
+    LOG(WARNING)
+        << "Skip speculative validate profile because prompt length is too "
+        << "small: " << profile_max_prompt_length;
+    return;
+  }
+
+  const int32_t max_query_len =
+      std::min<int32_t>(speculative_config.num_speculative_tokens() + 1, 10);
+  const int32_t max_batch_size =
+      std::min<int32_t>(options_.max_seqs_per_batch(), 256);
+  std::vector<int32_t> query_lens;
+  query_lens.push_back(1);
+  if (max_query_len > 2) {
+    query_lens.push_back((max_query_len + 1) / 2);
+  }
+  if (max_query_len > 1) {
+    query_lens.push_back(max_query_len);
+  }
+  query_lens.erase(std::unique(query_lens.begin(), query_lens.end()),
+                   query_lens.end());
+
+  constexpr int32_t kMaxProfileBatchSize = 32;
+  std::vector<int32_t> candidate_batch_sizes = {1, 16, 32};
+  std::vector<int32_t> batch_sizes;
+  for (const int32_t batch_size : candidate_batch_sizes) {
+    if (batch_size <= max_batch_size && batch_size <= kMaxProfileBatchSize) {
+      batch_sizes.push_back(batch_size);
+    }
+  }
+  if (batch_sizes.empty()) {
+    batch_sizes.push_back(std::min<int32_t>(
+        std::max<int32_t>(max_batch_size, 1), kMaxProfileBatchSize));
+  }
+
+  std::vector<int32_t> prefix_lens;
+  prefix_lens.push_back(profile_max_prompt_length);
+  if (profile_max_prompt_length >= 64) {
+    prefix_lens.push_back(profile_max_prompt_length / 4);
+  }
+  prefix_lens.push_back(16);
+  for (int32_t& prefix_len : prefix_lens) {
+    prefix_len = std::clamp(prefix_len, 16, profile_max_prompt_length);
+  }
+  std::sort(prefix_lens.begin(), prefix_lens.end());
+  prefix_lens.erase(std::unique(prefix_lens.begin(), prefix_lens.end()),
+                    prefix_lens.end());
+
+  std::vector<std::tuple<int32_t, int32_t, int32_t, double>>
+      time_profiling_data;
+  const int32_t total_blocks =
+      static_cast<int32_t>(block_manager_pool_->num_blocks());
+  const auto block_size = block_manager_pool_->options().block_size();
+  for (const int32_t prefix_len : prefix_lens) {
+    for (const int32_t query_len : query_lens) {
+      for (const int32_t batch_size : batch_sizes) {
+        const int32_t token_length = prefix_len + query_len;
+        const int32_t blocks_per_seq =
+            (prefix_len + block_size - 1) / block_size +
+            (token_length + block_size - 1) / block_size;
+        if (batch_size * blocks_per_seq > total_blocks * 9 / 10) {
+          continue;
+        }
+        double latency_mean = 0.0;
+        for (int32_t k = 0; k < profile_count_per_step_; ++k) {
+          latency_mean += run_request(token_length, prefix_len, batch_size);
+        }
+        latency_mean /= static_cast<double>(profile_count_per_step_);
+        time_profiling_data.emplace_back(
+            batch_size, query_len, prefix_len, latency_mean);
+      }
+    }
+  }
+  train_speculative_validate_time_predictor(time_profiling_data);
 }
 
 // ----------------------predict step time-----------------------

--- a/xllm/core/scheduler/profile/profile_manager.cpp
+++ b/xllm/core/scheduler/profile/profile_manager.cpp
@@ -351,9 +351,13 @@ void ProfileManager::profile_step_time(bool if_dump_to_file) {
   for (int32_t token_length = 2; token_length < profile_max_prompt_length;
        token_length += profile_length_step_) {
     for (int32_t batch_size = 1; batch_size < max_batch_size; batch_size += 2) {
+      // Use run_decode_request to build genuine decode-stage requests (each
+      // seq prefills token_length-1 then decodes 1 token) instead of
+      // approximating via run_request.
+      std::vector<int32_t> total_length_vec(batch_size, token_length);
       double latency_mean = 0;
       for (int32_t k = 0; k < profile_count_per_step_; k++) {
-        latency_mean += run_request(token_length, token_length - 1, batch_size);
+        latency_mean += run_decode_request(total_length_vec);
       }
       latency_mean /= profile_count_per_step_;
       time_profiling_data.emplace_back(token_length, batch_size, latency_mean);
@@ -385,7 +389,11 @@ void ProfileManager::train_speculative_validate_time_predictor(
     return;
   }
 
-  constexpr int32_t kNumCoefficients = 4;
+  // Fit T = intercept + query_token_ms*(batch*query) +
+  // query_prefix_ms*(batch*query*prefix). The standalone batch_ms term is
+  // dropped: it is pruning-invariant (does not depend on prefix) and only
+  // steals variance from the marginal query terms that drive pruning.
+  constexpr int32_t kNumCoefficients = 3;
   Eigen::MatrixXd matrix(time_profiling_data.size(), kNumCoefficients);
   Eigen::VectorXd target(time_profiling_data.size());
   for (int32_t i = 0; i < static_cast<int32_t>(time_profiling_data.size());
@@ -397,9 +405,8 @@ void ProfileManager::train_speculative_validate_time_predictor(
     const double query = static_cast<double>(query_len);
     const double prefix = static_cast<double>(prefix_len);
     matrix(i, 0) = 1.0;
-    matrix(i, 1) = batch;
-    matrix(i, 2) = batch * query;
-    matrix(i, 3) = batch * query * prefix;
+    matrix(i, 1) = batch * query;
+    matrix(i, 2) = batch * query * prefix;
     target(i) = std::get<3>(time_profiling_data[i]);
   }
 
@@ -431,9 +438,9 @@ void ProfileManager::train_speculative_validate_time_predictor(
 
   SpeculativeProfileRegistry::ValidateTimePredictor predictor;
   predictor.intercept_ms = coefficients(0);
-  predictor.batch_ms = coefficients(1);
-  predictor.query_token_ms = coefficients(2);
-  predictor.query_prefix_ms = coefficients(3);
+  predictor.batch_ms = 0.0;
+  predictor.query_token_ms = coefficients(1);
+  predictor.query_prefix_ms = coefficients(2);
   SpeculativeProfileRegistry::get_instance().set_validate_time_predictor(
       predictor);
   if (!engine_->set_speculative_validate_time_predictor(predictor)) {
@@ -444,7 +451,6 @@ void ProfileManager::train_speculative_validate_time_predictor(
   }
 
   LOG(INFO) << "Fitted speculative validate equation: time = "
-            << predictor.batch_ms << " * batch_size + "
             << predictor.query_token_ms << " * batch_size * query_len + "
             << predictor.query_prefix_ms
             << " * batch_size * query_len * prefix_len + "
@@ -542,6 +548,9 @@ void ProfileManager::profile_speculative_validate_time() {
           latency_mean += run_request(token_length, prefix_len, batch_size);
         }
         latency_mean /= static_cast<double>(profile_count_per_step_);
+        LOG(INFO) << "[spec_validate_profile] batch=" << batch_size
+                  << " query_len=" << query_len << " prefix_len=" << prefix_len
+                  << " latency_ms=" << latency_mean;
         time_profiling_data.emplace_back(
             batch_size, query_len, prefix_len, latency_mean);
       }

--- a/xllm/core/scheduler/profile/profile_manager.cpp
+++ b/xllm/core/scheduler/profile/profile_manager.cpp
@@ -351,13 +351,9 @@ void ProfileManager::profile_step_time(bool if_dump_to_file) {
   for (int32_t token_length = 2; token_length < profile_max_prompt_length;
        token_length += profile_length_step_) {
     for (int32_t batch_size = 1; batch_size < max_batch_size; batch_size += 2) {
-      // Use run_decode_request to build genuine decode-stage requests (each
-      // seq prefills token_length-1 then decodes 1 token) instead of
-      // approximating via run_request.
-      std::vector<int32_t> total_length_vec(batch_size, token_length);
       double latency_mean = 0;
       for (int32_t k = 0; k < profile_count_per_step_; k++) {
-        latency_mean += run_decode_request(total_length_vec);
+        latency_mean += run_request(token_length, token_length - 1, batch_size);
       }
       latency_mean /= profile_count_per_step_;
       time_profiling_data.emplace_back(token_length, batch_size, latency_mean);

--- a/xllm/core/scheduler/profile/profile_manager.cpp
+++ b/xllm/core/scheduler/profile/profile_manager.cpp
@@ -389,6 +389,10 @@ void ProfileManager::train_speculative_validate_time_predictor(
   // query_prefix_ms*(batch*query*prefix). A standalone batch term was tried
   // and dropped: it is pruning-invariant (does not depend on prefix) and only
   // steals variance from the marginal query terms that drive pruning.
+  //
+  // TODO: dedup this Eigen least-squares + MAE/MAPE + negative-coefficient
+  // clamp with TimePredictor::fit_for_decode (same routine, different design
+  // matrix). Deferred to a follow-up commit to keep this PR focused.
   constexpr int32_t kNumCoefficients = 3;
   Eigen::MatrixXd matrix(time_profiling_data.size(), kNumCoefficients);
   Eigen::VectorXd target(time_profiling_data.size());
@@ -436,14 +440,23 @@ void ProfileManager::train_speculative_validate_time_predictor(
   predictor.intercept_ms = coefficients(0);
   predictor.query_token_ms = coefficients(1);
   predictor.query_prefix_ms = coefficients(2);
+  // Broadcast to workers FIRST, then commit locally. Workers gate the
+  // adaptive path on their own SpeculativeProfileRegistry, so any rank
+  // that misses the predictor will diverge from ranks that received it:
+  // one side runs adaptive (per-seq variable validate width), the other
+  // runs static, which corrupts collectives and shape assumptions.
+  // Treat broadcast failure as fatal for the adaptive path and leave the
+  // registry unset so every rank consistently falls back to static.
+  if (!engine_->set_speculative_validate_time_predictor(predictor)) {
+    LOG(ERROR)
+        << "Failed to broadcast speculative validate predictor to workers. "
+        << "Disabling adaptive speculative decode on all ranks to avoid "
+        << "cross-rank divergence.";
+    SpeculativeProfileRegistry::get_instance().reset_validate_time_predictor();
+    return;
+  }
   SpeculativeProfileRegistry::get_instance().set_validate_time_predictor(
       predictor);
-  if (!engine_->set_speculative_validate_time_predictor(predictor)) {
-    LOG(WARNING)
-        << "Failed to broadcast speculative validate predictor to workers. "
-        << "Adaptive speculative decode will fallback to runtime EWMA on "
-        << "workers without the profile.";
-  }
 
   LOG(INFO) << "Fitted speculative validate equation: time = "
             << predictor.query_token_ms << " * batch_size * query_len + "
@@ -456,15 +469,13 @@ void ProfileManager::train_speculative_validate_time_predictor(
 void ProfileManager::profile_speculative_validate_time() {
   const SpeculativeConfig& speculative_config =
       ::xllm::SpeculativeConfig::get_instance();
-  std::string speculative_algorithm =
-      speculative_config.speculative_algorithm();
-  std::transform(
-      speculative_algorithm.begin(),
-      speculative_algorithm.end(),
-      speculative_algorithm.begin(),
-      [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-  if (speculative_config.num_speculative_tokens() <= 1 ||
-      speculative_algorithm != "mtp") {
+  // Only fit the validate-time predictor when the adaptive path can
+  // actually consume it: MTP with SL > 1 and adaptive explicitly enabled.
+  // Otherwise this whole prefix/query/batch sweep is wasted startup time.
+  if (!speculative_config.enable_adaptive_speculative_decode() ||
+      speculative_config.num_speculative_tokens() <= 1 ||
+      !SpeculativeConfig::is_mtp_algorithm(
+          speculative_config.speculative_algorithm())) {
     return;
   }
   LOG(INFO) << "Starting speculative validate profile for MTP, "

--- a/xllm/core/scheduler/profile/profile_manager.cpp
+++ b/xllm/core/scheduler/profile/profile_manager.cpp
@@ -386,8 +386,8 @@ void ProfileManager::train_speculative_validate_time_predictor(
   }
 
   // Fit T = intercept + query_token_ms*(batch*query) +
-  // query_prefix_ms*(batch*query*prefix). The standalone batch_ms term is
-  // dropped: it is pruning-invariant (does not depend on prefix) and only
+  // query_prefix_ms*(batch*query*prefix). A standalone batch term was tried
+  // and dropped: it is pruning-invariant (does not depend on prefix) and only
   // steals variance from the marginal query terms that drive pruning.
   constexpr int32_t kNumCoefficients = 3;
   Eigen::MatrixXd matrix(time_profiling_data.size(), kNumCoefficients);
@@ -434,7 +434,6 @@ void ProfileManager::train_speculative_validate_time_predictor(
 
   SpeculativeProfileRegistry::ValidateTimePredictor predictor;
   predictor.intercept_ms = coefficients(0);
-  predictor.batch_ms = 0.0;
   predictor.query_token_ms = coefficients(1);
   predictor.query_prefix_ms = coefficients(2);
   SpeculativeProfileRegistry::get_instance().set_validate_time_predictor(

--- a/xllm/core/scheduler/profile/profile_manager.h
+++ b/xllm/core/scheduler/profile/profile_manager.h
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <memory>
 #include <optional>
+#include <tuple>
 #include <vector>
 
 #include "common/macros.h"
@@ -114,6 +115,10 @@ class ProfileManager {
   void train_prefill_time_predictor(
       std::vector<std::pair<int32_t, double>> time_profiling_data);
 
+  void train_speculative_validate_time_predictor(
+      const std::vector<std::tuple<int32_t, int32_t, int32_t, double>>&
+          time_profiling_data);
+
   double get_constant_overhead();
 
   int32_t get_quadratic_root(Sequence* sequence, double budget);
@@ -145,6 +150,8 @@ class ProfileManager {
   void eval_batch_latency_prediction(const std::string mode);
 
   void profile_token_budget();
+
+  void profile_speculative_validate_time();
 
   // Warmup ACL graph executor according to the instance role.
   void warmup_for_graph();

--- a/xllm/proto/worker.proto
+++ b/xllm/proto/worker.proto
@@ -59,6 +59,13 @@ message AllocateKVCacheRequest {
   KVCacheShape kv_cache_shape = 1;
 }
 
+message SpeculativeValidateTimePredictor {
+  double intercept_ms = 1;
+  double batch_ms = 2;
+  double query_token_ms = 3;
+  double query_prefix_ms = 4;
+}
+
 message SleepRequest {
   MasterStatus master_status = 1;
 }
@@ -400,6 +407,8 @@ service DistributeWorker {
   rpc ProcessGroupTest (Empty) returns (Status);
   rpc ProfileDeviceMemory (Empty) returns (DeviceMemory);
   rpc AllocateKVCache (AllocateKVCacheRequest) returns (Status);
+  rpc SetSpeculativeValidateTimePredictor(SpeculativeValidateTimePredictor)
+      returns (Status) {}
   rpc AllocateKVCacheWithTransfer(AllocateKVCacheRequest) returns (Status) {}
   rpc PullKVCache(PullKVCacheRequest) returns (Status) {}
   rpc GetCacheInfo(Empty) returns (CacheInfo) {}

--- a/xllm/proto/worker.proto
+++ b/xllm/proto/worker.proto
@@ -61,7 +61,7 @@ message AllocateKVCacheRequest {
 
 message SpeculativeValidateTimePredictor {
   double intercept_ms = 1;
-  double batch_ms = 2;
+  reserved 2;  // was: double batch_ms (dropped, dead field)
   double query_token_ms = 3;
   double query_prefix_ms = 4;
 }

--- a/xllm/xllm.cpp
+++ b/xllm/xllm.cpp
@@ -161,6 +161,10 @@ Options create_options(const std::string& instance_name, bool is_local) {
       .speculative_suffix_use_tree_spec(
           speculative_config.speculative_suffix_use_tree_spec())
       .enable_mtp_draft_body_tp1(speculative_config.enable_mtp_draft_body_tp1())
+      .enable_adaptive_speculative_decode(
+          speculative_config.enable_adaptive_speculative_decode())
+      .adaptive_speculative_min_gain(
+          speculative_config.adaptive_speculative_min_gain())
       .num_request_handling_threads(
           service_config.num_request_handling_threads())
       .communication_backend(parallel_config.communication_backend())


### PR DESCRIPTION
## Description

实现自适应投机推理的 validate 前剪枝优化。在每个 decode step 的 draft 阶段结束后、validate 阶段开始前，根据 draft model 产出的 token 概率动态决定每个 sequence 保留多少 speculative tokens 参与 validate，裁剪掉置信度低、预期收益为负的 draft tokens。

核心算法：将 batch 内所有请求所有位置的候选 token 按 path probability（从第一个 token 到当前位置的累积概率）从大到小排列，从最高概率开始依次尝试加入验证集。每加入一个 token，基于 profile 拟合的时间预测模型更新估计吞吐（expected_emitted_tokens / estimated_time）。若加入后估计吞吐不增反降则停止加入该 token。最终每个 sequence 可能有不同的验证长度。

validate 阶段利用 ATB attention kernel 的 variable q_len 能力，只对每个 sequence 实际保留的 tokens 做计算，真正减少 validate 的 attention 和 FFN 计算量。

此方案参考 DSPark 自适应投机推理算法（区别主要在于计算接受概率时 DSpark 用的是模型本身的 confidence head，其他 draft 模型如 MTP / DFlash 用 draft 输出的 prob 作为预期接受长度预测），但还未专门针对 graph 和 ZOS 做适配。后续还可以进一步支持：(1) 对 draft 的 early stop；(2) 根据近期各位置接受率动态调整 num_speculative_tokens。

### 裁剪对 num_speculative_tokens 的敏感性

`num_speculative_tokens`（SL）越大，adaptive 的收益应该越显著：SL 越大 static 里越多"低质量 draft"（path_prob 随位置递减越快），controller 越有裁剪空间。SL 较小时 draft 本身命中率高，裁剪空间小，adaptive 与 static 接近。下面的实测结果印证了这一点。

### 后续支持的 draft 模型

- **MTP / DFlash**：使用 draft 输出的 prob 作为预期接受长度预测（本 PR 已支持 MTP）
- **DSPark**：使用模型自带的 confidence head 作为预期接受长度预测

## Related Issues

N/A

## Change Type

- [x] Bug fix
- [x] New feature
- [x] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

### DeepSeek V3.2（16 卡 TP NPU，ShareGPT，batch=32）

| SL | Metric | Static | Adaptive | Δ |
|---|---|---|---|---|
| 3 | output_throughput | 244.7 | **256.9** | **+5.0%** |
| 3 | acceptance_rate | 52.2% | **60.9%** | +8.7pp |
| 5 | output_throughput | 243.2 | **279.8** | **+15.0%** |
| 5 | acceptance_rate | 35.5% | **63.7%** | +28.2pp |
| 7 | output_throughput | 217.0 | **234.6** | **+8.1%** |
| 7 | acceptance_rate | 25.1% | **66.1%** | +41.0pp |

SL 越大 adaptive 收益越明显，接受率提升幅度也随 SL 递增，与算法预期一致。

### Qwen3.5-27B（4 卡 TP NPU，ShareGPT，batch=32）

| SL | Metric | Static | Adaptive | Δ |
|---|---|---|---|---|
| 3 | output_throughput | 443.9 | 428.8 | -3.4% |
| 3 | acceptance_rate | 57.1% | **75.0%** | +17.9pp |
| 5 | output_throughput | 469.9 | 445.7 | -5.2% |
| 5 | acceptance_rate | 43.4% | **65.4%** | +22.0pp |
| 7 | output_throughput | 453.1 | 443.0 | -2.2% |
| 7 | acceptance_rate | 29.5% | **62.1%** | +32.6pp |

Qwen3.5 上 adaptive 接受率显著提升但吞吐略降，主要有两个原因，可在后续 PR 修复：

1. **GDN spec-verify 融合内核硬约束 batch-uniform val_tokens**：Qwen3.5 GDN 层的 `FusedRecurrentGatedDeltaRule` 内核 `CHECK_EQ` batch 内所有 sequence 的 q_seq_len 必须相同，无法真正做 per-seq 变长裁剪。本 PR 在 mtp_worker_impl 里对 Qwen3.5 强制 uniform val_tokens（仍能享受 batch-max 裁剪，但收益打折）。修复方向：由 GDN kernel 侧支持 varlen（cu_seqlens），或走单独的 non-fused 路径。

2. **`aclnnCausalConv1d` tiling 在 `nat > lenI` 时报错**：GDN 的 CausalConv1d 内核在"当前 step 输入 x 长度 < 上一步接受的 token 数 nat"时 tiling 失败，是 kernel 契约缺陷。本 PR 通过三层 workaround 绕开：
   - kernel tiling 侧放开 `OP_CHECK_IF(a > lenI)` 校验（在 `xllm-ops` submodule，见配套 PR https://github.com/xLLM-AI/xllm-ops/pull/37）
   - 抬高 `effective_speculative_tokens ≥ max(nat)` 保证 `x_len ≥ nat`
   - `nat` clamp 到 `kernel_conv_size-1 (=3)` 避免读到 rolling buffer 之外的 slot

   修复方向：GDN CausalConv1d kernel 侧显式处理 `nat > lenI` 或 `nat > 3` 的合法输入。

### 无裁剪时的 baseline 影响

关闭 `enable_adaptive_speculative_decode` 后完全不影响 static 路径（record_speculative_metrics 在 MTP 路径已由 MTPWorkerImpl 内部记录，本 PR 顺带修复了 worker_service 的双计数）。
