### PR TITLE
refactor: decouple SINGLE block into EMBEDDING slot and LINEAR conv/ssm group.

### DIFF
--- a/tests/core/framework/batch/batch_test.cpp
+++ b/tests/core/framework/batch/batch_test.cpp
@@ -482,11 +482,13 @@ TEST(BatchTest, DecodeForwardInputConsumesMtpBootstrap) {
   BlockManagerPool::Options options;
   options.num_blocks(8).block_size(4).enable_disagg_pd(true);
   options.max_seqs_per_batch(1024);
+  options.num_speculative_tokens(1);
+  options.num_embedding_blocks(8);
   BlockManagerPool manager(options, /*dp_size=*/1);
 
   Sequence sequence = make_basic_sequence({1, 2, 3});
   ASSERT_TRUE(manager.allocate(&sequence));
-  ASSERT_GE(sequence.get_single_block_id(), 0);
+  ASSERT_GE(sequence.get_embedding_block_id(), 0);
   sequence.kv_state().set_kv_cache_tokens_num(sequence.num_prompt_tokens());
   sequence.append_token(Token(42));
 
@@ -509,6 +511,8 @@ TEST(BatchTest, DecodeForwardInputMapsSparseMtpBootstrapRows) {
   BlockManagerPool::Options options;
   options.num_blocks(8).block_size(4).enable_disagg_pd(true);
   options.max_seqs_per_batch(1024);
+  options.num_speculative_tokens(1);
+  options.num_embedding_blocks(8);
   BlockManagerPool manager(options, /*dp_size=*/1);
 
   Sequence first = make_basic_sequence({1, 2, 3});
@@ -1300,7 +1304,7 @@ TEST(BatchTest, DecodeMinBatchSizeDoesNotPadTransportState) {
             std::vector<int32_t>({-1}));
 }
 
-TEST(BatchTest, DecodeSingleBlockIdsStaySplitInTransportButShareSlotValue) {
+TEST(BatchTest, DecodeEmbeddingAndLinearStateIdsAreIndependentSlots) {
   const uint32_t n_blocks = 8;
   const uint32_t block_size = 4;
   BlockManager::Options options;
@@ -1328,10 +1332,19 @@ TEST(BatchTest, DecodeSingleBlockIdsStaySplitInTransportButShareSlotValue) {
   seq.kv_state().incr_kv_cache_tokens_num(/*size=*/3);
   seq.append_token(4);
 
-  auto slot_block = manager.allocate(1);
-  ASSERT_EQ(slot_block.size(), 1u);
-  const int32_t expected_slot_id = slot_block[0].id();
-  seq.add_blocks(BlockType::SINGLE, slot_block);
+  // EMBEDDING and LINEAR are now fully decoupled slots: the embedding-row id
+  // (embedding_ids) and the recurrent-state id (linear_state_ids) come from
+  // separate blocks and no longer share a value.
+  auto embedding_block = manager.allocate(1);
+  ASSERT_EQ(embedding_block.size(), 1u);
+  const int32_t expected_embedding_id = embedding_block[0].id();
+  seq.add_blocks(BlockType::EMBEDDING, embedding_block);
+
+  auto linear_block = manager.allocate(1);
+  ASSERT_EQ(linear_block.size(), 1u);
+  const int32_t expected_linear_id = linear_block[0].id();
+  seq.add_blocks(BlockType::LINEAR, linear_block);
+  ASSERT_NE(expected_embedding_id, expected_linear_id);
 
   std::vector<Sequence*> sequences = {&seq};
   std::vector<uint32_t> allowed_max_tokens = {1};
@@ -1355,9 +1368,9 @@ TEST(BatchTest, DecodeSingleBlockIdsStaySplitInTransportButShareSlotValue) {
   ASSERT_EQ(forward_input.input_params.embedding.embedding_ids.size(), 1u);
   ASSERT_EQ(forward_input.input_params.embedding.linear_state_ids.size(), 1u);
   EXPECT_EQ(forward_input.input_params.embedding.embedding_ids[0],
-            expected_slot_id);
+            expected_embedding_id);
   EXPECT_EQ(forward_input.input_params.embedding.linear_state_ids[0],
-            expected_slot_id);
+            expected_linear_id);
 }
 
 TEST(BatchTest, LinearStateCheckpointSavesOnlyAtPrefillStepBoundary) {

--- a/tests/core/framework/block/CMakeLists.txt
+++ b/tests/core/framework/block/CMakeLists.txt
@@ -18,7 +18,7 @@ if(USE_NPU)
       block_test
     SRCS
       block_manager_test.cpp
-      single_block_manager_test.cpp
+      embedding_block_manager_test.cpp
       composite_block_manager_test.cpp
     DEPS
       :xllm_server

--- a/tests/core/framework/block/block_manager_test.cpp
+++ b/tests/core/framework/block/block_manager_test.cpp
@@ -163,10 +163,11 @@ BlockManagerPool::Options make_linear_state_pool_options(
   BlockManagerPool::Options options;
   options.num_blocks(8).host_num_blocks(0).block_size(4).enable_prefix_cache(
       true);
-  // Zero out max_seqs_per_batch so the SINGLE pool is sized purely by
-  // num_single_blocks (otherwise the pool takes the max of the two).
+  // The EMBEDDING pool is sized directly by num_embedding_blocks and is only
+  // built under spec decode, so opt in here.
   options.max_seqs_per_batch(0)
-      .num_single_blocks(4)
+      .num_embedding_blocks(4)
+      .num_speculative_tokens(1)
       .enable_linear_state(true)
       .linear_state_num_slots(linear_state_num_slots);
   return options;
@@ -280,7 +281,8 @@ TEST(BlockManagerPoolTest, AllocateAssignsSingleBlockWhenEnabled) {
   BlockManagerPool::Options options;
   options.num_blocks(8).host_num_blocks(0).block_size(1).enable_prefix_cache(
       false);
-  options.num_single_blocks(FLAGS_max_seqs_per_batch + 2)
+  options.num_embedding_blocks(FLAGS_max_seqs_per_batch + 2)
+      .num_speculative_tokens(1)
       .enable_linear_state(true)
       .linear_state_num_slots(64);
   ScopedValue<int32_t> chunk_guard(
@@ -289,10 +291,10 @@ TEST(BlockManagerPoolTest, AllocateAssignsSingleBlockWhenEnabled) {
 
   Sequence seq = make_sequence(0, /*prompt_tokens=*/{1, 2, 3});
   EXPECT_TRUE(pool.allocate(&seq));
-  EXPECT_TRUE(seq.get_single_block_id() >= 0);
+  EXPECT_TRUE(seq.get_embedding_block_id() >= 0);
   // id 0 is the reserved padding slot, so a real assignment is strictly
   // positive.
-  EXPECT_GT(seq.get_single_block_id(), 0);
+  EXPECT_GT(seq.get_embedding_block_id(), 0);
 }
 
 TEST(BlockManagerPoolTest, DeallocateReleasesSingleBlockId) {
@@ -302,7 +304,8 @@ TEST(BlockManagerPoolTest, DeallocateReleasesSingleBlockId) {
   BlockManagerPool::Options options;
   options.num_blocks(8).host_num_blocks(0).block_size(1).enable_prefix_cache(
       false);
-  options.num_single_blocks(FLAGS_max_seqs_per_batch + 2)
+  options.num_embedding_blocks(FLAGS_max_seqs_per_batch + 2)
+      .num_speculative_tokens(1)
       .enable_linear_state(true)
       .linear_state_num_slots(64);
   ScopedValue<int32_t> chunk_guard(
@@ -311,26 +314,31 @@ TEST(BlockManagerPoolTest, DeallocateReleasesSingleBlockId) {
 
   Sequence seq1 = make_sequence(0, /*prompt_tokens=*/{1, 2, 3});
   ASSERT_TRUE(pool.allocate(&seq1));
-  const int32_t id1 = seq1.get_single_block_id();
+  const int32_t id1 = seq1.get_embedding_block_id();
   pool.deallocate(&seq1);
-  EXPECT_FALSE(seq1.get_single_block_id() >= 0);
+  EXPECT_FALSE(seq1.get_embedding_block_id() >= 0);
 
   Sequence seq2 = make_sequence(1, /*prompt_tokens=*/{4, 5, 6});
   ASSERT_TRUE(pool.allocate(&seq2));
-  EXPECT_EQ(seq2.get_single_block_id(), id1);
+  EXPECT_EQ(seq2.get_embedding_block_id(), id1);
 }
 
-TEST(BlockManagerPoolTest, SingleBlockCapacityUsesOptionsMaxSeqs) {
+TEST(BlockManagerPoolTest, EmbeddingBlockCapacityUsesNumEmbeddingBlocks) {
   ScopedValue<int32_t> max_seqs_guard(
       &SchedulerConfig::get_instance().max_seqs_per_batch(), 0);
 
   BlockManagerPool::Options options;
+  // The EMBEDDING pool is sized directly by num_embedding_blocks (id 0 is
+  // reserved for padding, so 5 exposes 4 usable ids for the 4 sequences).
   options.num_blocks(16)
       .host_num_blocks(0)
       .block_size(1)
       .enable_prefix_cache(false)
       .max_seqs_per_batch(4);
-  options.enable_linear_state(true).linear_state_num_slots(64);
+  options.num_embedding_blocks(5)
+      .num_speculative_tokens(1)
+      .enable_linear_state(true)
+      .linear_state_num_slots(64);
   ScopedValue<int32_t> chunk_guard(
       &SchedulerConfig::get_instance().max_tokens_per_chunk_for_prefill(), 4);
   BlockManagerPool pool(options, /*dp_size=*/1);
@@ -340,7 +348,7 @@ TEST(BlockManagerPoolTest, SingleBlockCapacityUsesOptionsMaxSeqs) {
   for (size_t i = 0; i < 4; ++i) {
     sequences.emplace_back(make_sequence(i, /*prompt_tokens=*/{1}));
     EXPECT_TRUE(pool.allocate(&sequences.back()));
-    EXPECT_TRUE(sequences.back().get_single_block_id() >= 0);
+    EXPECT_TRUE(sequences.back().get_embedding_block_id() >= 0);
   }
 }
 
@@ -350,9 +358,11 @@ TEST(BlockManagerPoolTest, TryAllocateKvFailureRollsBackSingleBlock) {
       false);
   // id 0 is reserved for padding, so capacity 3 exposes 2 usable single-block
   // ids, enough for the two sequences allocated after the rollback. Zero out
-  // max_seqs_per_batch so num_single_blocks alone drives the SINGLE pool size.
+  // max_seqs_per_batch so num_embedding_blocks alone drives the EMBEDDING pool
+  // size.
   options.max_seqs_per_batch(0)
-      .num_single_blocks(3)
+      .num_embedding_blocks(3)
+      .num_speculative_tokens(1)
       .enable_linear_state(true)
       .linear_state_num_slots(64);
   ScopedValue<int32_t> chunk_guard(
@@ -364,7 +374,7 @@ TEST(BlockManagerPoolTest, TryAllocateKvFailureRollsBackSingleBlock) {
   std::vector<int32_t> huge_prompt(100, 1);
   Sequence fail_seq = make_sequence(0, huge_prompt);
   EXPECT_FALSE(pool.try_allocate(&fail_seq));
-  EXPECT_FALSE(fail_seq.get_single_block_id() >= 0);
+  EXPECT_FALSE(fail_seq.get_embedding_block_id() >= 0);
 
   // The unified slot must have been rolled back, leaving enough capacity for
   // two new sequences to allocate.
@@ -372,25 +382,24 @@ TEST(BlockManagerPoolTest, TryAllocateKvFailureRollsBackSingleBlock) {
   Sequence seq2 = make_sequence(2, /*prompt_tokens=*/{2});
   EXPECT_TRUE(pool.try_allocate(&seq1));
   EXPECT_TRUE(pool.try_allocate(&seq2));
-  EXPECT_TRUE(seq1.get_single_block_id() >= 0);
-  EXPECT_TRUE(seq2.get_single_block_id() >= 0);
+  EXPECT_TRUE(seq1.get_embedding_block_id() >= 0);
+  EXPECT_TRUE(seq2.get_embedding_block_id() >= 0);
 }
 
 TEST(BlockManagerPoolTest, SingleBlockCapacityCanBeLowerThanMaxSeqs) {
   BlockManagerPool::Options options;
-  // id 0 is reserved for padding, so capacity 4 exposes 3 usable single blocks.
-  // max_seqs_per_batch is 8 in the scheduler view, but num_single_blocks caps
-  // the SINGLE pool at 4 (pool takes the max, so num_single_blocks wins only
-  // when it is >= max_seqs_per_batch + 2 -- here it is 4 vs 8+2=10, so the
-  // 8+2 path would win; force num_single_blocks to be the winner by lowering
-  // the scheduler side).
+  // The EMBEDDING pool is sized directly by num_embedding_blocks, independent
+  // of max_seqs_per_batch. id 0 is reserved for padding, so 4 exposes 3 usable
+  // ids -- a deliberately smaller pool than the scheduler's max_seqs view.
   options.num_blocks(16)
       .host_num_blocks(0)
       .block_size(1)
       .max_seqs_per_batch(0)
-      .num_single_blocks(4)
+      .num_embedding_blocks(4)
       .enable_prefix_cache(false);
-  options.enable_linear_state(true).linear_state_num_slots(64);
+  options.num_speculative_tokens(1)
+      .enable_linear_state(true)
+      .linear_state_num_slots(64);
   ScopedValue<int32_t> chunk_guard(
       &SchedulerConfig::get_instance().max_tokens_per_chunk_for_prefill(), 4);
   BlockManagerPool pool(options, /*dp_size=*/1);
@@ -405,24 +414,26 @@ TEST(BlockManagerPoolTest, SingleBlockCapacityCanBeLowerThanMaxSeqs) {
   EXPECT_TRUE(pool.try_allocate(&seq2));
   EXPECT_FALSE(pool.try_allocate(&seq3));
 
-  EXPECT_TRUE(seq0.get_single_block_id() >= 0);
-  EXPECT_TRUE(seq1.get_single_block_id() >= 0);
-  EXPECT_TRUE(seq2.get_single_block_id() >= 0);
-  EXPECT_FALSE(seq3.get_single_block_id() >= 0);
+  EXPECT_TRUE(seq0.get_embedding_block_id() >= 0);
+  EXPECT_TRUE(seq1.get_embedding_block_id() >= 0);
+  EXPECT_TRUE(seq2.get_embedding_block_id() >= 0);
+  EXPECT_FALSE(seq3.get_embedding_block_id() >= 0);
 }
 
 TEST(BlockManagerPoolTest, DpRankSelectionSkipsExhaustedSingleBlockPool) {
   BlockManagerPool::Options options;
   // id 0 is reserved for padding, so capacity 2 exposes 1 usable block per
-  // rank. Zero out max_seqs_per_batch so num_single_blocks alone drives the
-  // SINGLE pool size.
+  // rank. Zero out max_seqs_per_batch so num_embedding_blocks alone drives the
+  // EMBEDDING pool size.
   options.num_blocks(16)
       .host_num_blocks(0)
       .block_size(1)
       .max_seqs_per_batch(0)
-      .num_single_blocks(2)
+      .num_embedding_blocks(2)
       .enable_prefix_cache(false);
-  options.enable_linear_state(true).linear_state_num_slots(64);
+  options.num_speculative_tokens(1)
+      .enable_linear_state(true)
+      .linear_state_num_slots(64);
   ScopedValue<int32_t> chunk_guard(
       &SchedulerConfig::get_instance().max_tokens_per_chunk_for_prefill(), 4);
   BlockManagerPool pool(options, /*dp_size=*/2);
@@ -439,15 +450,17 @@ TEST(BlockManagerPoolTest, DpRankSelectionSkipsExhaustedSingleBlockPool) {
 TEST(BlockManagerPoolTest, SingleBlockExhaustionBehavesLikeKvBlockExhaustion) {
   BlockManagerPool::Options options;
   // id 0 is reserved for padding, so capacity 2 exposes 1 usable block per
-  // rank. Zero out max_seqs_per_batch so num_single_blocks alone drives the
-  // SINGLE pool size.
+  // rank. Zero out max_seqs_per_batch so num_embedding_blocks alone drives the
+  // EMBEDDING pool size.
   options.num_blocks(16)
       .host_num_blocks(0)
       .block_size(1)
       .max_seqs_per_batch(0)
-      .num_single_blocks(2)
+      .num_embedding_blocks(2)
       .enable_prefix_cache(false);
-  options.enable_linear_state(true).linear_state_num_slots(64);
+  options.num_speculative_tokens(1)
+      .enable_linear_state(true)
+      .linear_state_num_slots(64);
   ScopedValue<int32_t> chunk_guard(
       &SchedulerConfig::get_instance().max_tokens_per_chunk_for_prefill(), 4);
   BlockManagerPool pool(options, /*dp_size=*/2);
@@ -473,11 +486,12 @@ TEST(BlockManagerPoolTest, AllocateAssignsSingleBlockWhenLinearStateDisabled) {
   BlockManagerPool::Options options;
   options.num_blocks(8).host_num_blocks(0).block_size(1).enable_prefix_cache(
       false);
+  options.num_speculative_tokens(1).num_embedding_blocks(4);
   BlockManagerPool pool(options, /*dp_size=*/1);
 
   Sequence seq = make_sequence(0, /*prompt_tokens=*/{1, 2});
   EXPECT_TRUE(pool.allocate(&seq));
-  EXPECT_TRUE(seq.get_single_block_id() >= 0);
+  EXPECT_TRUE(seq.get_embedding_block_id() >= 0);
 }
 
 TEST(BlockManagerPoolTest, CapacityReportsKvPoolWhenLinearStateEnabled) {
@@ -496,7 +510,7 @@ TEST(BlockManagerPoolTest, CapacityReportsKvPoolWhenLinearStateEnabled) {
       .host_num_blocks(0)
       .block_size(8)
       .enable_prefix_cache(false);
-  options.num_single_blocks(FLAGS_max_seqs_per_batch + 2)
+  options.num_embedding_blocks(FLAGS_max_seqs_per_batch + 2)
       .enable_linear_state(true)
       .linear_state_num_slots(kLinearStateSlots);
   ScopedValue<int32_t> chunk_guard(
@@ -519,7 +533,8 @@ TEST(BlockManagerPoolTest, SequenceCopyDoesNotReuseSingleBlockSlot) {
   BlockManagerPool::Options options;
   options.num_blocks(8).host_num_blocks(0).block_size(1).enable_prefix_cache(
       false);
-  options.num_single_blocks(FLAGS_max_seqs_per_batch + 2)
+  options.num_embedding_blocks(FLAGS_max_seqs_per_batch + 2)
+      .num_speculative_tokens(1)
       .enable_linear_state(true)
       .linear_state_num_slots(64);
   ScopedValue<int32_t> chunk_guard(
@@ -528,20 +543,20 @@ TEST(BlockManagerPoolTest, SequenceCopyDoesNotReuseSingleBlockSlot) {
 
   Sequence src = make_sequence(0, /*prompt_tokens=*/{1, 2, 3});
   ASSERT_TRUE(pool.allocate(&src));
-  ASSERT_TRUE(src.get_single_block_id() >= 0);
+  ASSERT_TRUE(src.get_embedding_block_id() >= 0);
   ASSERT_TRUE(src.has_linear_state_slot());
-  const int32_t src_single_block_id = src.get_single_block_id();
+  const int32_t src_single_block_id = src.get_embedding_block_id();
   const int32_t src_linear_state_slot_id = src.get_linear_state_slot_id();
 
   Sequence clone(src);
-  EXPECT_FALSE(clone.get_single_block_id() >= 0);
-  EXPECT_EQ(clone.get_single_block_id(), -1);
+  EXPECT_FALSE(clone.get_embedding_block_id() >= 0);
+  EXPECT_EQ(clone.get_embedding_block_id(), -1);
   EXPECT_FALSE(clone.has_linear_state_slot());
   EXPECT_EQ(clone.get_linear_state_slot_id(), -1);
 
   ASSERT_TRUE(pool.allocate(&clone));
-  EXPECT_TRUE(clone.get_single_block_id() >= 0);
-  EXPECT_NE(clone.get_single_block_id(), src_single_block_id);
+  EXPECT_TRUE(clone.get_embedding_block_id() >= 0);
+  EXPECT_NE(clone.get_embedding_block_id(), src_single_block_id);
   EXPECT_TRUE(clone.has_linear_state_slot());
   EXPECT_NE(clone.get_linear_state_slot_id(), src_linear_state_slot_id);
 }
@@ -575,7 +590,7 @@ TEST(BlockManagerPoolTest, LinearStateBlockManagerMatchesOnlyCheckpointHashes) {
   BlockManagerPool::Options options;
   options.num_blocks(8).host_num_blocks(0).block_size(4).enable_prefix_cache(
       true);
-  options.num_single_blocks(FLAGS_max_seqs_per_batch + 2)
+  options.num_embedding_blocks(FLAGS_max_seqs_per_batch + 2)
       .enable_linear_state(true)
       .linear_state_num_slots(64);
   ScopedValue<int32_t> chunk_guard(
@@ -631,7 +646,7 @@ TEST(BlockManagerPoolTest, ExactPromptCannotReuseUncheckpointedTailBoundary) {
   BlockManagerPool::Options options;
   options.num_blocks(32).host_num_blocks(0).block_size(4).enable_prefix_cache(
       true);
-  options.num_single_blocks(FLAGS_max_seqs_per_batch + 2)
+  options.num_embedding_blocks(FLAGS_max_seqs_per_batch + 2)
       .enable_linear_state(true)
       .linear_state_num_slots(64);
   ScopedValue<int32_t> chunk_guard(
@@ -670,7 +685,7 @@ TEST(BlockManagerPoolTest, PromptPastCheckpointReusesCheckpointBoundary) {
   BlockManagerPool::Options options;
   options.num_blocks(32).host_num_blocks(0).block_size(4).enable_prefix_cache(
       true);
-  options.num_single_blocks(FLAGS_max_seqs_per_batch + 2)
+  options.num_embedding_blocks(FLAGS_max_seqs_per_batch + 2)
       .enable_linear_state(true)
       .linear_state_num_slots(64);
   ScopedValue<int32_t> chunk_guard(
@@ -967,7 +982,7 @@ TEST(BlockManagerPoolTest, SparseLinearStateCheckpointTrimsSharedKVBlocks) {
     BlockManagerPool::Options options;
     options.num_blocks(48).host_num_blocks(0).block_size(4).enable_prefix_cache(
         true);
-    options.num_single_blocks(FLAGS_max_seqs_per_batch + 2)
+    options.num_embedding_blocks(FLAGS_max_seqs_per_batch + 2)
         .enable_linear_state(true)
         .linear_state_num_slots(64);
     ScopedValue<int32_t> chunk_guard(
@@ -1023,7 +1038,7 @@ TEST(BlockManagerPoolTest, SparseLinearStateCheckpointCannotExceedKVMatch) {
   BlockManagerPool::Options options;
   options.num_blocks(48).host_num_blocks(0).block_size(4).enable_prefix_cache(
       true);
-  options.num_single_blocks(FLAGS_max_seqs_per_batch + 2)
+  options.num_embedding_blocks(FLAGS_max_seqs_per_batch + 2)
       .enable_linear_state(true)
       .linear_state_num_slots(64);
   ScopedValue<int32_t> chunk_guard(
@@ -1073,7 +1088,7 @@ TEST(BlockManagerPoolTest, ExactPromptStopsAtEarlierCheckpoint) {
   BlockManagerPool::Options options;
   options.num_blocks(32).host_num_blocks(0).block_size(4).enable_prefix_cache(
       true);
-  options.num_single_blocks(FLAGS_max_seqs_per_batch + 2)
+  options.num_embedding_blocks(FLAGS_max_seqs_per_batch + 2)
       .enable_linear_state(true)
       .linear_state_num_slots(64);
   ScopedValue<int32_t> chunk_guard(

--- a/tests/core/framework/block/composite_block_manager_test.cpp
+++ b/tests/core/framework/block/composite_block_manager_test.cpp
@@ -734,7 +734,7 @@ TEST(CompositeBlockManagerTest, Dsv4PrefixCacheExactRepeatPopsOneC128) {
 // DSV4 D-side (instance_is_decode=true) should skip the SWA leaf's prefix
 // cache entirely: no shared blocks on SWA even when the same prompt was
 // previously seeded. C4 / C128 continue to hit because the role predicate
-// only masks SWA / LINEAR / SINGLE on the DECODE side. This is the mirror of
+// only masks SWA / LINEAR / EMBEDDING on the DECODE side. This is the mirror of
 // Dsv4PrefixCacheHitOnRepeatedPrefix under the DECODE role.
 TEST(CompositeBlockManagerTest, DecodeRoleSkipsSwaPrefixCache) {
   const uint32_t base_num_blocks = 4096;

--- a/tests/core/framework/block/embedding_block_manager_test.cpp
+++ b/tests/core/framework/block/embedding_block_manager_test.cpp
@@ -13,16 +13,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "single_block_manager.h"
+#include "embedding_block_manager.h"
 
 #include <gtest/gtest.h>
 
 namespace xllm {
 
-TEST(SingleBlockManagerTest, AllocateAndFreeRoundTrip) {
+TEST(EmbeddingBlockManagerTest, AllocateAndFreeRoundTrip) {
   // id 0 is reserved for padding (matching BlockManagerImpl), so a pool sized
   // for 4 physical slots exposes 3 usable blocks.
-  SingleBlockManager manager(4, "single");
+  EmbeddingBlockManager manager(4, "single");
 
   EXPECT_EQ(manager.num_total_blocks(), 3);
   EXPECT_EQ(manager.num_blocks_in_prefix_cache(), 0);
@@ -49,30 +49,30 @@ TEST(SingleBlockManagerTest, AllocateAndFreeRoundTrip) {
   EXPECT_DOUBLE_EQ(manager.kv_cache_utilization(), 0.0);
 }
 
-TEST(SingleBlockManagerTest, AllocateReturnsEmptyWhenExhausted) {
+TEST(EmbeddingBlockManagerTest, AllocateReturnsEmptyWhenExhausted) {
   // id 0 is reserved internally, so 3 physical slots expose 2 usable blocks.
-  SingleBlockManager manager(3, "single");
+  EmbeddingBlockManager manager(3, "single");
   auto blocks = manager.allocate(2);
   ASSERT_EQ(blocks.size(), 2);
   EXPECT_TRUE(manager.allocate(1).empty());
 }
 
-TEST(SingleBlockManagerTest, AllocateSingleDiesWhenExhausted) {
+TEST(EmbeddingBlockManagerTest, AllocateSingleDiesWhenExhausted) {
   // id 0 is reserved internally, so 2 physical slots expose a single usable
   // block, whose id is 1.
-  SingleBlockManager manager(2, "single");
+  EmbeddingBlockManager manager(2, "single");
   Block block = manager.allocate();
   EXPECT_EQ(block.id(), 1);
   EXPECT_DEATH(manager.allocate(), "No more single blocks available");
 }
 
-TEST(SingleBlockManagerTest, PrefixCacheApisAreNotImplemented) {
-  SingleBlockManager manager(2, "single");
+TEST(EmbeddingBlockManagerTest, PrefixCacheApisAreNotImplemented) {
+  EmbeddingBlockManager manager(2, "single");
 
   const int32_t token_ids_arr[] = {1, 2, 3};
   const Slice<int32_t> token_ids(token_ids_arr, 3);
 
-  // SINGLE never serves the prefix cache. These APIs are explicitly
+  // EMBEDDING never serves the prefix cache. These APIs are explicitly
   // NOT_IMPLEMENTED so a stray caller fails loudly instead of silently
   // mis-routing (the composite only calls them on prefix-capable leaves).
   EXPECT_DEATH(manager.allocate_shared(token_ids), "not implemented");
@@ -83,14 +83,14 @@ TEST(SingleBlockManagerTest, PrefixCacheApisAreNotImplemented) {
   EXPECT_DEATH(manager.cache(blocks), "not implemented");
 }
 
-TEST(SingleBlockManagerTest, UsedBlocksAccountingRoundTrips) {
-  // SingleBlockManager now reuses BlockManagerImpl's free list. With prefix
+TEST(EmbeddingBlockManagerTest, UsedBlocksAccountingRoundTrips) {
+  // EmbeddingBlockManager now reuses BlockManagerImpl's free list. With prefix
   // cache disabled there is no aliasing scenario (single blocks live only in
   // the owning sequence, never in a prefix cache), so deallocate drops
   // effective usage immediately and the physical id returns when the Block is
   // destroyed. id 0 is reserved internally, so 2 physical slots expose a single
   // usable block.
-  SingleBlockManager manager(2, "single");
+  EmbeddingBlockManager manager(2, "single");
   EXPECT_EQ(manager.num_used_blocks(), 0u);
   EXPECT_EQ(manager.num_free_blocks(), 1u);
 
@@ -113,11 +113,11 @@ TEST(SingleBlockManagerTest, UsedBlocksAccountingRoundTrips) {
   EXPECT_EQ(manager.num_free_blocks(), 1u);
 }
 
-TEST(SingleBlockManagerTest, ReservesPaddingSlotZero) {
+TEST(EmbeddingBlockManagerTest, ReservesPaddingSlotZero) {
   // Draining the whole pool must never yield the reserved padding id 0, which
   // padded batch rows use as kPaddingLinearStateId. 4 physical slots expose 3
   // usable blocks.
-  SingleBlockManager manager(4, "single");
+  EmbeddingBlockManager manager(4, "single");
   EXPECT_EQ(manager.num_total_blocks(), 3);
 
   std::vector<Block> blocks = manager.allocate(3);
@@ -132,8 +132,8 @@ TEST(SingleBlockManagerTest, ReservesPaddingSlotZero) {
   EXPECT_EQ(manager.num_free_blocks(), 3u);
 }
 
-TEST(SingleBlockManagerTest, ConstructorRejectsZeroBlocks) {
-  EXPECT_DEATH({ SingleBlockManager manager(0, "single"); }, "No blocks");
+TEST(EmbeddingBlockManagerTest, ConstructorRejectsZeroBlocks) {
+  EXPECT_DEATH({ EmbeddingBlockManager manager(0, "single"); }, "No blocks");
 }
 
 }  // namespace xllm

--- a/tests/core/framework/request/sequence_kv_state_test.cpp
+++ b/tests/core/framework/request/sequence_kv_state_test.cpp
@@ -54,7 +54,7 @@ TEST(KVCacheStateTest, ResetClearsBeamSourceState) {
 }
 
 // Finding 2 regression: has_any_blocks() must report true for ANY
-// cache-bearing type (KV / SWA / C4 / C128) and IGNORE SINGLE. The pool's
+// cache-bearing type (KV / SWA / C4 / C128) and IGNORE EMBEDDING. The pool's
 // "started_empty" rollback decision relies on this so that a DSV4 sequence
 // (which holds SWA/C4/C128 but no KV) is not treated as fresh on a failed grow.
 TEST(KVCacheStateTest, HasAnyBlocksIgnoresSingle) {
@@ -68,10 +68,10 @@ TEST(KVCacheStateTest, HasAnyBlocksIgnoresSingle) {
     EXPECT_FALSE(state.has_any_blocks());
   }
 
-  // SINGLE-only must NOT count as cache.
+  // EMBEDDING-only must NOT count as cache.
   {
     KVCacheState state;
-    state.add_blocks(BlockType::SINGLE, make_block(1));
+    state.add_blocks(BlockType::EMBEDDING, make_block(1));
     EXPECT_FALSE(state.has_any_blocks());
   }
 
@@ -89,7 +89,7 @@ TEST(KVCacheStateTest, HasAnyBlocksIgnoresSingle) {
     state.add_blocks(BlockType::SWA, make_block(3));
     state.add_blocks(BlockType::C4, make_block(4));
     state.add_blocks(BlockType::C128, make_block(5));
-    state.add_blocks(BlockType::SINGLE, make_block(6));
+    state.add_blocks(BlockType::EMBEDDING, make_block(6));
     EXPECT_TRUE(state.has_any_blocks());
   }
 }

--- a/tests/core/runtime/acl_graph_executor_test.cpp
+++ b/tests/core/runtime/acl_graph_executor_test.cpp
@@ -870,14 +870,14 @@ TEST_F(AclGraphExecutorTest, BatchInputCarriesLinearStateIds) {
   ASSERT_FALSE(batch->empty());
   ASSERT_FALSE(sequences_.empty());
 
-  // embedding_ids come from the single_block slot, while linear_state_ids come
-  // from the dedicated linear_state_slot slot; the two are decoupled and carry
+  // embedding_ids come from the EMBEDDING slot, while linear_state_ids come
+  // from the dedicated LINEAR slot; the two are decoupled and carry
   // independent ids through transport.
   auto& seq = sequences_.back();
   auto embedding_block = block_manager_->allocate(1);
   ASSERT_EQ(embedding_block.size(), 1);
   const int32_t expected_embedding_id = embedding_block[0].id();
-  seq.add_blocks(BlockType::SINGLE, embedding_block);
+  seq.add_blocks(BlockType::EMBEDDING, embedding_block);
 
   auto linear_state_slot = block_manager_->allocate(1);
   ASSERT_EQ(linear_state_slot.size(), 1);

--- a/tests/core/runtime/acl_graph_task_update_test.cpp
+++ b/tests/core/runtime/acl_graph_task_update_test.cpp
@@ -310,9 +310,9 @@ class AclGraphTaskUpdateTest : public ::testing::Test {
       if (!kv_blocks.empty()) {
         block_manager_->deallocate(kv_blocks);
       }
-      auto single_blocks = sequence.kv_state().blocks(BlockType::SINGLE);
-      if (!single_blocks.empty()) {
-        block_manager_->deallocate(single_blocks);
+      auto linear_blocks = sequence.kv_state().blocks(BlockType::LINEAR);
+      if (!linear_blocks.empty()) {
+        block_manager_->deallocate(linear_blocks);
       }
     }
     sequences_.clear();
@@ -368,7 +368,7 @@ class AclGraphTaskUpdateTest : public ::testing::Test {
       auto& sequence = sequences_.back();
 
       auto linear_state_block = block_manager_->allocate(1);
-      sequence.add_blocks(BlockType::SINGLE, linear_state_block);
+      sequence.add_blocks(BlockType::LINEAR, linear_state_block);
       sequence.add_blocks(BlockType::KV, block_manager_->allocate(2));
       sequence.kv_state().incr_kv_cache_tokens_num(4);
       sequence.append_token(token_seed + static_cast<int32_t>(i));
@@ -392,7 +392,7 @@ class AclGraphTaskUpdateTest : public ::testing::Test {
       auto& sequence = sequences_.back();
 
       auto linear_state_block = block_manager_->allocate(1);
-      sequence.add_blocks(BlockType::SINGLE, linear_state_block);
+      sequence.add_blocks(BlockType::LINEAR, linear_state_block);
       sequence.add_blocks(
           BlockType::KV,
           block_manager_->allocate(static_cast<size_t>(num_kv_blocks)));

--- a/tests/core/scheduler/disagg_pd_scheduler_test.cpp
+++ b/tests/core/scheduler/disagg_pd_scheduler_test.cpp
@@ -64,12 +64,16 @@ class FakeTokenizer final : public Tokenizer {
 
 class FakeEngine final : public Engine {
  public:
-  FakeEngine(int32_t num_blocks, int32_t block_size) {
+  FakeEngine(int32_t num_blocks,
+             int32_t block_size,
+             int32_t num_speculative_tokens = 0) {
     BlockManagerPool::Options options;
     options.num_blocks(num_blocks)
         .block_size(block_size)
         .enable_prefix_cache(true)
-        .enable_disagg_pd(true);
+        .enable_disagg_pd(true)
+        .num_speculative_tokens(num_speculative_tokens)
+        .num_embedding_blocks(num_blocks);
     tokenizer_ = std::make_unique<FakeTokenizer>();
     block_manager_ = std::make_unique<BlockManagerPool>(options, /*dp_size=*/1);
   }
@@ -285,7 +289,9 @@ TEST(DisaggPDSchedulerTest, CacheSkipsExistingSharedBlocks) {
 }
 
 TEST(DisaggPDSchedulerTest, MtpFirstGenerationRequiresBootstrapBeforeQueue) {
-  FakeEngine engine(/*num_blocks=*/8, /*block_size=*/2);
+  FakeEngine engine(/*num_blocks=*/8,
+                    /*block_size=*/2,
+                    /*num_speculative_tokens=*/1);
   TestDisaggPDScheduler scheduler(&engine, make_mtp_decode_options());
   std::shared_ptr<Request> request = make_request({1, 2, 3, 4});
   ASSERT_TRUE(
@@ -298,13 +304,15 @@ TEST(DisaggPDSchedulerTest, MtpFirstGenerationRequiresBootstrapBeforeQueue) {
 }
 
 TEST(DisaggPDSchedulerTest, MtpFirstGenerationStoresBootstrapThenQueues) {
-  FakeEngine engine(/*num_blocks=*/8, /*block_size=*/2);
+  FakeEngine engine(/*num_blocks=*/8,
+                    /*block_size=*/2,
+                    /*num_speculative_tokens=*/1);
   TestDisaggPDScheduler scheduler(&engine, make_mtp_decode_options());
   std::shared_ptr<Request> request = make_request({1, 2, 3, 4});
   Sequence* sequence = request->sequences()[0].get();
   ASSERT_TRUE(engine.block_manager_pool()->allocate(sequence));
   sequence->kv_state().set_kv_cache_tokens_num(sequence->num_prompt_tokens());
-  ASSERT_GE(sequence->get_single_block_id(), 0);
+  ASSERT_GE(sequence->get_embedding_block_id(), 0);
   ASSERT_TRUE(scheduler.decode_schedule(request, "prefill"));
 
   torch::Tensor embedding = torch::tensor({1.0f, 2.0f});
@@ -388,7 +396,9 @@ TEST(DisaggPDSchedulerTest, AmortizedTokenLatencyRoundsHalfUp) {
 }
 
 TEST(DisaggPDSchedulerTest, SpeculativeGaugeReportsBatchMeanTokensPerStep) {
-  FakeEngine engine(/*num_blocks=*/8, /*block_size=*/2);
+  FakeEngine engine(/*num_blocks=*/8,
+                    /*block_size=*/2,
+                    /*num_speculative_tokens=*/1);
   TestDisaggPDScheduler scheduler(&engine, make_mtp_decode_options());
 
   std::shared_ptr<Request> first_request = make_request({1, 2, 3, 4});

--- a/xllm/core/common/constants.h
+++ b/xllm/core/common/constants.h
@@ -25,7 +25,7 @@ inline constexpr char kContentLength[] = "Content-Length";
 // Reserved row 0 of the linear / SSM state cache, used as the padding slot for
 // padded decode batch rows. This mirrors the KV cache convention, where block
 // id 0 is permanently held for padding (see BlockManagerImpl and
-// SingleBlockManager). Keeping both caches padded to row 0 makes the padding
+// EmbeddingBlockManager). Keeping both caches padded to row 0 makes the padding
 // contract uniform across attention and linear-attention layers; real
 // sequences are handed ids in [1, num_blocks - 1] only.
 inline constexpr int32_t kPaddingLinearStateId = 0;

--- a/xllm/core/distributed_runtime/disagg_pd_service_impl.cpp
+++ b/xllm/core/distributed_runtime/disagg_pd_service_impl.cpp
@@ -176,9 +176,10 @@ void DisaggPDServiceImpl::decode_recv_new_requests(
 
       auto dp_rank = sequence->dp_rank();
       resp->set_dp_rank(dp_rank);
-      // Advertise the recurrent-state slot: LINEAR for Qwen3.5 GDN, SINGLE
-      // for legacy models. Sender-side batch_input_builder resolves the slot
-      // via the same helper so both sides agree.
+      // Advertise the recurrent-state slot: the LINEAR slot for Qwen3.5 GDN,
+      // or -1 for models without linear-attention layers. Sender-side
+      // batch_input_builder resolves the slot via the same helper so both
+      // sides agree.
       resp->set_linear_state_id(sequence->get_recurrent_state_slot_id());
 
       std::vector<int32_t> block_ids;

--- a/xllm/core/distributed_runtime/llm_engine.cpp
+++ b/xllm/core/distributed_runtime/llm_engine.cpp
@@ -562,6 +562,8 @@ bool LLMEngine::allocate_kv_cache(const KVCacheCapacity& kv_cache_cap) {
       .model_id(options_.model_id())
       .max_seqs_per_batch(options_.max_seqs_per_batch())
       .num_speculative_tokens(options_.num_speculative_tokens())
+      .num_embedding_blocks(
+          static_cast<uint32_t>(kv_cache_shape.key_cache_shape()[0]))
       // DECODE-side prefix cache participation is per-leaf and gated by the
       // predicate in composite_block_manager.cpp. P and MIX are treated
       // identically (both admit prefix cache on every leaf).
@@ -609,10 +611,7 @@ bool LLMEngine::allocate_kv_cache(const KVCacheCapacity& kv_cache_cap) {
         .swa_blocks_per_seq(swa_blocks_per_seq)
         .max_tokens_per_batch(options_.max_tokens_per_batch())
         .manager_types(std::move(manager_types))
-        .compress_ratios(std::move(manager_compress_ratios))
-        .max_seqs_per_batch(options_.max_seqs_per_batch())
-        .num_single_blocks(static_cast<uint32_t>(std::min<int64_t>(
-            kv_cache_cap.swa_count(), std::numeric_limits<uint32_t>::max())));
+        .compress_ratios(std::move(manager_compress_ratios));
   }
 
   if (options_.host_blocks_factor() > 1.0) {

--- a/xllm/core/distributed_runtime/vlm_engine.cpp
+++ b/xllm/core/distributed_runtime/vlm_engine.cpp
@@ -340,6 +340,8 @@ bool VLMEngine::allocate_kv_cache(const KVCacheCapacity& kv_cache_cap) {
       .enable_disagg_pd(options_.enable_disagg_pd())
       .hasher_type(BlockHasherType::MM)
       .max_seqs_per_batch(options_.max_seqs_per_batch())
+      .num_embedding_blocks(
+          static_cast<uint32_t>(kv_cache_shape.key_cache_shape()[0]))
       // DECODE-side prefix cache participation is per-leaf and gated by the
       // predicate in composite_block_manager.cpp; mirror llm_engine so a
       // linear-attention VLM decode instance disables the LINEAR prefix cache.

--- a/xllm/core/framework/batch/batch_input_builder.cpp
+++ b/xllm/core/framework/batch/batch_input_builder.cpp
@@ -784,7 +784,7 @@ void BatchInputBuilder::extract_tokens_and_positions(Sequence* sequence,
     // last chunk of prefill and decode
     // add -1 as extra token id
     state.extra_token_ids.emplace_back(-1);
-    state.embedding_ids.emplace_back(sequence->get_single_block_id());
+    state.embedding_ids.emplace_back(sequence->get_embedding_block_id());
     state.request_ids.emplace_back(sequence->request_id());
     torch::Tensor mtp_bootstrap = sequence->get_mtp_bootstrap_embedding();
     if (state.batch_forward_type.is_decode() && mtp_bootstrap.defined()) {
@@ -823,15 +823,11 @@ void BatchInputBuilder::append_linear_state_row(Sequence* sequence,
                                                 BuilderState& state) {
   // linear_state_ids must stay aligned with logical batch rows even when the
   // model has no linear-attention layers, because downstream consumers index by
-  // batch row. Prefer the dedicated linear-state slot. Linear-attention decode
-  // paths that only carry a scheduler-side single block still share that live
-  // slot value across embedding and linear-state transport fields.
+  // batch row. GDN models always hold a dedicated LINEAR slot, so read it
+  // directly; non-linear models emit -1 and return early below.
   const bool has_linear_attention =
       args_ && has_linear_attention_layers(*args_);
   int32_t linear_state_id = sequence->get_linear_state_slot_id();
-  if (linear_state_id < 0 && has_linear_attention) {
-    linear_state_id = sequence->get_single_block_id();
-  }
   state.linear_state_ids.emplace_back(linear_state_id);
   if (!has_linear_attention) {
     return;

--- a/xllm/core/framework/batch/rec_multi_round_batch_input_builder.cpp
+++ b/xllm/core/framework/batch/rec_multi_round_batch_input_builder.cpp
@@ -271,7 +271,7 @@ void RecMultiRoundBatchInputBuilder::extract_tokens_and_positions(
     // last chunk of prefill and decode
     // add -1 as extra token id
     base_state.extra_token_ids.push_back(-1);
-    base_state.embedding_ids.push_back(sequence->get_single_block_id());
+    base_state.embedding_ids.push_back(sequence->get_embedding_block_id());
   } else {
     base_state.extra_token_ids.push_back(token_ids[seq_len]);
   }

--- a/xllm/core/framework/block/CMakeLists.txt
+++ b/xllm/core/framework/block/CMakeLists.txt
@@ -18,7 +18,7 @@ cc_library(
   HDRS
     block.h
     block_manager.h
-    single_block_manager.h
+    embedding_block_manager.h
     block_manager_pool.h
     linear_state_block_manager.h
     block_manager_impl.h
@@ -28,7 +28,7 @@ cc_library(
     composite_block_manager.h
   SRCS
     block.cpp
-    single_block_manager.cpp
+    embedding_block_manager.cpp
     block_manager_pool.cpp
     linear_state_block_manager.cpp
     concurrent_block_manager_impl.cpp

--- a/xllm/core/framework/block/block.h
+++ b/xllm/core/framework/block/block.h
@@ -34,20 +34,24 @@ class BlockManager;
 
 // Identity of a KV block's cache role inside a sequence's KVCacheState. Used as
 // the key of the per-sequence block map: the legacy flat attention KV lives
-// under KV, DSV4's three groups under SWA/C4/C128, and the per-sequence
-// linear/embedding resource block (formerly Sequence::single_block_) under
-// Single. A block carries no type identity itself; the owning BlockManager
-// decides which key to store it under when it fills the sequence state.
+// under KV, DSV4's three groups under SWA/C4/C128. EMBEDDING and LINEAR are
+// per-sequence single-resource slots (one block per sequence): EMBEDDING backs
+// the spec-decode embedding-row id, LINEAR backs the GDN recurrent state (its
+// slot id also indexes the conv/ssm KV tensors, which are tagged as the LINEAR
+// cache group). A block carries no type identity itself; the owning
+// BlockManager decides which key to store it under when it fills the state.
 enum class BlockType : int8_t {
-  KV = 0,      // normal/Qwen flat attention KV, exported to block_tables
-  SWA = 1,     // DSV4 sliding window, exported to multi_block_tables[0]
-  C4 = 2,      // DSV4 compressed, exported to multi_block_tables[1]
-  C128 = 3,    // DSV4 compressed, exported to multi_block_tables[2]
-  SINGLE = 4,  // per-sequence embedding resource block, exported via
-               // get_single_block_id() (embedding_ids)
-  LINEAR = 5,  // per-sequence linear-state (GDN recurrent) live slot, drawn
-               // from LinearStateBlockManager; exported via
-               // get_linear_block_id() (linear_state_ids)
+  KV = 0,         // normal/Qwen flat attention KV, exported to block_tables
+  SWA = 1,        // DSV4 sliding window, exported to multi_block_tables[0]
+  C4 = 2,         // DSV4 compressed, exported to multi_block_tables[1]
+  C128 = 3,       // DSV4 compressed, exported to multi_block_tables[2]
+  EMBEDDING = 4,  // per-sequence spec-decode embedding-row slot, exported via
+                  // get_embedding_block_id() (embedding_ids). Value kept at 4
+                  // for proto BlockType wire compatibility.
+  LINEAR = 5,     // per-sequence linear-state (GDN recurrent) live slot, drawn
+                  // from LinearStateBlockManager; exported via
+  // get_linear_block_id() (linear_state_ids). Also the cache group
+  // for the conv/ssm recurrent-state KV tensors.
 };
 
 // Fixed column order of worker multi_block_tables. The exported tables must
@@ -76,8 +80,6 @@ inline constexpr std::optional<BlockType> block_type_from_cache_group_id(
       return BlockType::C4;
     case cache_group_id(BlockType::C128):
       return BlockType::C128;
-    case cache_group_id(BlockType::SINGLE):
-      return BlockType::SINGLE;
     default:
       return std::nullopt;
   }

--- a/xllm/core/framework/block/block_manager.h
+++ b/xllm/core/framework/block/block_manager.h
@@ -149,7 +149,8 @@ class BlockManager {
   // get number of slots per block
   size_t block_size() const { return options_.block_size(); }
 
-  // The block category this leaf serves (KV / SWA / C4 / C128 / SINGLE). A leaf
+  // The block category this leaf serves (KV / SWA / C4 / C128 / EMBEDDING /
+  // LINEAR). A leaf
   // reads its own held-block count from the sequence under this type, and the
   // CompositeBlockManager inserts the returned blocks into the sequence under
   // this type. Carried via Options by the spec builder.

--- a/xllm/core/framework/block/block_manager_pool.cpp
+++ b/xllm/core/framework/block/block_manager_pool.cpp
@@ -35,8 +35,6 @@ BlockManagerPool::BlockManagerPool(const Options& options, int32_t dp_size)
     : options_(options) {
   CHECK(dp_size > 0) << "dp_size must be greater than 0";
   block_managers_.reserve(dp_size);
-  const uint32_t default_max_single_block_sequences =
-      options_.max_seqs_per_batch();
 
   BlockManager::Options block_options;
   block_options.num_blocks(options_.num_blocks())
@@ -61,36 +59,35 @@ BlockManagerPool::BlockManagerPool(const Options& options, int32_t dp_size)
       .num_speculative_tokens(options_.num_speculative_tokens())
       .instance_is_decode(options_.instance_is_decode());
 
-  uint32_t num_single_blocks = std::max<uint32_t>(
-      options_.num_single_blocks(), default_max_single_block_sequences + 2);
-  CHECK_GT(num_single_blocks, 0u) << "num_single_blocks must be positive";
-
   for (int32_t i = 0; i < dp_size; ++i) {
     // The pool always holds a CompositeBlockManager. Its KV leaf is a flat
     // BlockManagerImpl, or an XTensorBlockManagerImpl when enable_xtensor (the
-    // builder picks); SWA / C4 / C128 come from manager_types; the per-sequence
-    // SINGLE resource leaf is appended here under the SINGLE key. Every leaf is
-    // routed by its BlockType, so xtensor and Single are ordinary leaves.
+    // builder picks); SWA / C4 / C128 come from manager_types; the LINEAR leaf
+    // is added by the builder when enable_linear_state. The per-sequence
+    // EMBEDDING resource leaf is appended here under the EMBEDDING key when
+    // spec decode needs it. Every leaf is routed by its BlockType.
     auto leaves = build_composite_leaves(block_options, /*dp_rank=*/i);
-    // SINGLE leaf needs the same concurrency wrapper as the other leaves when
-    // sequence-level entry points run off the scheduler thread (disagg PD /
-    // kvcache store prefill threadpools call try_allocate concurrently, and the
-    // host-offload D2H callback frees blocks off-thread).
-    std::unique_ptr<BlockManager> single_leaf =
-        std::make_unique<SingleBlockManager>(
-            /*num_blocks=*/num_single_blocks,
-            /*resource_name=*/"single block",
-            /*exhaustion_message=*/"No more single-block ids available");
-    if (options_.enable_disagg_pd() || options_.enable_kvcache_store() ||
-        options_.enable_host_offload()) {
-      single_leaf =
-          std::make_unique<ConcurrentBlockManagerImpl>(std::move(single_leaf));
+    if (options_.num_speculative_tokens() > 0) {
+      // EMBEDDING leaf needs the same concurrency wrapper as the other leaves
+      // when sequence-level entry points run off the scheduler thread (disagg
+      // PD / kvcache store prefill threadpools call try_allocate concurrently,
+      // and the host-offload D2H callback frees blocks off-thread).
+      std::unique_ptr<BlockManager> embedding_leaf =
+          std::make_unique<EmbeddingBlockManager>(
+              /*num_blocks=*/options_.num_embedding_blocks(),
+              /*resource_name=*/"embedding block",
+              /*exhaustion_message=*/"No more embedding-block ids available");
+      if (options_.enable_disagg_pd() || options_.enable_kvcache_store() ||
+          options_.enable_host_offload()) {
+        embedding_leaf = std::make_unique<ConcurrentBlockManagerImpl>(
+            std::move(embedding_leaf));
+      }
+      leaves.emplace(
+          BlockType::EMBEDDING,
+          CompositeBlockManager::LeafEntry{std::move(embedding_leaf),
+                                           /*participates_in_admission=*/false,
+                                           /*supports_prefix_cache=*/false});
     }
-    leaves.emplace(
-        BlockType::SINGLE,
-        CompositeBlockManager::LeafEntry{std::move(single_leaf),
-                                         /*participates_in_admission=*/false,
-                                         /*supports_prefix_cache=*/false});
     block_managers_.emplace_back(
         std::make_unique<CompositeBlockManager>(std::move(leaves)));
   }
@@ -144,7 +141,7 @@ void BlockManagerPool::deallocate(Sequence* sequence) {
   DCHECK(sequence != nullptr);
   int32_t dp_rank = get_dp_rank(sequence);
   // The composite fans deallocate (with final cache) out across all leaves,
-  // including the SINGLE resource leaf, the LINEAR leaf, and the (flat or
+  // including the EMBEDDING resource leaf, the LINEAR leaf, and the (flat or
   // xtensor) KV leaf.
   auto* composite =
       static_cast<CompositeBlockManager*>(block_managers_[dp_rank].get());
@@ -183,7 +180,7 @@ bool BlockManagerPool::allocate(Sequence* sequence, size_t num_tokens) {
   // failure, wrongly deallocate + reset the already-held SWA/C4/C128 blocks.
   const bool started_empty = !sequence->kv_state().has_any_blocks();
 
-  // The leaves (KV / SWA / C4 / C128 / SINGLE / LINEAR) each apply their own
+  // The leaves (KV / SWA / C4 / C128 / EMBEDDING / LINEAR) each apply their own
   // strategy; the pool only orchestrates prefix-share-then-beam-then-grow,
   // which beam (KV copy-on-write) must sit between.
   auto* composite =
@@ -201,7 +198,7 @@ bool BlockManagerPool::allocate(Sequence* sequence, size_t num_tokens) {
   }
   // Always run the composite growth pass: even when KV is already satisfied, a
   // sequence (e.g. a fork/clone of a beam parent) may still be missing its
-  // per-sequence SINGLE / LINEAR block. The composite skips no-op leaves
+  // per-sequence EMBEDDING / LINEAR block. The composite skips no-op leaves
   // internally.
   if (!composite->allocate_sequence(sequence, num_tokens)) {
     if (started_empty) {
@@ -390,7 +387,7 @@ void BlockManagerPool::deallocate_without_cache(Sequence* sequence) {
                                BlockType::SWA,
                                BlockType::C4,
                                BlockType::C128,
-                               BlockType::SINGLE,
+                               BlockType::EMBEDDING,
                                BlockType::LINEAR}) {
     const Slice<Block> blocks = sequence->kv_state().blocks(type);
     if (!blocks.empty()) {

--- a/xllm/core/framework/block/block_manager_pool.h
+++ b/xllm/core/framework/block/block_manager_pool.h
@@ -19,8 +19,8 @@ limitations under the License.
 #include <vector>
 
 #include "block_manager.h"
+#include "framework/block/embedding_block_manager.h"
 #include "framework/block/kv_cache_manager.h"
-#include "framework/block/single_block_manager.h"
 
 namespace xllm {
 
@@ -57,7 +57,7 @@ class BlockManagerPool : public KVCacheManager {
     PROPERTY(uint32_t, max_seqs_per_batch) = 0;
     // Hasher type bound to the engine (TEXT for LLM, MM for VLM).
     PROPERTY(BlockHasherType, hasher_type) = BlockHasherType::TEXT;
-    PROPERTY(uint32_t, num_single_blocks) = 0;
+    PROPERTY(uint32_t, num_embedding_blocks) = 0;
     PROPERTY(uint32_t, num_speculative_tokens) = 0;
     // Role flag: true on the DECODE side of disaggregated PD. Forwarded to
     // BlockManager::Options for every composite leaf; the leaf's prefix

--- a/xllm/core/framework/block/composite_block_manager.cpp
+++ b/xllm/core/framework/block/composite_block_manager.cpp
@@ -24,9 +24,9 @@ limitations under the License.
 #include "concurrent_block_manager_impl.h"
 #include "core/framework/config/kv_cache_config.h"
 #include "core/framework/config/scheduler_config.h"
+#include "embedding_block_manager.h"
 #include "framework/xtensor/xtensor_block_manager_impl.h"
 #include "linear_state_block_manager.h"
-#include "single_block_manager.h"
 #include "sliding_window_block_manager.h"
 
 namespace xllm {
@@ -47,7 +47,7 @@ uint32_t ceil_div(uint32_t numerator, uint32_t denominator) {
 // LINEAR because the D forward never reads their shared prefix before P
 // overwrites it -- SWA hits carry gap-invalid placeholders that would break
 // the grouped-response CHECK, and LINEAR restore is a net waste (D does no
-// prefill). SINGLE has never had a prefix cache and stays out on both sides.
+// prefill). EMBEDDING has never had a prefix cache and stays out on both sides.
 //
 // The same predicate governs the set of leaves that will participate in
 // future host offload (see xllm_docs/pd_d_side_skip_swa_linear_prefix_cache.md
@@ -65,7 +65,7 @@ bool leaf_participates_in_prefix_cache(BlockType type,
       return true;
     case BlockType::SWA:
     case BlockType::LINEAR:
-    case BlockType::SINGLE:
+    case BlockType::EMBEDDING:
       return false;
   }
   // Fail loudly on unhandled BlockType. Falling back to false would silently
@@ -318,8 +318,8 @@ void CompositeBlockManager::cache_full_blocks_for_sequence(Sequence* seq) {
   KVCacheState& kv = seq->kv_state();
   for (auto& [type, entry] : leaves_) {
     // KV owns its final flush via cache_for_sequence at deallocate time;
-    // SINGLE / LINEAR hold no token cache.
-    if (type == BlockType::KV || type == BlockType::SINGLE ||
+    // EMBEDDING / LINEAR hold no token cache.
+    if (type == BlockType::KV || type == BlockType::EMBEDDING ||
         type == BlockType::LINEAR) {
       continue;
     }
@@ -400,9 +400,9 @@ bool CompositeBlockManager::allocate_sequence(Sequence* seq,
   // pressure would let the pool report admission success while the device
   // is under-provisioned -- batch_input_builder's CHECK then fires
   // downstream. Rolling back lets the scheduler defer to the next tick.
-  // SINGLE / LINEAR are per-sequence resource slots, not token cache.
+  // EMBEDDING / LINEAR are per-sequence resource slots, not token cache.
   for (const auto& [type, entry] : leaves_) {
-    if (type == BlockType::SINGLE || type == BlockType::LINEAR) {
+    if (type == BlockType::EMBEDDING || type == BlockType::LINEAR) {
       continue;
     }
     const size_t leaf_block_size = entry.leaf->block_size();

--- a/xllm/core/framework/block/composite_block_manager.h
+++ b/xllm/core/framework/block/composite_block_manager.h
@@ -126,7 +126,7 @@ class CompositeBlockManager : public BlockManager {
   // full blocks into its own prefix cache incrementally (cursor lives in
   // KVCacheState::num_cached_blocks). Only fires for leaves that carry token
   // cache and are not the KV leaf -- KV has its own final-flush semantics
-  // via cache_for_sequence at deallocate time; SINGLE / LINEAR hold no token
+  // via cache_for_sequence at deallocate time; EMBEDDING / LINEAR hold no token
   // cache.
   void cache_full_blocks_for_sequence(Sequence* seq);
 
@@ -134,13 +134,15 @@ class CompositeBlockManager : public BlockManager {
   LeafCombination combination_;
 };
 
-// Build the leaf map for one DP rank. Per model:
-//   normal / Qwen -> {KV, SINGLE}
-//   DSV4          -> {SWA, C4, C128, SINGLE}
-//   xtensor       -> {KV(XTensorBlockManagerImpl), SINGLE}
+// Build the leaf map for one DP rank. Per model (base cache-bearing leaves):
+//   normal / Qwen -> {KV}
+//   DSV4          -> {SWA, C4, C128}
+//   xtensor       -> {KV(XTensorBlockManagerImpl)}
+// A LINEAR leaf is added when enable_linear_state (GDN recurrent models).
 // Leaves are wrapped in ConcurrentBlockManagerImpl for disagg-PD / kvcache
-// store. SINGLE is appended by the pool caller. dp_rank is used by the
-// xtensor KV leaf (per-rank VMM page pool).
+// store. The EMBEDDING leaf is appended by the pool caller only when spec
+// decode needs it. dp_rank is used by the xtensor KV leaf (per-rank VMM page
+// pool).
 std::map<BlockType, CompositeBlockManager::LeafEntry> build_composite_leaves(
     const BlockManager::Options& options,
     int32_t dp_rank = 0);

--- a/xllm/core/framework/block/concurrent_block_manager_impl.h
+++ b/xllm/core/framework/block/concurrent_block_manager_impl.h
@@ -28,8 +28,9 @@ namespace xllm {
 // threadpools).
 //
 // Composition, not inheritance: the inner manager is always a leaf
-// (BlockManagerImpl / SingleBlockManager / ...), never a CompositeBlockManager.
-// The composite constructs this wrapper around the leaves that need it.
+// (BlockManagerImpl / EmbeddingBlockManager / ...), never a
+// CompositeBlockManager. The composite constructs this wrapper around the
+// leaves that need it.
 class ConcurrentBlockManagerImpl : public BlockManager {
  public:
   explicit ConcurrentBlockManagerImpl(std::unique_ptr<BlockManager> inner);

--- a/xllm/core/framework/block/embedding_block_manager.cpp
+++ b/xllm/core/framework/block/embedding_block_manager.cpp
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "single_block_manager.h"
+#include "embedding_block_manager.h"
 
 #include <glog/logging.h>
 
@@ -22,29 +22,30 @@ limitations under the License.
 namespace xllm {
 namespace {
 
-// One physical id == one block; no prefix cache; blocks live under the SINGLE
-// slot of the sequence's KVCacheState. id 0 stays the reserved padding slot
-// (BlockManagerImpl reserves it in its ctor), so usable ids are [1, n-1].
-BlockManager::Options make_single_block_options(uint32_t num_blocks) {
+// One physical id == one block; no prefix cache; blocks live under the
+// EMBEDDING slot of the sequence's KVCacheState. id 0 stays the reserved
+// padding slot (BlockManagerImpl reserves it in its ctor), so usable ids are
+// [1, n-1].
+BlockManager::Options make_embedding_block_options(uint32_t num_blocks) {
   BlockManager::Options options;
   options.num_blocks(num_blocks);
   options.block_size(/*unused, one id == one block=*/1);
   options.enable_prefix_cache(false);
   options.enable_disagg_pd(false);
-  options.block_type(BlockType::SINGLE);
+  options.block_type(BlockType::EMBEDDING);
   return options;
 }
 
 }  // namespace
 
-SingleBlockManager::SingleBlockManager(uint32_t num_blocks,
-                                       std::string resource_name,
-                                       std::string exhaustion_message)
-    : BlockManagerImpl(make_single_block_options(num_blocks)),
+EmbeddingBlockManager::EmbeddingBlockManager(uint32_t num_blocks,
+                                             std::string resource_name,
+                                             std::string exhaustion_message)
+    : BlockManagerImpl(make_embedding_block_options(num_blocks)),
       resource_name_(std::move(resource_name)),
       exhaustion_message_(std::move(exhaustion_message)) {}
 
-std::optional<std::vector<Block>> SingleBlockManager::allocate_for_sequence(
+std::optional<std::vector<Block>> EmbeddingBlockManager::allocate_for_sequence(
     Sequence* seq,
     size_t /*num_tokens*/) {
   if (seq == nullptr) {
@@ -67,7 +68,7 @@ std::optional<std::vector<Block>> SingleBlockManager::allocate_for_sequence(
   return blocks;
 }
 
-Block SingleBlockManager::allocate() {
+Block EmbeddingBlockManager::allocate() {
   // Surface exhaustion with this resource's identity instead of the generic
   // base message, then delegate to the counting allocate(1) path (the base
   // zero-arg allocate() skips num_used accounting -- it exists for padding).
@@ -82,7 +83,7 @@ Block SingleBlockManager::allocate() {
   return std::move(blocks[0]);
 }
 
-std::vector<Block> SingleBlockManager::allocate_shared(
+std::vector<Block> EmbeddingBlockManager::allocate_shared(
     const Slice<int32_t>& /*token_ids*/,
     const Slice<Block>& /*existed_shared_blocks*/,
     const MMData& /*mm_data*/,
@@ -91,15 +92,15 @@ std::vector<Block> SingleBlockManager::allocate_shared(
   return {};
 }
 
-void SingleBlockManager::cache(const Slice<int32_t>& /*token_ids*/,
-                               std::vector<Block>& /*blocks*/,
-                               size_t /*existed_shared_blocks_num*/,
-                               const MMData& /*mm_data*/,
-                               const Slice<XXH3Key>& /*block_hashes*/) {
+void EmbeddingBlockManager::cache(const Slice<int32_t>& /*token_ids*/,
+                                  std::vector<Block>& /*blocks*/,
+                                  size_t /*existed_shared_blocks_num*/,
+                                  const MMData& /*mm_data*/,
+                                  const Slice<XXH3Key>& /*block_hashes*/) {
   NOT_IMPLEMENTED();
 }
 
-void SingleBlockManager::cache(const std::vector<Block>& /*blocks*/) {
+void EmbeddingBlockManager::cache(const std::vector<Block>& /*blocks*/) {
   NOT_IMPLEMENTED();
 }
 

--- a/xllm/core/framework/block/embedding_block_manager.h
+++ b/xllm/core/framework/block/embedding_block_manager.h
@@ -21,24 +21,24 @@ limitations under the License.
 
 namespace xllm {
 
-// Per-sequence single-resource leaf (BlockType::SINGLE): linear-state /
-// embedding row id, exactly one block per sequence, reused for its lifetime.
+// Per-sequence single-resource leaf (BlockType::EMBEDDING): the spec-decode
+// embedding-row id, exactly one block per sequence, reused for its lifetime.
 //
 // The physical id pool (free list, allocate / deallocate / free, num_*
 // accounting, id-0 padding) is identical to BlockManagerImpl, so this derives
 // from it and reuses that machinery. block_size is 1 (each id is one block) and
 // there is no prefix cache. What differs is the sequence-level policy: grow
 // allocates one block only when the sequence does not already hold one.
-class SingleBlockManager final : public BlockManagerImpl {
+class EmbeddingBlockManager final : public BlockManagerImpl {
  public:
-  SingleBlockManager(uint32_t num_blocks,
-                     std::string resource_name,
-                     std::string exhaustion_message = "");
-  ~SingleBlockManager() override = default;
+  EmbeddingBlockManager(uint32_t num_blocks,
+                        std::string resource_name,
+                        std::string exhaustion_message = "");
+  ~EmbeddingBlockManager() override = default;
 
   // One block per sequence: empty when already held, else a single block (or
   // std::nullopt when the pool is exhausted). Does not insert into the sequence
-  // -- the composite commits the returned block under BlockType::SINGLE.
+  // -- the composite commits the returned block under BlockType::EMBEDDING.
   std::optional<std::vector<Block>> allocate_for_sequence(
       Sequence* seq,
       size_t num_tokens) override;
@@ -52,7 +52,7 @@ class SingleBlockManager final : public BlockManagerImpl {
   using BlockManagerImpl::allocate;
   Block allocate() override;
 
-  // SINGLE never serves prefix cache; these must not be reached.
+  // EMBEDDING never serves prefix cache; these must not be reached.
   std::vector<Block> allocate_shared(
       const Slice<int32_t>& token_ids,
       const Slice<Block>& existed_shared_blocks = {},

--- a/xllm/core/framework/kv_cache/kv_cache.cpp
+++ b/xllm/core/framework/kv_cache/kv_cache.cpp
@@ -108,7 +108,7 @@ std::unique_ptr<KVCacheImpl> create_host_kv_cache_impl(
   }
 
   switch (type) {
-    case BlockType::SINGLE:
+    case BlockType::LINEAR:
       return std::make_unique<LinearAttentionKVCacheImpl>(
           kv_cache_shape, create_options, type, layer_count);
     case BlockType::KV:

--- a/xllm/core/framework/kv_cache/kv_cache_impl.cpp
+++ b/xllm/core/framework/kv_cache/kv_cache_impl.cpp
@@ -136,7 +136,7 @@ std::vector<KVCacheTensor> KVCacheImpl::get_cache_tensors() const {
       tensors.emplace_back(KVCacheTensor{role,
                                          tensor,
                                          cache_group_id(block_type),
-                                         block_type == BlockType::SINGLE});
+                                         block_type == BlockType::LINEAR});
     }
   };
 
@@ -148,8 +148,8 @@ std::vector<KVCacheTensor> KVCacheImpl::get_cache_tensors() const {
     add_tensor(
         KVCacheTensorRole::INDEX_SCALE, index_scale.value(), BlockType::KV);
   }
-  add_tensor(KVCacheTensorRole::CONV, get_conv_cache(), BlockType::SINGLE);
-  add_tensor(KVCacheTensorRole::SSM, get_ssm_cache(), BlockType::SINGLE);
+  add_tensor(KVCacheTensorRole::CONV, get_conv_cache(), BlockType::LINEAR);
+  add_tensor(KVCacheTensorRole::SSM, get_ssm_cache(), BlockType::LINEAR);
   const auto key_scale = get_k_cache_scale();
   if (key_scale.has_value()) {
     add_tensor(KVCacheTensorRole::KEY_SCALE, key_scale.value(), BlockType::KV);

--- a/xllm/core/framework/kv_cache/linear_attention_kv_cache_impl.cpp
+++ b/xllm/core/framework/kv_cache/linear_attention_kv_cache_impl.cpp
@@ -43,9 +43,9 @@ LinearAttentionKVCacheImpl::LinearAttentionKVCacheImpl(
     BlockType type,
     int64_t layer_count)
     : KVCacheImpl() {
-  CHECK(type == BlockType::SINGLE)
+  CHECK(type == BlockType::LINEAR)
       << "LinearAttentionKVCacheImpl host cache only supports "
-         "BlockType::SINGLE.";
+         "BlockType::LINEAR.";
   host_page_aligned_regions_.reserve(2);
   if (kv_cache_shape.has_conv_cache_shape()) {
     create_host_tensor(
@@ -78,7 +78,7 @@ torch::Tensor LinearAttentionKVCacheImpl::get_ssm_cache() const {
 BlockTypeTensorMap LinearAttentionKVCacheImpl::get_block_type_tensors(
     BlockType type) const {
   BlockTypeTensorMap tensor_map;
-  if (type != BlockType::SINGLE) {
+  if (type != BlockType::LINEAR) {
     return tensor_map;
   }
   if (conv_cache_.defined() && conv_cache_.numel() > 0) {

--- a/xllm/core/framework/kv_cache_transfer/hierarchy_kv_cache_transfer.cpp
+++ b/xllm/core/framework/kv_cache_transfer/hierarchy_kv_cache_transfer.cpp
@@ -90,7 +90,7 @@ BlockTypeTensorMap build_block_type_tensor_map(const KVCache& kv_cache,
         map.emplace(KVCacheTensorRole::INDEX_SCALE, index_cache_scale.value());
       }
       return map;
-    case BlockType::SINGLE:
+    case BlockType::LINEAR:
       if (has_tensor(conv_cache)) {
         map.emplace(KVCacheTensorRole::CONV, conv_cache);
       }
@@ -173,7 +173,7 @@ void HierarchyKVCacheTransfer::build_device_block_type_map() {
   device_block_type_layer_ids_.clear();
 
   const std::vector<BlockType> kBlockTypes = {BlockType::KV,
-                                              BlockType::SINGLE,
+                                              BlockType::LINEAR,
                                               BlockType::SWA,
                                               BlockType::C4,
                                               BlockType::C128};

--- a/xllm/core/framework/request/sequence.cpp
+++ b/xllm/core/framework/request/sequence.cpp
@@ -315,12 +315,12 @@ Sequence::Sequence(const Sequence& other)
   logprob_state_ = std::make_unique<LogprobState>(*other.logprob_state_);
   // A forked sequence (beam / best_of) shares the prompt KV prefix by
   // ref-counting those blocks, but its linear-state / embedding resource block
-  // is private: drop the copied Single and Linear blocks so this sequence
+  // is private: drop the copied Embedding and Linear blocks so this sequence
   // allocates its own on the next allocate. Preserves the pre-map behavior
-  // where single_block_ was never copied by this constructor.
-  kv_state_.erase_blocks(BlockType::SINGLE);
+  // where the private slot was never copied by this constructor.
+  kv_state_.erase_blocks(BlockType::EMBEDDING);
   kv_state_.erase_blocks(BlockType::LINEAR);
-  host_kv_state_.erase_blocks(BlockType::SINGLE);
+  host_kv_state_.erase_blocks(BlockType::EMBEDDING);
   host_kv_state_.erase_blocks(BlockType::LINEAR);
 }
 

--- a/xllm/core/framework/request/sequence.h
+++ b/xllm/core/framework/request/sequence.h
@@ -205,9 +205,9 @@ class Sequence final {
   void clear_mtp_bootstrap_embedding() {
     mtp_bootstrap_embedding_ = torch::Tensor();
   }
-  // Single per-sequence resource block id (linear-state / embedding), or -1.
-  int32_t get_single_block_id() const {
-    return kv_state_.get_single_block_id();
+
+  int32_t get_embedding_block_id() const {
+    return kv_state_.get_embedding_block_id();
   }
 
   // Linear-state (Qwen3.5 GDN) live slot, stored in composite_blocks_ under
@@ -220,16 +220,8 @@ class Sequence final {
     return kv_state_.get_linear_block_id();
   }
 
-  // Recurrent state slot for models with sequence-scoped CONV/SSM caches.
-  // Prefer the dedicated LINEAR slot (Qwen3.5 GDN, drawn from
-  // LinearStateBlockManager); fall back to the SINGLE resource block id for
-  // legacy models where recurrent state still lives in the SINGLE slot. All
-  // P/D endpoints that advertise or consume the recurrent-state slot id must
-  // use this helper so the sender and receiver agree on which slot is holding
-  // the state.
   int32_t get_recurrent_state_slot_id() const {
-    const int32_t linear_slot = get_linear_state_slot_id();
-    return linear_slot >= 0 ? linear_slot : get_single_block_id();
+    return get_linear_state_slot_id();
   }
 
   void set_pending_linear_save(const XXH3Key& hash) {

--- a/xllm/core/framework/request/sequence_kv_state.cpp
+++ b/xllm/core/framework/request/sequence_kv_state.cpp
@@ -89,7 +89,7 @@ size_t KVCacheState::num_blocks(BlockType type) const {
 }
 
 bool KVCacheState::has_any_blocks() const {
-  // Cache-bearing types only; SINGLE is a per-sequence resource block, not
+  // Cache-bearing types only; EMBEDDING is a per-sequence resource block, not
   // token cache, and must not count toward "the sequence already holds cache".
   for (const BlockType type :
        {BlockType::KV, BlockType::SWA, BlockType::C4, BlockType::C128}) {
@@ -144,7 +144,7 @@ void KVCacheState::erase_blocks(BlockType type) {
 }
 
 Block KVCacheState::copy_block(BlockType type) const {
-  DCHECK(type == BlockType::SINGLE || type == BlockType::LINEAR)
+  DCHECK(type == BlockType::EMBEDDING || type == BlockType::LINEAR)
       << "copy_block is for singleton block types only";
   auto it = composite_blocks_.find(type);
   if (it == composite_blocks_.end() || it->second.empty()) {
@@ -319,8 +319,8 @@ bool KVCacheState::has_multi_block_export() const {
   return false;
 }
 
-int32_t KVCacheState::get_single_block_id() const {
-  const auto it = composite_blocks_.find(BlockType::SINGLE);
+int32_t KVCacheState::get_embedding_block_id() const {
+  const auto it = composite_blocks_.find(BlockType::EMBEDDING);
   if (it == composite_blocks_.end() || it->second.empty() ||
       !it->second[0].is_valid()) {
     return -1;

--- a/xllm/core/framework/request/sequence_kv_state.h
+++ b/xllm/core/framework/request/sequence_kv_state.h
@@ -49,9 +49,9 @@ class KVCacheState {
   // Number of blocks held under `type`.
   size_t num_blocks(BlockType type) const;
   // True if the sequence holds any cache-bearing blocks (KV / SWA / C4 / C128).
-  // Excludes SINGLE, which is a per-sequence resource, not token cache. Used to
-  // decide whether an allocation that started from an empty sequence should be
-  // fully rolled back on failure (vs. a grow on an already-populated sequence).
+  // Excludes EMBEDDING, which is a per-sequence resource, not token cache. Used
+  // to decide whether an allocation that started from an empty sequence should
+  // be fully rolled back on failure (vs. a grow on an already-populated seq).
   bool has_any_blocks() const;
   // token <-> physical slot mapping for `type` (paged attention). CHECKs the
   // type is present.
@@ -119,10 +119,10 @@ class KVCacheState {
   // (SWA / C4 / C128).
   bool has_multi_block_export() const;
 
-  // Single per-sequence resource block (BlockType::SINGLE): returns the Single
-  // block id, or -1 when absent. Used for embedding_ids export and disagg-PD's
-  // linear_state_id fallback. Other block types read via blocks(type).
-  int32_t get_single_block_id() const;
+  // Per-sequence embedding-row block (BlockType::EMBEDDING): returns the
+  // EMBEDDING block id, or -1 when absent. Used for embedding_ids export
+  // (spec-decode EmbeddingCache). Other block types read via blocks(type).
+  int32_t get_embedding_block_id() const;
 
   // Linear-state live slot id (BlockType::LINEAR), or -1 when absent.
   int32_t get_linear_block_id() const;
@@ -196,7 +196,8 @@ class KVCacheState {
 
   // KV cache blocks keyed by cache role. The flat attention KV lives under
   // BlockType::KV; DSV4 keeps its SWA / C4 / C128 groups here; the per-sequence
-  // linear/embedding resource block lives under BlockType::SINGLE. std::map
+  // embedding-row slot lives under BlockType::EMBEDDING and the GDN recurrent
+  // slot under BlockType::LINEAR. std::map
   // keeps deterministic iteration for reset / dealloc / debugging, but worker
   // export order is governed by kMultiBlockExportOrder, not by map order.
   std::map<BlockType, std::vector<Block>> composite_blocks_;

--- a/xllm/core/scheduler/disagg_pd_scheduler.cpp
+++ b/xllm/core/scheduler/disagg_pd_scheduler.cpp
@@ -746,10 +746,9 @@ void DisaggPDScheduler::prefill_send_first_generation() {
           block_ids.push_back(block.id());
         }
         ADD_VECTOR_TO_PROTO(gen->mutable_block_ids(), block_ids);
-        // Advertise the recurrent-state slot the D side should pull from.
-        // Prefer the dedicated LINEAR slot (Qwen3.5 GDN); fall back to
-        // SINGLE for legacy models where the CONV/SSM caches still live in
-        // the SINGLE slot. Must match the D-side response helper.
+        // Advertise the recurrent-state slot the D side should pull from: the
+        // dedicated LINEAR slot (Qwen3.5 GDN), or -1 for models without
+        // linear-attention layers. Must match the D-side response helper.
         gen->set_linear_state_id(
             request->sequences()[0]->get_recurrent_state_slot_id());
         gen->set_dp_size(instance_info_.dp_size);
@@ -896,7 +895,7 @@ bool DisaggPDScheduler::decode_recv_first_generation(
       static_cast<size_t>(num_cached_tokens));
   const bool need_mtp_bootstrap = options_.num_speculative_tokens() > 0;
   if (need_mtp_bootstrap) {
-    const int32_t slot_id = sequence->get_single_block_id();
+    const int32_t slot_id = sequence->get_embedding_block_id();
     if (slot_id < 0) {
       LOG(ERROR) << "Invalid MTP bootstrap slot, request_id: " << req_id;
       kv_cache_manager_->deallocate(request.get());
@@ -962,8 +961,8 @@ bool DisaggPDScheduler::decode_recv_first_generation(
     std::vector<uint64_t> src_linear_state_ids;
     std::vector<uint64_t> dst_linear_state_ids;
     // Resolve the destination recurrent-state slot with the same helper the
-    // sender used to advertise src_linear_state_id (LINEAR for Qwen3.5 GDN,
-    // SINGLE otherwise), so PULL writes the pulled state into the slot the
+    // sender used to advertise src_linear_state_id (the LINEAR slot for Qwen3.5
+    // GDN, -1 otherwise), so PULL writes the pulled state into the slot the
     // decode forward actually reads (see
     // Sequence::get_recurrent_state_slot_id).
     const int32_t dst_linear_state_id = sequence->get_recurrent_state_slot_id();

--- a/xllm/core/scheduler/pd_ooc_scheduler.cpp
+++ b/xllm/core/scheduler/pd_ooc_scheduler.cpp
@@ -1648,8 +1648,8 @@ void PDOOCScheduler::prefill_send_first_generation() {
           block_ids.push_back(block.id());
         }
         ADD_VECTOR_TO_PROTO(gen->mutable_block_ids(), block_ids);
-        // Advertise the recurrent-state slot to pull from: LINEAR for
-        // Qwen3.5 GDN, SINGLE fallback. Must match the D-side response
+        // Advertise the recurrent-state slot to pull from: the LINEAR slot for
+        // Qwen3.5 GDN, or -1 otherwise. Must match the D-side response
         // helper (Sequence::get_recurrent_state_slot_id).
         gen->set_linear_state_id(
             request->sequences()[0]->get_recurrent_state_slot_id());
@@ -1796,8 +1796,8 @@ bool PDOOCScheduler::decode_recv_multi_generations(
     std::vector<uint64_t> src_linear_state_ids;
     std::vector<uint64_t> dst_linear_state_ids;
     // Resolve the destination recurrent-state slot with the same helper the
-    // sender used to advertise src_linear_state_id (LINEAR for Qwen3.5 GDN,
-    // SINGLE otherwise), so PULL writes the pulled state into the slot the
+    // sender used to advertise src_linear_state_id (the LINEAR slot for Qwen3.5
+    // GDN, -1 otherwise), so PULL writes the pulled state into the slot the
     // decode forward actually reads (see
     // Sequence::get_recurrent_state_slot_id).
     const int32_t dst_linear_state_id =

--- a/xllm/proto/worker.proto
+++ b/xllm/proto/worker.proto
@@ -110,13 +110,15 @@ enum TransferType {
 }
 
 // Mirrors xllm::BlockType (framework/block/block.h). Kept in wire order so
-// numeric values round-trip losslessly across RPC.
+// numeric values round-trip losslessly across RPC (serialized by number, not
+// name). Enumerator 4 was historically named SINGLE; it is now EMBEDDING to
+// match the C++ enum, with the value pinned at 4 for wire compatibility.
 enum BlockType {
   KV = 0;
   SWA = 1;
   C4 = 2;
   C128 = 3;
-  SINGLE = 4;
+  EMBEDDING = 4;
   LINEAR = 5;
 }
 

--- a/xllm/xllm.cpp
+++ b/xllm/xllm.cpp
@@ -20,7 +20,6 @@ limitations under the License.
 namespace py = pybind11;
 #include <torch/torch.h>
 
-#include <algorithm>
 #if defined(USE_NPU)
 #include <acl/acl.h>
 #endif
@@ -91,33 +90,6 @@ void initialize_configs() {
   SchedulerConfig::get_instance().initialize();
   ServiceConfig::get_instance().initialize();
   SpeculativeConfig::get_instance().initialize();
-
-  // Reconcile the two per-batch admission caps into a single scheduler view
-  // consumed by every downstream user (Master -> Engine -> BlockManagerPool
-  // etc.). max_seqs_per_batch bounds the scheduler batch;
-  // max_concurrent_requests bounds the service-level admission; the effective
-  // batch cap is the tighter of the two. 0 means "unset" on either side; if
-  // both are 0 the caller has no way to size batch-bound resources (e.g. the
-  // SINGLE block pool) and we fail early.
-  {
-    SchedulerConfig& scheduler_config = SchedulerConfig::get_instance();
-    ServiceConfig& service_config = ServiceConfig::get_instance();
-    const int32_t scheduler_cap = scheduler_config.max_seqs_per_batch();
-    const int32_t service_cap = service_config.max_concurrent_requests();
-    int32_t effective_cap = 0;
-    if (scheduler_cap > 0 && service_cap > 0) {
-      effective_cap = std::min(scheduler_cap, service_cap);
-    } else if (scheduler_cap > 0) {
-      effective_cap = scheduler_cap;
-    } else if (service_cap > 0) {
-      effective_cap = service_cap;
-    } else {
-      LOG(FATAL) << "Both max_seqs_per_batch and max_concurrent_requests are "
-                    "0; set at least one to a positive value.";
-    }
-    scheduler_config.max_seqs_per_batch(effective_cap);
-    service_config.max_concurrent_requests(effective_cap);
-  }
 }
 
 Options create_options(const std::string& instance_name, bool is_local) {


### PR DESCRIPTION

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
