### PR TITLE
refactor: prefer std::make_unique and std::make_shared to direct use of new.

### DIFF
--- a/.agents/skills/code-review/references/custom-code-style.md
+++ b/.agents/skills/code-review/references/custom-code-style.md
@@ -168,6 +168,23 @@ virtual ModelOutput forward(torch::Tensor tokens, ...);
   - Use `std::shared_ptr` only when shared ownership is genuinely needed.
   - Raw pointers are acceptable only for non-owning references where the lifetime is clearly managed elsewhere.
 
+- **Prefer `std::make_unique` and `std::make_shared` to direct use of `new`** when creating heap objects managed by smart pointers.
+  - Avoid repeating the type and avoid exception-unsafe patterns such as passing `std::shared_ptr<T>(new T(...))` in the same statement as other expressions.
+  - Direct `new` is acceptable when make functions cannot be used (e.g. custom deleters, braced initialization of the pointee, or APIs that require a raw pointer and take ownership explicitly).
+  - If `new` is required, assign the result to a smart pointer in a standalone statement before any other expression that may throw.
+
+```cpp
+// Good
+auto widget = std::make_unique<Widget>(arg);
+auto widget = std::make_shared<Widget>(arg);
+stub_ = std::make_unique<ServiceStub>(&channel_);
+
+// Bad
+std::unique_ptr<Widget> widget(new Widget(arg));
+stub_.reset(new ServiceStub(&channel_));
+process(std::shared_ptr<Widget>(new Widget), compute_priority());  // may leak
+```
+
 ---
 
 ## 6. Scoping & Visibility

--- a/xllm/core/distributed_runtime/comm_channel.cpp
+++ b/xllm/core/distributed_runtime/comm_channel.cpp
@@ -35,7 +35,7 @@ bool CommChannel::init_brpc(const std::string& server_address) {
     return false;
   }
 
-  stub_.reset(new proto::DistributeWorker_Stub(&channel_));
+  stub_ = std::make_unique<proto::DistributeWorker_Stub>(&channel_);
   return true;
 }
 

--- a/xllm/core/framework/xtensor/xtensor_dist_client.cpp
+++ b/xllm/core/framework/xtensor/xtensor_dist_client.cpp
@@ -38,7 +38,7 @@ XTensorDistClient::XTensorDistClient(int32_t global_rank,
     LOG(ERROR) << "Failed to initialize brpc channel to " << server_address;
     return;
   }
-  stub_.reset(new proto::XTensorDist_Stub(&channel_));
+  stub_ = std::make_unique<proto::XTensorDist_Stub>(&channel_);
   wait_for_server_ready(server_address);
 }
 

--- a/xllm/core/triton_jit/src/jit_kernel.cpp
+++ b/xllm/core/triton_jit/src/jit_kernel.cpp
@@ -92,9 +92,9 @@ JITKernel& JITKernel::get(std::string py_path, std::string fn_name) {
   std::lock_guard<std::mutex> lock(registry_mutex);
   auto it = registry.find(key);
   if (it == registry.end()) {
-    std::unique_ptr<JITKernel> p(
-        new JITKernel(std::move(py_path), std::move(fn_name)));
-    auto [ins, ok] = registry.emplace(key, std::move(p));
+    auto [ins, ok] = registry.emplace(
+        key,
+        std::make_unique<JITKernel>(std::move(py_path), std::move(fn_name)));
     it = ins;
   }
   return *it->second;

--- a/xllm/core/util/suffix_tree.cpp
+++ b/xllm/core/util/suffix_tree.cpp
@@ -375,7 +375,7 @@ void SuffixTree::append(int32_t seq_id, int32_t token) {
           // This should be the first child being added.
           assert(!node->head_child && !node->tail_child);
           node->head_child = node->tail_child = new_child;
-          new_child->group.reset(new Group(new_child));
+          new_child->group = std::make_shared<Group>(new_child);
         } else {
           assert(node->tail_child);
           insert_into_siblings_after(new_child, node->tail_child);
@@ -500,7 +500,7 @@ void SuffixTree::append(int32_t seq_id, int32_t token) {
 
         // Create a new group for the child node.
         new_node->head_child = new_node->tail_child = child;
-        child->group.reset(new Group(child));
+        child->group = std::make_shared<Group>(child);
 
         // Increment the new node count and update siblings lists.
         increment_count(new_node);


### PR DESCRIPTION
## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->
Replace new with std::make_unique and std::make_shared following "Effective Modern C++" Item 21 guidelines.

> Item 21: Prefer std::make_unique and std::make_shared to direct use of new.

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [x] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
