### PR TITLE
bugfix: initialize Python for NPU C++ tests.

### DIFF
--- a/cmake/cc_test.cmake
+++ b/cmake/cc_test.cmake
@@ -113,6 +113,9 @@ function(cc_test)
   )
 
   if(USE_NPU)
+    target_sources(${CC_TEST_NAME} PRIVATE
+      "${PROJECT_SOURCE_DIR}/tests/npu_test_environment.cpp"
+    )
     set(COMMON_LIBS Python::Python torch_npu torch_python)
     target_link_libraries(${CC_TEST_NAME} PRIVATE ${COMMON_LIBS})
   endif()

--- a/tests/core/kernels/npu/npu_xllm_ops_test.cpp
+++ b/tests/core/kernels/npu/npu_xllm_ops_test.cpp
@@ -75,11 +75,11 @@ class NpuXllmOpsTest : public ::testing::Test {
     if (!Py_IsInitialized()) {
       setenv("TORCH_DEVICE_BACKEND_AUTOLOAD", "0", 1);
       Py_InitializeEx(0);
-      py::gil_scoped_acquire gil;
-      prepend_python_model_path();
-      py::module_::import("xllm.python._npu_bootstrap");
-      py::module_::import("xllm.python");
     }
+    py::gil_scoped_acquire gil;
+    prepend_python_model_path();
+    py::module_::import("xllm.python._npu_bootstrap");
+    py::module_::import("xllm.python");
   }
 };
 

--- a/tests/npu_test_environment.cpp
+++ b/tests/npu_test_environment.cpp
@@ -1,0 +1,38 @@
+/* Copyright 2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <Python.h>
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+
+namespace {
+
+class NpuPythonEnvironment : public ::testing::Environment {
+ public:
+  void SetUp() override {
+    if (Py_IsInitialized()) {
+      return;
+    }
+
+    setenv("TORCH_DEVICE_BACKEND_AUTOLOAD", "0", 1);
+    Py_InitializeEx(0);
+  }
+};
+
+::testing::Environment* const kNpuPythonEnvironment =
+    ::testing::AddGlobalTestEnvironment(new NpuPythonEnvironment);
+
+}  // namespace


### PR DESCRIPTION
The torch_npu 2.9 upgrade introduced by 062ff4dd requires a live embedded Python interpreter when NPU tensor allocation acquires the GIL. Initialize Python before NPU test suites run and keep the xllm_ops bootstrap independent from interpreter ownership.

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
