### PR TITLE
bugfix: preserve MTP correctness during asynchronous execution.

### DIFF
--- a/tests/core/runtime/acl_graph_executor_test.cpp
+++ b/tests/core/runtime/acl_graph_executor_test.cpp
@@ -27,6 +27,7 @@ limitations under the License.
 #include "core/framework/block/block.h"
 #include "core/framework/block/block_manager_impl.h"
 #include "core/framework/config/execution_config.h"
+#include "core/framework/config/speculative_config.h"
 #include "core/framework/kv_cache/kv_cache.h"
 #include "core/framework/model/model_args.h"
 #include "core/framework/model/model_output.h"
@@ -37,6 +38,7 @@ limitations under the License.
 #include "core/layers/npu/npu_lm_head_impl.h"
 #include "core/layers/npu/npu_word_embedding_impl.h"
 #include "core/runtime/acl_graph_executor_impl.h"
+#include "core/runtime/acl_graph_persistent_param.h"
 #include "core/runtime/base_executor_impl.h"
 #include "core/runtime/options.h"
 
@@ -768,6 +770,86 @@ TEST_F(AclGraphExecutorTest, GraphDoubleBufferFlagControlsSlotCount) {
 
   execution_config.enable_graph_double_buffer(
       original_enable_graph_double_buffer);
+}
+
+TEST(AclGraphPersistentParamTest, SpecVerifyMetadataUsesTokenCapacity) {
+  SpeculativeConfig& speculative_config = SpeculativeConfig::get_instance();
+  const bool original_enable_atb_spec_kernel =
+      speculative_config.enable_atb_spec_kernel();
+  speculative_config.enable_atb_spec_kernel(false);
+
+  ModelArgs args;
+  args.model_type("deepseek_v4");
+  args.dtype("float32");
+  args.hidden_size(8);
+  args.max_position_embeddings(32);
+
+  runtime::Options options;
+  options.block_size(4);
+  options.max_seqs_per_batch(10);
+  options.max_tokens_per_batch(64);
+  options.num_decoding_tokens(3);
+  options.enable_speculative_decode(true);
+  options.is_draft_engine(false);
+
+  const torch::Device device("npu:0");
+  ::xllm::npu::GraphPersistentParam persistent_param(
+      args,
+      device,
+      options,
+      /*need_update_attn_mask=*/false,
+      /*is_hybrid_linear_attention=*/false);
+  EXPECT_EQ(persistent_param.q_seq_lens().size(0), 30);
+  EXPECT_EQ(persistent_param.kv_seq_lens().size(0), 30);
+  EXPECT_EQ(persistent_param.persistent_block_tables().size(0), 30);
+
+  constexpr int64_t kValidateRows = 12;
+  const torch::TensorOptions int_options =
+      torch::dtype(torch::kInt).device(device);
+  const torch::Tensor tokens = torch::arange(kValidateRows, int_options);
+  const torch::Tensor positions = torch::arange(kValidateRows, int_options);
+  ModelInputParams params;
+  params.is_spec_verify = true;
+  params.meta.batch_forward_type = BatchForwardType::DECODE;
+  params.meta.num_sequences = kValidateRows;
+  params.attention.host.q_seq_lens.assign(kValidateRows, 1);
+  params.attention.host.kv_seq_lens.assign(kValidateRows, 8);
+  params.attention.device.q_seq_lens =
+      torch::ones({kValidateRows}, int_options);
+  params.attention.device.kv_seq_lens =
+      torch::full({kValidateRows}, 8, int_options);
+  params.attention.device.new_cache_slots =
+      torch::zeros({kValidateRows}, int_options);
+  params.attention.device.block_tables =
+      torch::zeros({kValidateRows, 2}, int_options);
+
+  std::optional<ModelInputParams> capture_params;
+  EXPECT_NO_THROW(capture_params = persistent_param.update(
+                      tokens,
+                      torch::Tensor(),
+                      torch::Tensor(),
+                      positions,
+                      params,
+                      /*padded_num_tokens=*/kValidateRows,
+                      /*return_capture_params=*/true));
+  EXPECT_TRUE(capture_params.has_value());
+  if (capture_params.has_value()) {
+    EXPECT_EQ(capture_params->attention.device.q_seq_lens.size(0),
+              kValidateRows);
+    EXPECT_EQ(capture_params->attention.device.block_tables.size(0),
+              kValidateRows);
+  }
+
+  ::xllm::npu::GraphPersistentParam hybrid_persistent_param(
+      args,
+      device,
+      options,
+      /*need_update_attn_mask=*/false,
+      /*is_hybrid_linear_attention=*/true);
+  EXPECT_EQ(hybrid_persistent_param.q_seq_lens().size(0), 10);
+  EXPECT_EQ(hybrid_persistent_param.persistent_block_tables().size(0), 10);
+
+  speculative_config.enable_atb_spec_kernel(original_enable_atb_spec_kernel);
 }
 
 TEST(AclGraphExecutorHybridTest, KvCacheSupportsLinearOnlyLayers) {

--- a/xllm/core/runtime/acl_graph_persistent_param.cpp
+++ b/xllm/core/runtime/acl_graph_persistent_param.cpp
@@ -162,7 +162,11 @@ GraphPersistentParam::GraphPersistentParam(const ModelArgs& args,
   // only serves decode / spec-verify batches, so the relevant row upper bound
   // comes from decode graph capacity instead.
   const int64_t max_graph_tokens = get_decode_graph_token_capacity(options);
-  const int64_t max_seqs_per_batch = get_decode_graph_capacity(options);
+  // Hybrid spec verify keeps sequence-scoped metadata, while non-hybrid MTP
+  // expands every proposal token into its own decode metadata row.
+  const int64_t metadata_capacity = is_hybrid_linear_attention
+                                        ? get_decode_graph_capacity(options)
+                                        : max_graph_tokens;
 
   const int64_t max_seq_len = args_.max_position_embeddings();
 
@@ -182,18 +186,17 @@ GraphPersistentParam::GraphPersistentParam(const ModelArgs& args,
   persistent_new_cache_slots_default_ = torch::zeros(
       {max_tokens_per_batch}, torch::dtype(torch::kInt).device(device));
   persistent_linear_state_indices_ = torch::zeros(
-      {max_seqs_per_batch}, torch::dtype(torch::kInt).device(device));
+      {metadata_capacity}, torch::dtype(torch::kInt).device(device));
   persistent_num_accepted_tokens_ = torch::ones(
-      {max_seqs_per_batch}, torch::dtype(torch::kInt).device(device));
+      {metadata_capacity}, torch::dtype(torch::kInt).device(device));
 
-  // Sequence length tensors with max_seqs_per_batch
-  q_seq_lens_ = torch::zeros({max_seqs_per_batch},
+  q_seq_lens_ = torch::zeros({metadata_capacity},
                              torch::dtype(torch::kInt).device(device));
-  kv_seq_lens_ = torch::zeros({max_seqs_per_batch},
+  kv_seq_lens_ = torch::zeros({metadata_capacity},
                               torch::dtype(torch::kInt).device(device));
-  q_seq_lens_default_ = torch::ones({max_seqs_per_batch},
+  q_seq_lens_default_ = torch::ones({metadata_capacity},
                                     torch::dtype(torch::kInt).device(device));
-  kv_seq_lens_default_ = torch::ones({max_seqs_per_batch},
+  kv_seq_lens_default_ = torch::ones({metadata_capacity},
                                      torch::dtype(torch::kInt).device(device));
   expanded_kv_seq_lens_ = torch::zeros(
       {max_tokens_per_batch}, torch::dtype(torch::kInt).device(device));
@@ -203,10 +206,10 @@ GraphPersistentParam::GraphPersistentParam(const ModelArgs& args,
   const int64_t max_block_table_len =
       (max_seq_len + block_size - 1) / block_size + 1;
   persistent_block_tables_ =
-      torch::zeros({max_seqs_per_batch, max_block_table_len},
+      torch::zeros({metadata_capacity, max_block_table_len},
                    torch::dtype(torch::kInt).device(device));
   persistent_block_tables_default_ =
-      torch::zeros({max_seqs_per_batch, max_block_table_len},
+      torch::zeros({metadata_capacity, max_block_table_len},
                    torch::dtype(torch::kInt).device(device));
   persistent_expanded_block_tables_ =
       torch::zeros({max_tokens_per_batch, max_block_table_len},
@@ -243,8 +246,8 @@ GraphPersistentParam::GraphPersistentParam(const ModelArgs& args,
   }
 
   q_cu_seq_lens_default_ = torch::zeros(
-      {max_seqs_per_batch + 1}, torch::dtype(torch::kInt).device(device));
-  q_cu_seq_lens_ = torch::zeros({max_seqs_per_batch + 1},
+      {metadata_capacity + 1}, torch::dtype(torch::kInt).device(device));
+  q_cu_seq_lens_ = torch::zeros({metadata_capacity + 1},
                                 torch::dtype(torch::kInt).device(device));
 
   // Pre-allocate persistent dp/cp ep padding buffers with maximum capacity.
@@ -782,9 +785,15 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
 
   if (persistent_block_tables_default_.defined() &&
       persistent_block_tables_default_.sizes() ==
-          persistent_block_tables_.sizes()) {
-    persistent_block_tables_.copy_(persistent_block_tables_default_,
-                                   /*non_blocking=*/true);
+          persistent_block_tables_.sizes() &&
+      padded_batch_size > 0) {
+    CHECK_LE(padded_batch_size, persistent_block_tables_.size(0))
+        << "padded graph metadata rows exceed persistent block table capacity";
+    persistent_block_tables_
+        .slice(/*dim=*/0, /*start=*/0, /*end=*/padded_batch_size)
+        .copy_(persistent_block_tables_default_.slice(
+                   /*dim=*/0, /*start=*/0, /*end=*/padded_batch_size),
+               /*non_blocking=*/true);
   }
   if (actual_seq_len_rows > 0 &&
       params.attention.device.block_tables.defined() &&

--- a/xllm/core/runtime/forward_params.h
+++ b/xllm/core/runtime/forward_params.h
@@ -908,6 +908,9 @@ struct ForwardOutput {
   // Keep no-sync input tensor handles alive until downstream consumers finish
   // using outputs on the same compute stream.
   std::shared_ptr<ForwardInput> retained_input;
+  // Composite workers retain nested no-sync inputs until their final output is
+  // synchronized or its ready event is consumed.
+  std::vector<std::shared_ptr<ForwardInput>> retained_input_dependencies;
   // Device-side readiness dependency for no-sync outputs. This local runtime
   // handle is intentionally not included in proto or shared-memory transport.
   StreamEventPtr ready_event;

--- a/xllm/core/runtime/llm_worker_impl.cpp
+++ b/xllm/core/runtime/llm_worker_impl.cpp
@@ -123,7 +123,8 @@ std::optional<ForwardOutput> LLMWorkerImpl::step_no_sync(
 
 std::optional<ForwardOutput> LLMWorkerImpl::execute_no_sync_on_stream(
     const ForwardInput& input,
-    Stream& compute_stream) {
+    Stream& compute_stream,
+    bool record_ready_event) {
   const ForwardSyncPolicy sync_policy = ForwardSyncPolicy::NO_SYNC;
   c10::StreamGuard stream_guard = compute_stream.set_stream_guard();
   if (::xllm::LoadConfig::get_instance().enable_manual_loader()) {
@@ -135,19 +136,19 @@ std::optional<ForwardOutput> LLMWorkerImpl::execute_no_sync_on_stream(
           const_cast<atb::Context*>(context_.get_atb_context());
       atb_context->SetExecuteStream(current_acl_stream);
       wait_input_ready_events(input, compute_stream);
-      return step_internal(input, sync_policy);
+      return step_internal(input, sync_policy, record_ready_event);
     } else {
       SET_ATB_EXECUTE_STREAM((&compute_stream), device_, context_);
       wait_input_ready_events(input, compute_stream);
-      return step_internal(input, sync_policy);
+      return step_internal(input, sync_policy, record_ready_event);
     }
 #else
     wait_input_ready_events(input, compute_stream);
-    return step_internal(input, sync_policy);
+    return step_internal(input, sync_policy, record_ready_event);
 #endif
   }
   wait_input_ready_events(input, compute_stream);
-  return step_internal(input, sync_policy);
+  return step_internal(input, sync_policy, record_ready_event);
 }
 
 std::optional<ForwardOutput> LLMWorkerImpl::step(const ForwardInput& input) {
@@ -212,7 +213,8 @@ LLMWorkerImpl::update_input_by_last_step_output_for_schedule_overlap(
 
 std::optional<ForwardOutput> LLMWorkerImpl::step_internal(
     const ForwardInput& input,
-    ForwardSyncPolicy sync_policy) {
+    ForwardSyncPolicy sync_policy,
+    bool record_ready_event) {
   MULTI_MODEL_STEP_LOCK(::xllm::KVCacheConfig::get_instance().enable_xtensor());
 
   Timer timer;
@@ -381,7 +383,7 @@ std::optional<ForwardOutput> LLMWorkerImpl::step_internal(
 #endif
   if (sync_policy == ForwardSyncPolicy::NO_SYNC) {
     output.retained_input = std::make_shared<ForwardInput>(input);
-    if (enable_schedule_overlap()) {
+    if (enable_schedule_overlap() && record_ready_event) {
       output.ready_event = record_current_stream_event(device_);
     }
     return output;

--- a/xllm/core/runtime/llm_worker_impl.h
+++ b/xllm/core/runtime/llm_worker_impl.h
@@ -51,14 +51,16 @@ class LLMWorkerImpl : public WorkerImpl {
   std::optional<ForwardOutput> step_no_sync(const ForwardInput& input);
   std::optional<ForwardOutput> execute_no_sync_on_stream(
       const ForwardInput& input,
-      Stream& compute_stream);
+      Stream& compute_stream,
+      bool record_ready_event = true);
 
   folly::SemiFuture<std::optional<ForwardOutput>> step_async_no_sync(
       const ForwardInput& input);
 
   std::optional<ForwardOutput> step_internal(
       const ForwardInput& input,
-      ForwardSyncPolicy sync_policy = ForwardSyncPolicy::LEGACY);
+      ForwardSyncPolicy sync_policy = ForwardSyncPolicy::LEGACY,
+      bool record_ready_event = true);
 
  protected:
   std::optional<ForwardOutput> step_for_schedule_overlap(

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -131,6 +131,51 @@ void wait_metadata_ready_event(const ForwardInput& input, Stream& stream) {
       << "failed to wait speculative metadata ready event";
 }
 
+void record_output_ready_event(ForwardOutput& output, Stream& stream) {
+  StreamEventPtr event = stream.record_event();
+  if (event == nullptr) {
+    const int32_t ret = stream.synchronize();
+    CHECK_EQ(ret, 0) << "failed to synchronize MTP compute stream, ret=" << ret;
+  }
+  output.ready_event = event;
+}
+
+void transfer_retained_inputs(ForwardOutput& destination,
+                              ForwardOutput& source) {
+  const size_t retained_input_count =
+      source.retained_input_dependencies.size() +
+      (source.retained_input != nullptr ? 1 : 0);
+  destination.retained_input_dependencies.reserve(
+      destination.retained_input_dependencies.size() + retained_input_count);
+  if (source.retained_input != nullptr) {
+    destination.retained_input_dependencies.emplace_back(
+        std::move(source.retained_input));
+  }
+  for (std::shared_ptr<ForwardInput>& retained_input :
+       source.retained_input_dependencies) {
+    destination.retained_input_dependencies.emplace_back(
+        std::move(retained_input));
+  }
+  source.retained_input_dependencies.clear();
+}
+
+void release_retained_inputs(ForwardOutput& output) {
+  output.retained_input.reset();
+  output.retained_input_dependencies.clear();
+}
+
+void finalize_output_on_stream(ForwardOutput& output,
+                               Stream& stream,
+                               bool allow_async) {
+  if (allow_async) {
+    record_output_ready_event(output, stream);
+    return;
+  }
+  const int32_t ret = stream.synchronize();
+  CHECK_EQ(ret, 0) << "failed to synchronize MTP compute stream, ret=" << ret;
+  release_retained_inputs(output);
+}
+
 #if defined(USE_NPU)
 void clear_expanded_spec_verify_graph_input(ModelInputParams& input_params) {
   input_params.graph.use_expanded_decode_for_spec_verify_attention = false;
@@ -255,11 +300,8 @@ std::optional<ForwardOutput> run_llm_no_sync_impl(
     ForwardInput& processed_input) {
   worker.prepare_work_before_execute_on_stream(
       input, processed_input, prepare_stream);
-  std::optional<ForwardOutput> output =
-      worker.execute_no_sync_on_stream(processed_input, compute_stream);
-  const int32_t ret = compute_stream.synchronize();
-  CHECK_EQ(ret, 0) << "failed to synchronize MTP compute stream, ret=" << ret;
-  return output;
+  return worker.execute_no_sync_on_stream(
+      processed_input, compute_stream, /*record_ready_event=*/false);
 }
 
 torch::Tensor clone_host_tensor(const torch::Tensor& tensor) {
@@ -770,37 +812,40 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_empty(
                                              *prepare_stream_,
                                              *compute_stream_,
                                              draft_prepared);
-    (void)draft_output;
+    if (draft_output.has_value()) {
+      transfer_retained_inputs(*output, draft_output.value());
+    }
     clear_all_output_embeddings(*output);
+    finalize_output_on_stream(
+        *output, *compute_stream_, enable_schedule_overlap());
     return output;
   } else {
     ForwardInput draft_extend_prepared;
     std::vector<ForwardInput> draft_step_prepared(
         options_.num_speculative_tokens());
     ForwardInput target_prepared;
+    std::vector<ForwardOutput> draft_outputs;
+    draft_outputs.reserve(options_.num_speculative_tokens());
 
     ForwardInput new_input = input;
     for (int32_t& token_num :
          new_input.input_params.parallel.dp_global_token_nums) {
       token_num *= 2;
     }
-    ForwardOutput draft_extend_output =
-        run_llm_no_sync_impl(*draft_impl_,
-                             new_input,
-                             *prepare_stream_,
-                             *compute_stream_,
-                             draft_extend_prepared)
-            .value();
-    (void)draft_extend_output;
+    draft_outputs.emplace_back(run_llm_no_sync_impl(*draft_impl_,
+                                                    new_input,
+                                                    *prepare_stream_,
+                                                    *compute_stream_,
+                                                    draft_extend_prepared)
+                                   .value());
 
     for (int32_t i = 1; i < options_.num_speculative_tokens(); ++i) {
-      ForwardOutput draft_output = run_llm_no_sync_impl(*draft_impl_,
-                                                        input,
-                                                        *prepare_stream_,
-                                                        *compute_stream_,
-                                                        draft_step_prepared[i])
-                                       .value();
-      (void)draft_output;
+      draft_outputs.emplace_back(run_llm_no_sync_impl(*draft_impl_,
+                                                      input,
+                                                      *prepare_stream_,
+                                                      *compute_stream_,
+                                                      draft_step_prepared[i])
+                                     .value());
     }
 
     new_input = input;
@@ -814,7 +859,12 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_empty(
                                                 *compute_stream_,
                                                 target_prepared)
                                .value();
+    for (ForwardOutput& draft_output : draft_outputs) {
+      transfer_retained_inputs(output, draft_output);
+    }
     clear_all_output_embeddings(output);
+    finalize_output_on_stream(
+        output, *compute_stream_, enable_schedule_overlap());
     return output;
   }
 }
@@ -840,28 +890,30 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_prefill(
   // prepare input for draft model
   auto& embeddings = output.sample_output.embeddings;
 
-  if (embeddings.defined()) {
-    prefill_input.input_params.embedding.input_embedding = embeddings.clone();
-  }
-  if (output.sample_output.next_tokens.defined()) {
+  {
     c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
-    const auto& extra_token_ids =
-        prefill_input.input_params.embedding.extra_token_ids;
-    if (options_.cp_size() > 1 &&
-        has_mtp_prefill_placeholder_extra_token(extra_token_ids, -1)) {
-      apply_cp_mtp_prefill_target_tokens(prefill_input,
-                                         output.sample_output.next_tokens,
-                                         -1,
-                                         prefill_input.token_ids.options());
-    } else {
-      replace_host_token_placeholders(prefill_input,
-                                      -1,
-                                      output.sample_output.next_tokens,
-                                      prefill_input.token_ids.options());
+    if (embeddings.defined()) {
+      prefill_input.input_params.embedding.input_embedding = embeddings.clone();
     }
-  }
-  if (embeddings.defined() || output.sample_output.next_tokens.defined()) {
-    record_current_metadata_ready_event(prefill_input, *compute_stream_);
+    if (output.sample_output.next_tokens.defined()) {
+      const auto& extra_token_ids =
+          prefill_input.input_params.embedding.extra_token_ids;
+      if (options_.cp_size() > 1 &&
+          has_mtp_prefill_placeholder_extra_token(extra_token_ids, -1)) {
+        apply_cp_mtp_prefill_target_tokens(prefill_input,
+                                           output.sample_output.next_tokens,
+                                           -1,
+                                           prefill_input.token_ids.options());
+      } else {
+        replace_host_token_placeholders(prefill_input,
+                                        -1,
+                                        output.sample_output.next_tokens,
+                                        prefill_input.token_ids.options());
+      }
+    }
+    if (embeddings.defined() || output.sample_output.next_tokens.defined()) {
+      record_current_metadata_ready_event(prefill_input, *compute_stream_);
+    }
   }
   // generate kv cache for draft model
   timer.reset();
@@ -871,11 +923,15 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_prefill(
                                                     *compute_stream_,
                                                     draft_prepared)
                                    .value();
-  process_draft_sample_output(draft_output.sample_output);
+  {
+    c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
+    process_draft_sample_output(draft_output.sample_output);
+  }
   COUNTER_ADD(speculative_execution_latency_seconds_draft,
               timer.elapsed_seconds());
 
   if (input.sampling_params.selected_token_idxes.defined()) {
+    c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
     // Under CP the target prefill `embeddings` is the full local token shard,
     // which cannot be indexed by the CP all-gather-space selected indices.
     // Prefer the LmHead-gathered per-sequence hidden when present so the cache
@@ -906,6 +962,10 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_prefill(
   } else {
     clear_all_output_embeddings(output);
   }
+
+  transfer_retained_inputs(output, draft_output);
+  finalize_output_on_stream(
+      output, *compute_stream_, enable_schedule_overlap());
 
   if (!enable_schedule_overlap() && !driver_ && !dp_driver_) {
     return std::nullopt;
@@ -1057,23 +1117,25 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
         << "draft output is empty in speculative step";
 
     draft_outputs.emplace_back(std::move(draft_output_opt.value()));
-    if (reuse_mtp_topk_indices) {
-      mtp_topk_indices = select_mtp_topk_indices_for_next_step(
-          draft_outputs.back().dsa_topk_indices,
-          current_draft_input.sampling_params);
-    }
-    // Unify this step's draft next_tokens across the consensus group before
-    // process_draft_sample_output() compresses the still-full [batch, vocab]
-    // probs into the cache: gathering the cached prob with a unified token
-    // yields a unified prob, so we only broadcast the [batch] token tensor
-    if (get_optimization_config().enable_spec_token_broadcast &&
-        enable_schedule_overlap()) {
+    {
       c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
-      SampleOutput& draft_sample = draft_outputs.back().sample_output;
-      broadcast_spec_tokens(draft_sample.next_tokens,
-                            spec_broadcast_group(parallel_args_));
+      if (reuse_mtp_topk_indices) {
+        mtp_topk_indices = select_mtp_topk_indices_for_next_step(
+            draft_outputs.back().dsa_topk_indices,
+            current_draft_input.sampling_params);
+      }
+      // Unify this step's draft next_tokens across the consensus group before
+      // process_draft_sample_output() compresses the still-full [batch, vocab]
+      // probs into the cache: gathering the cached prob with a unified token
+      // yields a unified prob, so we only broadcast the [batch] token tensor.
+      if (get_optimization_config().enable_spec_token_broadcast &&
+          enable_schedule_overlap()) {
+        SampleOutput& draft_sample = draft_outputs.back().sample_output;
+        broadcast_spec_tokens(draft_sample.next_tokens,
+                              spec_broadcast_group(parallel_args_));
+      }
+      process_draft_sample_output(draft_outputs.back().sample_output);
     }
-    process_draft_sample_output(draft_outputs.back().sample_output);
     if (draft_idx == num_speculative_tokens - 1) {
       continue;
     }
@@ -1087,9 +1149,8 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
     if (last_output.embeddings.defined()) {
       current_draft_input.input_params.embedding.input_embedding =
           last_output.embeddings;
-      record_current_metadata_ready_event(current_draft_input,
-                                          *compute_stream_);
     }
+    record_current_metadata_ready_event(current_draft_input, *compute_stream_);
   }
   COUNTER_ADD(speculative_execution_latency_seconds_draft,
               timer.elapsed_seconds());
@@ -1133,6 +1194,7 @@ void MTPWorkerImpl::fill_validate_input_from_draft_outputs(
         .copy_(draft_tokens, /*non_blocking=*/true);
   }
   validate_input.device_tensors_ready = true;
+  record_metadata_ready_event(compute_stream, validate_input);
 }
 
 std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
@@ -1155,8 +1217,11 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
 
   // verify the proposals with target and update the batch
   timer.reset();
-  SampleOutput val_output =
-      validate(input.sampling_params, draft_outputs, target_output);
+  SampleOutput val_output;
+  {
+    c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
+    val_output = validate(input.sampling_params, draft_outputs, target_output);
+  }
   COUNTER_ADD(speculative_execution_latency_seconds_validation,
               timer.elapsed_seconds());
 
@@ -1170,7 +1235,9 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
                           spec_broadcast_group(parallel_args_));
   }
 
-  compute_stream_->synchronize();
+  const int32_t ret = compute_stream_->synchronize();
+  CHECK_EQ(ret, 0) << "failed to synchronize MTP compute stream, ret=" << ret;
+  release_retained_inputs(target_output);
   val_output.next_tokens = val_output.next_tokens.to(torch::kCPU);
   write_target_context_to_cache(input, val_output);
 


### PR DESCRIPTION
- replace per-forward stream synchronization with retained input and ready-event dependencies
- size non-hybrid speculative graph metadata by decode token capacity
- cover expanded graph metadata rows with an NPU regression test

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
