### PR TITLE
feat: support DeepSeek-V3.2 Python MTP ACLGraph.

### DIFF
--- a/tests/core/kernels/npu/npu_xllm_ops_test.cpp
+++ b/tests/core/kernels/npu/npu_xllm_ops_test.cpp
@@ -416,5 +416,172 @@ with patch.object(
 )PY");
 }
 
+TEST_F(NpuXllmOpsTest, LightningIndexerOutKeepsBuffersAcrossGraphReplay) {
+  py::gil_scoped_acquire gil;
+
+  py::exec(R"PY(
+import torch
+
+query = torch.randn(
+    (1, 64, 128), dtype=torch.bfloat16, device="privateuseone:0"
+)
+key = torch.randn(
+    (1, 16, 1, 128), dtype=torch.bfloat16, device="privateuseone:0"
+)
+weights = torch.randn(
+    (1, 64), dtype=torch.bfloat16, device="privateuseone:0"
+)
+query_seq_lengths = torch.tensor(
+    [1], dtype=torch.int32, device="privateuseone:0"
+)
+key_seq_lengths = torch.tensor(
+    [16], dtype=torch.int32, device="privateuseone:0"
+)
+block_table = torch.tensor(
+    [[0]], dtype=torch.int32, device="privateuseone:0"
+)
+sparse_indices = torch.empty(
+    (1, 1, 4), dtype=torch.int32, device="privateuseone:0"
+)
+sparse_values = torch.empty(
+    (1, 1, 4), dtype=torch.bfloat16, device="privateuseone:0"
+)
+indices_address = sparse_indices.data_ptr()
+values_address = sparse_values.data_ptr()
+
+
+def run_indexer():
+    return torch.ops.xllm_ops.lightning_indexer_out(
+        query,
+        key,
+        weights,
+        query_seq_lengths,
+        key_seq_lengths,
+        block_table,
+        "TND",
+        "PA_BSND",
+        4,
+        3,
+        2**63 - 1,
+        2**63 - 1,
+        False,
+        sparse_indices,
+        sparse_values,
+    )
+
+
+eager_result = run_indexer()
+assert eager_result.shape == (1, 1, 4)
+assert eager_result.dtype == torch.int32
+assert eager_result.data_ptr() == indices_address
+assert sparse_values.shape == (1, 1, 4)
+assert sparse_values.dtype == torch.bfloat16
+assert sparse_values.data_ptr() == values_address
+
+stream = torch.npu.Stream()
+graph = torch.npu.NPUGraph()
+with torch.npu.stream(stream):
+    run_indexer()
+torch.npu.synchronize()
+with torch.npu.stream(stream):
+    with torch.npu.graph(graph, stream=stream):
+        graph_result = run_indexer()
+torch.npu.synchronize()
+
+with torch.npu.stream(stream):
+    query.add_(0.25)
+    graph.replay()
+    query.sub_(0.5)
+    graph.replay()
+torch.npu.synchronize()
+
+assert graph_result.data_ptr() == indices_address
+assert sparse_indices.data_ptr() == indices_address
+assert sparse_values.data_ptr() == values_address
+)PY");
+}
+
+TEST_F(NpuXllmOpsTest, SparseFlashAttentionOutKeepsBufferAcrossGraphReplay) {
+  py::gil_scoped_acquire gil;
+
+  py::exec(R"PY(
+import torch
+
+query = torch.randn(
+    (1, 8, 512), dtype=torch.bfloat16, device="privateuseone:0"
+)
+key = torch.randn(
+    (1, 16, 1, 512), dtype=torch.bfloat16, device="privateuseone:0"
+)
+value = torch.randn_like(key)
+sparse_indices = torch.tensor(
+    [[[0, 1, 2, 3]]], dtype=torch.int32, device="privateuseone:0"
+)
+block_table = torch.tensor(
+    [[0]], dtype=torch.int32, device="privateuseone:0"
+)
+actual_seq_lengths_query = torch.tensor(
+    [1], dtype=torch.int32, device="privateuseone:0"
+)
+actual_seq_lengths_kv = torch.tensor(
+    [16], dtype=torch.int32, device="privateuseone:0"
+)
+query_rope = torch.randn(
+    (1, 8, 64), dtype=torch.bfloat16, device="privateuseone:0"
+)
+key_rope = torch.randn(
+    (1, 16, 1, 64), dtype=torch.bfloat16, device="privateuseone:0"
+)
+output = torch.empty_like(query)
+output_address = output.data_ptr()
+
+
+def run_attention():
+    return torch.ops.xllm_ops.sparse_flash_attention_out(
+        query,
+        key,
+        value,
+        sparse_indices,
+        block_table,
+        actual_seq_lengths_query,
+        actual_seq_lengths_kv,
+        query_rope,
+        key_rope,
+        1.0 / 16.0,
+        1,
+        "TND",
+        "PA_BSND",
+        3,
+        output,
+    )
+
+
+eager_result = run_attention()
+assert eager_result.shape == query.shape
+assert eager_result.dtype == query.dtype
+assert eager_result.data_ptr() == output_address
+
+stream = torch.npu.Stream()
+graph = torch.npu.NPUGraph()
+with torch.npu.stream(stream):
+    run_attention()
+torch.npu.synchronize()
+with torch.npu.stream(stream):
+    with torch.npu.graph(graph, stream=stream):
+        graph_result = run_attention()
+torch.npu.synchronize()
+
+with torch.npu.stream(stream):
+    query.add_(0.25)
+    graph.replay()
+    query.sub_(0.5)
+    graph.replay()
+torch.npu.synchronize()
+
+assert graph_result.data_ptr() == output_address
+assert output.data_ptr() == output_address
+)PY");
+}
+
 }  // namespace
 }  // namespace xllm

--- a/tests/core/runtime/CMakeLists.txt
+++ b/tests/core/runtime/CMakeLists.txt
@@ -3,6 +3,28 @@ include(cc_test)
 if(USE_NPU)
   cc_test(
     NAME
+      mtp_async_input_builder_test
+    SRCS
+      mtp_async_input_builder_test.cpp
+    DEPS
+      :runtime
+      :models
+      GTest::gtest_main
+      torch
+      torch_npu
+      pybind11::embed
+  )
+  target_link_libraries(mtp_async_input_builder_test
+                        PRIVATE
+                        torch_python
+                        Python::Python
+                        ascendcl
+                        hccl
+                        c_sec
+                        nnopbase)
+
+  cc_test(
+    NAME
       acl_graph_executor_test
     SRCS
       acl_graph_executor_test.cpp

--- a/tests/core/runtime/mtp_async_input_builder_test.cpp
+++ b/tests/core/runtime/mtp_async_input_builder_test.cpp
@@ -1,0 +1,250 @@
+/* Copyright 2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "core/runtime/mtp_async_input_builder.h"
+
+#include <gtest/gtest.h>
+#include <pybind11/embed.h>
+#include <pybind11/stl.h>
+#include <torch/extension.h>
+#include <torch/torch.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "core/layers/common/attention_metadata.h"
+#include "core/layers/common/expanded_decode_metadata_builder.h"
+#include "core/runtime/forward_params.h"
+#include "core/runtime/py_attention_metadata.h"
+#include "models/llm/py_causal_lm.h"
+
+namespace py = pybind11;
+
+namespace xllm::mtp_async {
+namespace {
+
+constexpr int32_t kBlockSize = 4;
+
+ForwardInput make_draft_input(int64_t batch_size, int64_t hidden_size) {
+  ForwardInput input;
+  input.token_ids = torch::zeros({batch_size * 2}, torch::kInt);
+  input.positions = torch::zeros({batch_size * 2}, torch::kInt);
+  input.input_params.embedding.input_embedding =
+      torch::zeros({batch_size * 2, hidden_size}, torch::kFloat32);
+  input.input_params.attention.device.kv_seq_lens =
+      torch::zeros({batch_size * 2}, torch::kInt);
+  return input;
+}
+
+ForwardInput make_block_table_source(const torch::Tensor& block_tables,
+                                     std::vector<int32_t> kv_seq_lens) {
+  ForwardInput input;
+  input.input_params.attention.device.block_tables = block_tables;
+  input.input_params.attention.host.block_tables = block_tables;
+  input.input_params.attention.host.kv_seq_lens = std::move(kv_seq_lens);
+  input.input_params.multi_block_tables.emplace_back(torch::zeros({1}));
+  return input;
+}
+
+void prepare_single_sequence(ForwardInput& draft_input,
+                             const ForwardInput& block_table_source,
+                             int32_t base_kv_seq_len) {
+  const torch::Tensor accepted_tokens = torch::tensor({{42, -1}}, torch::kLong);
+  const torch::Tensor accepted_embeddings =
+      torch::tensor({{{1.0F, 2.0F}, {3.0F, 4.0F}}});
+  const torch::Tensor embedding_placeholder = torch::zeros({2});
+  const torch::Tensor base_positions =
+      torch::tensor({base_kv_seq_len - 2}, torch::kInt);
+  const torch::Tensor base_kv_seq_lens =
+      torch::tensor({base_kv_seq_len - 1}, torch::kInt);
+
+  prepare_next_draft_from_accepted_state(draft_input,
+                                         block_table_source,
+                                         accepted_tokens,
+                                         accepted_embeddings,
+                                         embedding_placeholder,
+                                         base_positions,
+                                         base_kv_seq_lens,
+                                         /*use_chunked_prefill=*/false,
+                                         kBlockSize);
+}
+
+void prepend_python_model_path() {
+  std::filesystem::path repo_root(__FILE__);
+  for (int32_t depth = 0; depth < 4; ++depth) {
+    repo_root = repo_root.parent_path();
+  }
+  py::list sys_path = py::module_::import("sys").attr("path");
+  sys_path.attr("insert")(0, repo_root.string());
+}
+
+TEST(MtpAsyncInputBuilderTest, BuildsExpandedMetadataAcrossBlockBoundary) {
+  ForwardInput draft_input = make_draft_input(/*batch_size=*/1,
+                                              /*hidden_size=*/2);
+  const torch::Tensor block_tables = torch::tensor({{10, 11}}, torch::kInt);
+  ForwardInput block_table_source = make_block_table_source(block_tables, {5});
+
+  prepare_single_sequence(
+      draft_input, block_table_source, /*base_kv_seq_len=*/5);
+
+  const auto& attention = draft_input.input_params.attention.device;
+  EXPECT_TRUE(torch::equal(draft_input.input_params.graph.expanded_kv_seq_lens,
+                           torch::tensor({4, 5}, torch::kInt)));
+  EXPECT_EQ(draft_input.input_params.graph.expanded_kv_seq_lens_vec,
+            (std::vector<int32_t>{4, 5}));
+  EXPECT_TRUE(torch::equal(attention.paged_kv_indptr,
+                           torch::tensor({0, 1, 3}, torch::kInt)));
+  EXPECT_TRUE(torch::equal(attention.paged_kv_indices,
+                           torch::tensor({10, 10, 11}, torch::kInt)));
+  EXPECT_TRUE(torch::equal(attention.paged_kv_last_page_len,
+                           torch::tensor({4, 1}, torch::kInt)));
+}
+
+TEST(MtpAsyncInputBuilderTest, BuildsTokenwiseSpecVerifyKvLengths) {
+  EXPECT_EQ(layer::ExpandedDecodeMetadataBuilder::build_tokenwise_kv_seq_lens(
+                /*q_seq_lens=*/{2, 1}, /*kv_seq_lens=*/{4, 3}),
+            (std::vector<int32_t>{3, 4, 3}));
+}
+
+TEST(MtpAsyncInputBuilderTest, KeepsGenericPagedMetadataSeparate) {
+  ModelInputParams params;
+  params.attention.device.paged_kv_indptr = torch::tensor({0, 1}, torch::kInt);
+  params.attention.device.paged_kv_indices = torch::tensor({99}, torch::kInt);
+  params.attention.device.paged_kv_last_page_len =
+      torch::tensor({1}, torch::kInt);
+
+  layer::ExpandedDecodeMetadataBuilder::populate_expanded_layout(
+      params,
+      torch::tensor({3, 4}, torch::kInt),
+      torch::tensor({{10}, {10}}, torch::kInt),
+      /*expanded_host_kv_seq_lens=*/{3, 4},
+      kBlockSize);
+
+  EXPECT_TRUE(torch::equal(params.attention.device.paged_kv_indptr,
+                           torch::tensor({0, 1}, torch::kInt)));
+  EXPECT_TRUE(torch::equal(params.attention.device.paged_kv_indices,
+                           torch::tensor({99}, torch::kInt)));
+  EXPECT_TRUE(torch::equal(params.graph.expanded_paged_kv_indptr,
+                           torch::tensor({0, 1, 2}, torch::kInt)));
+  EXPECT_TRUE(torch::equal(params.graph.expanded_paged_kv_indices,
+                           torch::tensor({10, 10}, torch::kInt)));
+}
+
+TEST(MtpAsyncInputBuilderTest, SupportsMaximumBlockTableWidth) {
+  ForwardInput draft_input = make_draft_input(/*batch_size=*/1,
+                                              /*hidden_size=*/2);
+  const torch::Tensor block_tables = torch::tensor({{10, 11}}, torch::kInt);
+  ForwardInput block_table_source = make_block_table_source(block_tables, {8});
+
+  prepare_single_sequence(
+      draft_input, block_table_source, /*base_kv_seq_len=*/8);
+
+  const auto& attention = draft_input.input_params.attention.device;
+  EXPECT_TRUE(torch::equal(attention.paged_kv_indptr,
+                           torch::tensor({0, 2, 4}, torch::kInt)));
+  EXPECT_TRUE(torch::equal(attention.paged_kv_indices,
+                           torch::tensor({10, 11, 10, 11}, torch::kInt)));
+  EXPECT_TRUE(torch::equal(attention.paged_kv_last_page_len,
+                           torch::tensor({3, 4}, torch::kInt)));
+}
+
+TEST(MtpAsyncInputBuilderTest, RejectsPageCountBeyondBlockTableWidth) {
+  ForwardInput draft_input = make_draft_input(/*batch_size=*/1,
+                                              /*hidden_size=*/2);
+  const torch::Tensor block_tables = torch::tensor({{10, 11}}, torch::kInt);
+  ForwardInput block_table_source = make_block_table_source(block_tables, {9});
+
+  EXPECT_DEATH(prepare_single_sequence(
+                   draft_input, block_table_source, /*base_kv_seq_len=*/9),
+               "Expanded KV length exceeds block-table capacity");
+}
+
+TEST(MtpAsyncInputBuilderTest, PybindViewSelectsExpandedGraphMetadata) {
+  if (!Py_IsInitialized()) {
+    setenv("TORCH_DEVICE_BACKEND_AUTOLOAD", "0", 1);
+    Py_InitializeEx(0);
+  }
+  py::gil_scoped_acquire gil;
+  prepend_python_model_path();
+  py::module_ main_module = py::module_::import("__main__");
+  register_attention_metadata_views(main_module);
+
+  auto metadata = std::make_shared<layer::AttentionMetadata>();
+  metadata->slot_mapping = torch::arange(4, torch::kInt);
+  metadata->expanded_decode.enabled = true;
+  metadata->expanded_decode.kv_seq_lens =
+      torch::tensor({3, 4, 7, 8}, torch::kInt);
+  metadata->expanded_decode.block_table =
+      torch::tensor({{10, 11}, {10, 11}, {20, 21}, {20, 21}}, torch::kInt);
+  metadata->expanded_decode.paged_kv_indptr =
+      torch::tensor({0, 1, 2, 4, 6}, torch::kInt);
+  metadata->expanded_decode.paged_kv_indices =
+      torch::tensor({10, 10, 20, 21, 20, 21}, torch::kInt);
+  metadata->expanded_decode.paged_kv_last_page_len =
+      torch::tensor({3, 4, 3, 4}, torch::kInt);
+  metadata->expanded_decode.kv_seq_lens_host_vec = {3, 4, 7, 8};
+  metadata->expanded_decode.kv_seq_lens_host =
+      torch::tensor({3, 4, 7, 8}, torch::kInt);
+
+  py::module_ runner_module = py::module_::import(
+      "xllm.python.model_executor.runners.decode_acl_graph");
+  py::object runner_class = runner_module.attr("DecodeAclGraphRunner");
+  py::object runner = runner_class.attr("__new__")(runner_class);
+  py::module_ types = py::module_::import("types");
+  runner.attr("attention_backend") = types.attr("SimpleNamespace")(
+      py::arg("page_size") = kBlockSize, py::arg("is_mla") = false);
+
+  py::object py_metadata = py::cast(PyAttentionMetadataView(metadata));
+  py::tuple selected = runner.attr("_decode_metadata")(py_metadata);
+
+  EXPECT_TRUE(torch::equal(selected[0].cast<torch::Tensor>(),
+                           metadata->expanded_decode.block_table));
+  EXPECT_TRUE(torch::equal(selected[1].cast<torch::Tensor>(),
+                           metadata->expanded_decode.kv_seq_lens));
+  EXPECT_EQ(selected[2].cast<std::vector<int32_t>>(),
+            metadata->expanded_decode.kv_seq_lens_host_vec);
+  EXPECT_TRUE(torch::equal(selected[3].cast<torch::Tensor>(),
+                           metadata->expanded_decode.paged_kv_indptr));
+}
+
+TEST(MtpAsyncInputBuilderTest, SharedModulesPointToTargetModel) {
+  py::gil_scoped_acquire gil;
+  py::module_ types = py::module_::import("types");
+  py::object target_lm_head = py::module_::import("builtins").attr("object")();
+  py::object target_embedding =
+      py::module_::import("builtins").attr("object")();
+  py::object target_body =
+      types.attr("SimpleNamespace")(py::arg("embed_tokens") = target_embedding);
+  py::object target_model = types.attr("SimpleNamespace")(
+      py::arg("lm_head") = target_lm_head, py::arg("model") = target_body);
+  py::object draft_body =
+      types.attr("SimpleNamespace")(py::arg("embed_tokens") = py::none());
+  py::object draft_model = types.attr("SimpleNamespace")(
+      py::arg("lm_head") = py::none(), py::arg("model") = draft_body);
+
+  ::xllm::detail::share_python_model_weights(draft_model, target_model);
+
+  py::object draft_lm_head = draft_model.attr("lm_head");
+  py::object draft_embedding = draft_model.attr("model").attr("embed_tokens");
+  EXPECT_TRUE(draft_lm_head.is(target_lm_head));
+  EXPECT_TRUE(draft_embedding.is(target_embedding));
+}
+
+}  // namespace
+}  // namespace xllm::mtp_async

--- a/tests/core/runtime/mtp_async_state_test.cpp
+++ b/tests/core/runtime/mtp_async_state_test.cpp
@@ -29,6 +29,7 @@ TEST(MtpAsyncStateTest, ClassifiesClosedTargetSpecVerifyPolicy) {
       {"qwen3_5_moe", TargetSpecVerifyMode::QWEN3_5_EXPANDED_VERIFY},
       {"qwen3_5_text", TargetSpecVerifyMode::QWEN3_5_EXPANDED_VERIFY},
       {"qwen3_5_moe_text", TargetSpecVerifyMode::QWEN3_5_EXPANDED_VERIFY},
+      {"deepseek_v32", TargetSpecVerifyMode::DEEPSEEK_V32_EXPANDED_VERIFY},
       {"mimo", TargetSpecVerifyMode::CAUSAL_CHUNKED_PREFILL},
       {"qwen3_next", TargetSpecVerifyMode::GENERIC},
       {"qwen3_5_mtp", TargetSpecVerifyMode::GENERIC},

--- a/tests/python/test_deepseek_v32_mtp.py
+++ b/tests/python/test_deepseek_v32_mtp.py
@@ -1,0 +1,101 @@
+# Copyright 2026 The xLLM Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://github.com/jd-opensource/xllm/blob/main/LICENSE
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+import torch.nn as nn
+
+pytest.importorskip("torch_npu")
+
+from xllm.python.models import deepseek_v32_mtp
+
+
+def test_mtp_constructor_defers_shared_target_modules() -> None:
+    config = {
+        "device": "cpu",
+        "dtype": "float32",
+        "tp_size": 1,
+        "tp_rank": 0,
+    }
+    model_config = SimpleNamespace(vocab_size=16)
+    mtp_body = nn.Module()
+    mtp_body.embed_tokens = None
+
+    with (
+        patch.object(
+            deepseek_v32_mtp.DeepseekV3Config,
+            "from_dict",
+            return_value=model_config,
+        ),
+        patch.object(
+            deepseek_v32_mtp.DeepseekV3ForCausalLM,
+            "resolve_dtype",
+            return_value=torch.float32,
+        ),
+        patch.object(
+            deepseek_v32_mtp,
+            "DeepseekV32MtpModel",
+            return_value=mtp_body,
+        ),
+    ):
+        draft = deepseek_v32_mtp.DeepseekV32MtpForCausalLM(config)
+
+    assert draft.lm_head is None
+    assert draft.model is mtp_body
+    assert draft.model.embed_tokens is None
+
+    target_lm_head = nn.Linear(4, 16, bias=False)
+    target_embedding = nn.Embedding(16, 4)
+    draft.lm_head = target_lm_head
+    draft.model.embed_tokens = target_embedding
+
+    assert draft.lm_head is target_lm_head
+    assert draft.model.embed_tokens is target_embedding
+
+
+def test_mtp_load_rejects_missing_required_weights() -> None:
+    config = {
+        "device": "cpu",
+        "dtype": "float32",
+        "tp_size": 1,
+        "tp_rank": 0,
+    }
+    model_config = SimpleNamespace(vocab_size=16)
+    mtp_body = nn.Module()
+    mtp_body.embed_tokens = None
+
+    with (
+        patch.object(
+            deepseek_v32_mtp.DeepseekV3Config,
+            "from_dict",
+            return_value=model_config,
+        ),
+        patch.object(
+            deepseek_v32_mtp.DeepseekV3ForCausalLM,
+            "resolve_dtype",
+            return_value=torch.float32,
+        ),
+        patch.object(
+            deepseek_v32_mtp,
+            "DeepseekV32MtpModel",
+            return_value=mtp_body,
+        ),
+        patch.object(deepseek_v32_mtp.DeepseekV3ForCausalLM, "load_weights"),
+    ):
+        draft = deepseek_v32_mtp.DeepseekV32MtpForCausalLM(config)
+        with pytest.raises(KeyError, match="missing required MTP weight"):
+            draft.load_weights([], tp_rank=0, tp_size=1)

--- a/tests/python/test_kernels_import.py
+++ b/tests/python/test_kernels_import.py
@@ -63,12 +63,22 @@ _NPU_SCHEMAS = (
     "query_seq_lengths, Tensor? key_seq_lengths, Tensor? block_table, str "
     "layout_query, str layout_key, int selected_count, int sparse_mode, int "
     "pre_tokens, int next_tokens, bool return_value) -> Tensor",
+    "lightning_indexer_out(Tensor query, Tensor key, Tensor weights, Tensor? "
+    "query_seq_lengths, Tensor? key_seq_lengths, Tensor? block_table, str "
+    "layout_query, str layout_key, int selected_count, int sparse_mode, int "
+    "pre_tokens, int next_tokens, bool return_value, Tensor(a!) "
+    "sparse_indices_out, Tensor(b!) sparse_values_out) -> Tensor",
     "scatter_nd_update(Tensor(a!) var, Tensor indices, Tensor updates) -> ()",
     "sparse_flash_attention(Tensor query, Tensor key, Tensor value, Tensor "
     "sparse_indices, Tensor? block_table, Tensor? actual_seq_lengths_query, "
     "Tensor? actual_seq_lengths_kv, Tensor? query_rope, Tensor? key_rope, "
     "float scale_value, int sparse_block_size, str layout_query, str "
     "layout_kv, int sparse_mode) -> Tensor",
+    "sparse_flash_attention_out(Tensor query, Tensor key, Tensor value, Tensor "
+    "sparse_indices, Tensor? block_table, Tensor? actual_seq_lengths_query, "
+    "Tensor? actual_seq_lengths_kv, Tensor? query_rope, Tensor? key_rope, "
+    "float scale_value, int sparse_block_size, str layout_query, str layout_kv, "
+    "int sparse_mode, Tensor(a!) output) -> Tensor",
 )
 
 _PLATFORM_REQUIRED = pytest.mark.skipif(

--- a/tests/python/test_model_executor.py
+++ b/tests/python/test_model_executor.py
@@ -48,6 +48,9 @@ from xllm.python.model_executor.runners.decode_cuda_graph import (  # noqa: E402
     DecodeCudaGraphRunner,
     _decode_graph_buckets,
 )
+from xllm.python.model_executor.runners.decode_acl_graph import (  # noqa: E402
+    DecodeAclGraphRunner,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -79,6 +82,12 @@ class StubAttentionBackend(AttentionBackend):
     @property
     def page_size(self) -> int:
         return 1
+
+
+class _PagedStubAttentionBackend(StubAttentionBackend):
+    @property
+    def page_size(self) -> int:
+        return 4
 
 
 def _make_attention_layer(
@@ -368,6 +377,226 @@ class TestDecodeCudaGraphDataParallelKeys:
         input_ids = torch.zeros(1, dtype=torch.int32)
 
         assert runner._graph_key(input_ids, self._metadata(token_counts)) is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: DecodeAclGraphRunner speculative metadata
+# ---------------------------------------------------------------------------
+
+
+class TestDecodeAclGraphSpeculativeMetadata:
+    @staticmethod
+    def _runner() -> DecodeAclGraphRunner:
+        return DecodeAclGraphRunner(
+            nn.Identity(),
+            _PagedStubAttentionBackend(),
+            torch.device("cpu"),
+            max_batch=4,
+            max_model_len=8,
+        )
+
+    @staticmethod
+    def _metadata() -> SimpleNamespace:
+        return SimpleNamespace(
+            slot_mapping=torch.arange(4, dtype=torch.int32),
+            paged_kv_indptr=torch.tensor(
+                [0, 1, 2, 4, 6], dtype=torch.int32
+            ),
+            paged_kv_indices=torch.tensor(
+                [10, 10, 20, 21, 20, 21], dtype=torch.int32
+            ),
+            paged_kv_last_page_len=torch.tensor(
+                [3, 4, 3, 4], dtype=torch.int32
+            ),
+            q_cu_seq_lens=torch.tensor([0, 2, 4], dtype=torch.int32),
+            kv_cu_seq_lens=torch.tensor([0, 4, 12], dtype=torch.int32),
+            kv_seq_lens_host=torch.tensor([4, 8], dtype=torch.int32),
+            kv_seq_lens_host_values=[4, 8],
+            block_table=torch.tensor(
+                [[10, 11], [20, 21]], dtype=torch.int32
+            ),
+            kv_seq_lens=torch.tensor([4, 8], dtype=torch.int32),
+            q_seq_lens=torch.tensor([2, 2], dtype=torch.int32),
+            expanded_decode_metadata=SimpleNamespace(
+                enabled=True,
+                kv_seq_lens=torch.tensor(
+                    [3, 4, 7, 8], dtype=torch.int32
+                ),
+                block_table=torch.tensor(
+                    [[10, 11], [10, 11], [20, 21], [20, 21]],
+                    dtype=torch.int32,
+                ),
+                paged_kv_indptr=torch.tensor(
+                    [0, 1, 2, 4, 6], dtype=torch.int32
+                ),
+                paged_kv_indices=torch.tensor(
+                    [10, 10, 20, 21, 20, 21], dtype=torch.int32
+                ),
+                paged_kv_last_page_len=torch.tensor(
+                    [3, 4, 3, 4], dtype=torch.int32
+                ),
+                paged_attention_tiling_data=None,
+                kv_seq_lens_host=torch.tensor(
+                    [3, 4, 7, 8], dtype=torch.int32
+                ),
+                kv_seq_lens_host_values=[3, 4, 7, 8],
+            ),
+            is_prefill=False,
+            is_chunked_prefill=True,
+        )
+
+    def test_expanded_metadata_selects_matching_paged_kv_rows(self) -> None:
+        runner = self._runner()
+        (
+            block_table,
+            kv_seq_lens,
+            _,
+            paged_kv_indptr,
+            paged_kv_indices,
+            paged_kv_last_page_len,
+        ) = runner._decode_metadata(self._metadata())
+
+        assert block_table.tolist() == [
+            [10, 11],
+            [10, 11],
+            [20, 21],
+            [20, 21],
+        ]
+        assert kv_seq_lens.tolist() == [3, 4, 7, 8]
+        assert paged_kv_indptr.tolist() == [0, 1, 2, 4, 6]
+        assert paged_kv_indices.tolist() == [10, 10, 20, 21, 20, 21]
+        assert paged_kv_last_page_len.tolist() == [3, 4, 3, 4]
+
+    def test_expanded_chunked_verify_can_use_decode_graph(self) -> None:
+        runner = self._runner()
+        input_ids = torch.arange(4, dtype=torch.int32)
+
+        assert runner.can_execute(input_ids, self._metadata())
+
+    @pytest.mark.parametrize(
+        ("field", "value", "message"),
+        [
+            (
+                "block_table",
+                torch.arange(8, dtype=torch.int32),
+                "block_table must be two-dimensional",
+            ),
+            (
+                "kv_seq_lens",
+                torch.tensor([3, 4, 7], dtype=torch.int32),
+                "kv_seq_lens must contain one value per sequence",
+            ),
+            (
+                "kv_seq_lens_host",
+                torch.tensor([3, 4, 7], dtype=torch.int32),
+                "kv_seq_lens_host must contain one value per sequence",
+            ),
+            (
+                "paged_kv_indptr",
+                torch.tensor([0, 1, 2, 4], dtype=torch.int32),
+                "paged_kv_indptr must contain one offset per sequence",
+            ),
+            (
+                "paged_kv_indices",
+                torch.tensor([[10, 10], [20, 21]], dtype=torch.int32),
+                "paged_kv_indices must be a non-empty flat page list",
+            ),
+            (
+                "paged_kv_last_page_len",
+                torch.tensor([3, 4, 3], dtype=torch.int32),
+                "paged_kv_last_page_len must contain one value per sequence",
+            ),
+        ],
+    )
+    def test_expanded_metadata_shape_mismatch_fails(
+        self,
+        field: str,
+        value: torch.Tensor,
+        message: str,
+    ) -> None:
+        metadata = self._metadata()
+        setattr(metadata.expanded_decode_metadata, field, value)
+
+        with pytest.raises(RuntimeError, match=message):
+            self._runner()._decode_metadata(metadata)
+
+    @pytest.mark.parametrize(
+        ("field", "value", "message"),
+        [
+            (
+                "paged_kv_indptr",
+                torch.tensor([1, 1, 2, 4, 6], dtype=torch.int32),
+                "must start at zero",
+            ),
+            (
+                "paged_kv_indptr",
+                torch.tensor([0, 2, 1, 4, 6], dtype=torch.int32),
+                "must be monotonic",
+            ),
+            (
+                "paged_kv_indptr",
+                torch.tensor([0, 1, 2, 4, 5], dtype=torch.int32),
+                "terminal page offset must match page count",
+            ),
+            (
+                "paged_kv_last_page_len",
+                torch.tensor([3, 4, 0, 4], dtype=torch.int32),
+                "last-page lengths must be positive",
+            ),
+            (
+                "paged_kv_last_page_len",
+                torch.tensor([3, 4, 5, 4], dtype=torch.int32),
+                "must not exceed block size",
+            ),
+        ],
+    )
+    def test_expanded_paged_metadata_invariant_fails(
+        self,
+        field: str,
+        value: torch.Tensor,
+        message: str,
+    ) -> None:
+        metadata = self._metadata()
+        setattr(metadata.expanded_decode_metadata, field, value)
+
+        with pytest.raises(RuntimeError, match=message):
+            self._runner()._decode_metadata(metadata)
+
+    def test_expanded_page_count_exceeding_capacity_fails(self) -> None:
+        metadata = self._metadata()
+        metadata.expanded_decode_metadata.kv_seq_lens_host_values = [3, 4, 7, 9]
+
+        with pytest.raises(RuntimeError, match="exceeds block-table capacity"):
+            self._runner()._decode_metadata(metadata)
+
+    @pytest.mark.parametrize(
+        ("input_ids", "slot_mapping", "message"),
+        [
+            (
+                torch.arange(3, dtype=torch.int32),
+                torch.arange(4, dtype=torch.int32),
+                "input_ids must contain one token per sequence",
+            ),
+            (
+                torch.arange(4, dtype=torch.int32),
+                torch.arange(3, dtype=torch.int32),
+                "slot_mapping must contain one slot per token",
+            ),
+        ],
+    )
+    def test_token_layout_mismatch_fails(
+        self,
+        input_ids: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        message: str,
+    ) -> None:
+        with pytest.raises(RuntimeError, match=message):
+            self._runner()._validate_decode_token_layout(
+                input_ids,
+                torch.arange(4, dtype=torch.int32),
+                slot_mapping,
+                sequence_count=4,
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/python/test_model_executor.py
+++ b/tests/python/test_model_executor.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import sys
 import types
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import List
 from unittest.mock import MagicMock, patch
 
@@ -38,6 +39,9 @@ from xllm.python.model_executor.executor import (  # noqa: E402
     ModelExecutor,
     _create_attention_backend,
     _resolve_graph_backend,
+)
+from xllm.python.model_executor.runners.decode_acl_graph import (  # noqa: E402
+    DecodeAclGraphRunner,
 )
 
 
@@ -70,6 +74,12 @@ class StubAttentionBackend(AttentionBackend):
     @property
     def page_size(self) -> int:
         return 1
+
+
+class _PagedStubAttentionBackend(StubAttentionBackend):
+    @property
+    def page_size(self) -> int:
+        return 4
 
 
 def _make_attention_layer(
@@ -219,6 +229,226 @@ class TestModelExecutorConstruction:
             )
             assert executor.decode_graph_runner is None
             assert executor.inductor_runner is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: DecodeAclGraphRunner speculative metadata
+# ---------------------------------------------------------------------------
+
+
+class TestDecodeAclGraphSpeculativeMetadata:
+    @staticmethod
+    def _runner() -> DecodeAclGraphRunner:
+        return DecodeAclGraphRunner(
+            nn.Identity(),
+            _PagedStubAttentionBackend(),
+            torch.device("cpu"),
+            max_batch=4,
+            max_model_len=8,
+        )
+
+    @staticmethod
+    def _metadata() -> SimpleNamespace:
+        return SimpleNamespace(
+            slot_mapping=torch.arange(4, dtype=torch.int32),
+            paged_kv_indptr=torch.tensor(
+                [0, 1, 2, 4, 6], dtype=torch.int32
+            ),
+            paged_kv_indices=torch.tensor(
+                [10, 10, 20, 21, 20, 21], dtype=torch.int32
+            ),
+            paged_kv_last_page_len=torch.tensor(
+                [3, 4, 3, 4], dtype=torch.int32
+            ),
+            q_cu_seq_lens=torch.tensor([0, 2, 4], dtype=torch.int32),
+            kv_cu_seq_lens=torch.tensor([0, 4, 12], dtype=torch.int32),
+            kv_seq_lens_host=torch.tensor([4, 8], dtype=torch.int32),
+            kv_seq_lens_host_values=[4, 8],
+            block_table=torch.tensor(
+                [[10, 11], [20, 21]], dtype=torch.int32
+            ),
+            kv_seq_lens=torch.tensor([4, 8], dtype=torch.int32),
+            q_seq_lens=torch.tensor([2, 2], dtype=torch.int32),
+            expanded_decode_metadata=SimpleNamespace(
+                enabled=True,
+                kv_seq_lens=torch.tensor(
+                    [3, 4, 7, 8], dtype=torch.int32
+                ),
+                block_table=torch.tensor(
+                    [[10, 11], [10, 11], [20, 21], [20, 21]],
+                    dtype=torch.int32,
+                ),
+                paged_kv_indptr=torch.tensor(
+                    [0, 1, 2, 4, 6], dtype=torch.int32
+                ),
+                paged_kv_indices=torch.tensor(
+                    [10, 10, 20, 21, 20, 21], dtype=torch.int32
+                ),
+                paged_kv_last_page_len=torch.tensor(
+                    [3, 4, 3, 4], dtype=torch.int32
+                ),
+                paged_attention_tiling_data=None,
+                kv_seq_lens_host=torch.tensor(
+                    [3, 4, 7, 8], dtype=torch.int32
+                ),
+                kv_seq_lens_host_values=[3, 4, 7, 8],
+            ),
+            is_prefill=False,
+            is_chunked_prefill=True,
+        )
+
+    def test_expanded_metadata_selects_matching_paged_kv_rows(self) -> None:
+        runner = self._runner()
+        (
+            block_table,
+            kv_seq_lens,
+            _,
+            paged_kv_indptr,
+            paged_kv_indices,
+            paged_kv_last_page_len,
+        ) = runner._decode_metadata(self._metadata())
+
+        assert block_table.tolist() == [
+            [10, 11],
+            [10, 11],
+            [20, 21],
+            [20, 21],
+        ]
+        assert kv_seq_lens.tolist() == [3, 4, 7, 8]
+        assert paged_kv_indptr.tolist() == [0, 1, 2, 4, 6]
+        assert paged_kv_indices.tolist() == [10, 10, 20, 21, 20, 21]
+        assert paged_kv_last_page_len.tolist() == [3, 4, 3, 4]
+
+    def test_expanded_chunked_verify_can_use_decode_graph(self) -> None:
+        runner = self._runner()
+        input_ids = torch.arange(4, dtype=torch.int32)
+
+        assert runner.can_execute(input_ids, self._metadata())
+
+    @pytest.mark.parametrize(
+        ("field", "value", "message"),
+        [
+            (
+                "block_table",
+                torch.arange(8, dtype=torch.int32),
+                "block_table must be two-dimensional",
+            ),
+            (
+                "kv_seq_lens",
+                torch.tensor([3, 4, 7], dtype=torch.int32),
+                "kv_seq_lens must contain one value per sequence",
+            ),
+            (
+                "kv_seq_lens_host",
+                torch.tensor([3, 4, 7], dtype=torch.int32),
+                "kv_seq_lens_host must contain one value per sequence",
+            ),
+            (
+                "paged_kv_indptr",
+                torch.tensor([0, 1, 2, 4], dtype=torch.int32),
+                "paged_kv_indptr must contain one offset per sequence",
+            ),
+            (
+                "paged_kv_indices",
+                torch.tensor([[10, 10], [20, 21]], dtype=torch.int32),
+                "paged_kv_indices must be a non-empty flat page list",
+            ),
+            (
+                "paged_kv_last_page_len",
+                torch.tensor([3, 4, 3], dtype=torch.int32),
+                "paged_kv_last_page_len must contain one value per sequence",
+            ),
+        ],
+    )
+    def test_expanded_metadata_shape_mismatch_fails(
+        self,
+        field: str,
+        value: torch.Tensor,
+        message: str,
+    ) -> None:
+        metadata = self._metadata()
+        setattr(metadata.expanded_decode_metadata, field, value)
+
+        with pytest.raises(RuntimeError, match=message):
+            self._runner()._decode_metadata(metadata)
+
+    @pytest.mark.parametrize(
+        ("field", "value", "message"),
+        [
+            (
+                "paged_kv_indptr",
+                torch.tensor([1, 1, 2, 4, 6], dtype=torch.int32),
+                "must start at zero",
+            ),
+            (
+                "paged_kv_indptr",
+                torch.tensor([0, 2, 1, 4, 6], dtype=torch.int32),
+                "must be monotonic",
+            ),
+            (
+                "paged_kv_indptr",
+                torch.tensor([0, 1, 2, 4, 5], dtype=torch.int32),
+                "terminal page offset must match page count",
+            ),
+            (
+                "paged_kv_last_page_len",
+                torch.tensor([3, 4, 0, 4], dtype=torch.int32),
+                "last-page lengths must be positive",
+            ),
+            (
+                "paged_kv_last_page_len",
+                torch.tensor([3, 4, 5, 4], dtype=torch.int32),
+                "must not exceed block size",
+            ),
+        ],
+    )
+    def test_expanded_paged_metadata_invariant_fails(
+        self,
+        field: str,
+        value: torch.Tensor,
+        message: str,
+    ) -> None:
+        metadata = self._metadata()
+        setattr(metadata.expanded_decode_metadata, field, value)
+
+        with pytest.raises(RuntimeError, match=message):
+            self._runner()._decode_metadata(metadata)
+
+    def test_expanded_page_count_exceeding_capacity_fails(self) -> None:
+        metadata = self._metadata()
+        metadata.expanded_decode_metadata.kv_seq_lens_host_values = [3, 4, 7, 9]
+
+        with pytest.raises(RuntimeError, match="exceeds block-table capacity"):
+            self._runner()._decode_metadata(metadata)
+
+    @pytest.mark.parametrize(
+        ("input_ids", "slot_mapping", "message"),
+        [
+            (
+                torch.arange(3, dtype=torch.int32),
+                torch.arange(4, dtype=torch.int32),
+                "input_ids must contain one token per sequence",
+            ),
+            (
+                torch.arange(4, dtype=torch.int32),
+                torch.arange(3, dtype=torch.int32),
+                "slot_mapping must contain one slot per token",
+            ),
+        ],
+    )
+    def test_token_layout_mismatch_fails(
+        self,
+        input_ids: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        message: str,
+    ) -> None:
+        with pytest.raises(RuntimeError, match=message):
+            self._runner()._validate_decode_token_layout(
+                input_ids,
+                torch.arange(4, dtype=torch.int32),
+                slot_mapping,
+                sequence_count=4,
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/xllm/api_service/request_id.cpp
+++ b/xllm/api_service/request_id.cpp
@@ -62,6 +62,9 @@ std::string get_header_x_request_id(const brpc::Controller* controller) {
     x_request_id =
         get_valid_header(controller->http_request(), "x-ms-client-request-id");
   }
+  if (x_request_id.empty()) {
+    x_request_id = get_valid_header(controller->http_request(), "trace_id");
+  }
   return x_request_id;
 }
 

--- a/xllm/core/framework/model/causal_lm.h
+++ b/xllm/core/framework/model/causal_lm.h
@@ -167,6 +167,8 @@ class CausalLM : public torch::nn::Module {
     NOT_IMPLEMENTED();
   }
 
+  virtual bool share_weights_from(CausalLM& /*source*/) { return false; }
+
   // DFlash-specific interface. Attention-free scatter-only pass that projects
   // target hidden into the draft's per-layer KV cache. Not part of forward()
   // because it has no attention and its shape doesn't match forward's decode

--- a/xllm/core/framework/model/model_input_params.h
+++ b/xllm/core/framework/model/model_input_params.h
@@ -939,6 +939,9 @@ struct GraphInput {
   bool use_expanded_decode_for_spec_verify_attention = false;
   torch::Tensor expanded_kv_seq_lens;
   torch::Tensor expanded_block_tables;
+  torch::Tensor expanded_paged_kv_indptr;
+  torch::Tensor expanded_paged_kv_indices;
+  torch::Tensor expanded_paged_kv_last_page_len;
   torch::Tensor expanded_tiling_data;
   std::vector<int32_t> expanded_kv_seq_lens_vec;
 #if defined(USE_NPU)
@@ -969,6 +972,12 @@ struct GraphInput {
         use_expanded_decode_for_spec_verify_attention;
     out.expanded_kv_seq_lens = safe_to(expanded_kv_seq_lens, device, true);
     out.expanded_block_tables = safe_to(expanded_block_tables, device, true);
+    out.expanded_paged_kv_indptr =
+        safe_to(expanded_paged_kv_indptr, device, true);
+    out.expanded_paged_kv_indices =
+        safe_to(expanded_paged_kv_indices, device, true);
+    out.expanded_paged_kv_last_page_len =
+        safe_to(expanded_paged_kv_last_page_len, device, true);
     out.expanded_tiling_data = safe_to(expanded_tiling_data, device, true);
     out.expanded_kv_seq_lens_vec = expanded_kv_seq_lens_vec;
 #if defined(USE_NPU)

--- a/xllm/core/framework/model/model_input_params.h
+++ b/xllm/core/framework/model/model_input_params.h
@@ -937,6 +937,9 @@ struct GraphInput {
   bool use_expanded_decode_for_spec_verify_attention = false;
   torch::Tensor expanded_kv_seq_lens;
   torch::Tensor expanded_block_tables;
+  torch::Tensor expanded_paged_kv_indptr;
+  torch::Tensor expanded_paged_kv_indices;
+  torch::Tensor expanded_paged_kv_last_page_len;
   torch::Tensor expanded_tiling_data;
   std::vector<int32_t> expanded_kv_seq_lens_vec;
 #if defined(USE_NPU)
@@ -967,6 +970,12 @@ struct GraphInput {
         use_expanded_decode_for_spec_verify_attention;
     out.expanded_kv_seq_lens = safe_to(expanded_kv_seq_lens, device, true);
     out.expanded_block_tables = safe_to(expanded_block_tables, device, true);
+    out.expanded_paged_kv_indptr =
+        safe_to(expanded_paged_kv_indptr, device, true);
+    out.expanded_paged_kv_indices =
+        safe_to(expanded_paged_kv_indices, device, true);
+    out.expanded_paged_kv_last_page_len =
+        safe_to(expanded_paged_kv_last_page_len, device, true);
     out.expanded_tiling_data = safe_to(expanded_tiling_data, device, true);
     out.expanded_kv_seq_lens_vec = expanded_kv_seq_lens_vec;
 #if defined(USE_NPU)

--- a/xllm/core/kernels/npu/npu_ops_library.cpp
+++ b/xllm/core/kernels/npu/npu_ops_library.cpp
@@ -187,6 +187,13 @@ TORCH_LIBRARY(xllm_ops, m) {
       "sparse_mode, int pre_tokens, int next_tokens, bool return_value) -> "
       "Tensor");
   m.def(
+      "lightning_indexer_out(Tensor query, Tensor key, Tensor weights, "
+      "Tensor? query_seq_lengths, Tensor? key_seq_lengths, Tensor? "
+      "block_table, str layout_query, str layout_key, int selected_count, "
+      "int sparse_mode, int pre_tokens, int next_tokens, bool return_value, "
+      "Tensor(a!) sparse_indices_out, Tensor(b!) sparse_values_out) -> "
+      "Tensor(a!)");
+  m.def(
       "scatter_nd_update(Tensor(a!) var, Tensor indices, Tensor updates) -> "
       "()");
   m.def(
@@ -195,6 +202,13 @@ TORCH_LIBRARY(xllm_ops, m) {
       "Tensor? actual_seq_lengths_kv, Tensor? query_rope, Tensor? key_rope, "
       "float scale_value, int sparse_block_size, str layout_query, str "
       "layout_kv, int sparse_mode) -> Tensor");
+  m.def(
+      "sparse_flash_attention_out(Tensor query, Tensor key, Tensor value, "
+      "Tensor sparse_indices, Tensor? block_table, Tensor? "
+      "actual_seq_lengths_query, Tensor? actual_seq_lengths_kv, Tensor? "
+      "query_rope, Tensor? key_rope, float scale_value, int "
+      "sparse_block_size, str layout_query, str layout_kv, int sparse_mode, "
+      "Tensor(a!) output) -> Tensor(a!)");
 }
 
 TORCH_LIBRARY_IMPL(xllm_ops, PrivateUse1, m) {
@@ -210,7 +224,11 @@ TORCH_LIBRARY_IMPL(xllm_ops, PrivateUse1, m) {
          TORCH_FN(xllm::kernel::npu::quantize_per_tensor));
   m.impl("dynamic_quant", TORCH_FN(xllm::kernel::npu::dynamic_quant));
   m.impl("lightning_indexer", TORCH_FN(xllm::kernel::npu::lightning_indexer));
+  m.impl("lightning_indexer_out",
+         TORCH_FN(xllm::kernel::npu::lightning_indexer_out));
   m.impl("scatter_nd_update", TORCH_FN(xllm::kernel::npu::scatter_nd_update));
   m.impl("sparse_flash_attention",
          TORCH_FN(xllm::kernel::npu::sparse_flash_attention));
+  m.impl("sparse_flash_attention_out",
+         TORCH_FN(xllm::kernel::npu::sparse_flash_attention_out));
 }

--- a/xllm/core/kernels/npu/xllm_ops/lightning_indexer.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/lightning_indexer.cpp
@@ -110,4 +110,53 @@ torch::Tensor lightning_indexer(
   return sparse_indices_out;
 }
 
+torch::Tensor lightning_indexer_out(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& weights,
+    const c10::optional<torch::Tensor>& query_seq_lengths,
+    const c10::optional<torch::Tensor>& key_seq_lengths,
+    const c10::optional<torch::Tensor>& block_table,
+    c10::string_view layout_query,
+    c10::string_view layout_key,
+    int64_t selected_count,
+    int64_t sparse_mode,
+    int64_t pre_tokens,
+    int64_t next_tokens,
+    bool return_value,
+    torch::Tensor& sparse_indices_out,
+    torch::Tensor& sparse_values_out) {
+  CHECK(sparse_indices_out.is_contiguous())
+      << "sparse_indices_out must be contiguous";
+  CHECK(sparse_values_out.is_contiguous())
+      << "sparse_values_out must be contiguous";
+  CHECK(sparse_indices_out.scalar_type() == torch::kInt)
+      << "sparse_indices_out must be int32";
+  CHECK(sparse_values_out.scalar_type() == torch::kBFloat16)
+      << "sparse_values_out must be bfloat16";
+
+  std::string query_layout_str = std::string(layout_query);
+  std::string key_layout_str = std::string(layout_key);
+  char* query_layout_ptr = const_cast<char*>(query_layout_str.c_str());
+  char* key_layout_ptr = const_cast<char*>(key_layout_str.c_str());
+
+  EXEC_NPU_CMD(aclnnLightningIndexer,
+               query,
+               key,
+               weights,
+               query_seq_lengths,
+               key_seq_lengths,
+               block_table,
+               query_layout_ptr,
+               key_layout_ptr,
+               selected_count,
+               sparse_mode,
+               pre_tokens,
+               next_tokens,
+               return_value,
+               sparse_indices_out,
+               sparse_values_out);
+  return sparse_indices_out;
+}
+
 }  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/npu/xllm_ops/sparse_flash_attention.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/sparse_flash_attention.cpp
@@ -107,4 +107,57 @@ at::Tensor sparse_flash_attention(
   return out;
 }
 
+at::Tensor sparse_flash_attention_out(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const at::Tensor& sparse_indices,
+    const c10::optional<at::Tensor>& block_table,
+    const c10::optional<at::Tensor>& actual_seq_lengths_query,
+    const c10::optional<at::Tensor>& actual_seq_lengths_kv,
+    const c10::optional<at::Tensor>& query_rope,
+    const c10::optional<at::Tensor>& key_rope,
+    double scale_value,
+    int64_t sparse_block_size,
+    c10::string_view layout_query,
+    c10::string_view layout_kv,
+    int64_t sparse_mode,
+    at::Tensor& output) {
+  check_sparse_flash_attention_shape_and_dtype(query,
+                                               key,
+                                               value,
+                                               sparse_indices,
+                                               sparse_block_size,
+                                               layout_query,
+                                               layout_kv);
+  CHECK(output.is_contiguous()) << "output must be contiguous";
+  CHECK(output.sizes() == query.sizes())
+      << "output shape must match query shape";
+  CHECK(output.scalar_type() == query.scalar_type())
+      << "output dtype must match query dtype";
+
+  std::string query_layout_str = std::string(layout_query);
+  std::string kv_layout_str = std::string(layout_kv);
+  char* query_layout_ptr = const_cast<char*>(query_layout_str.c_str());
+  char* kv_layout_ptr = const_cast<char*>(kv_layout_str.c_str());
+
+  EXEC_NPU_CMD(aclnnSparseFlashAttention,
+               query,
+               key,
+               value,
+               sparse_indices,
+               block_table,
+               actual_seq_lengths_query,
+               actual_seq_lengths_kv,
+               query_rope,
+               key_rope,
+               scale_value,
+               sparse_block_size,
+               query_layout_ptr,
+               kv_layout_ptr,
+               sparse_mode,
+               output);
+  return output;
+}
+
 }  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/npu/xllm_ops/xllm_ops_api.h
+++ b/xllm/core/kernels/npu/xllm_ops/xllm_ops_api.h
@@ -210,6 +210,23 @@ torch::Tensor lightning_indexer(
     int64_t pre_tokens,
     int64_t next_tokens,
     bool return_value);
+
+torch::Tensor lightning_indexer_out(
+    const torch::Tensor& query,
+    const torch::Tensor& key,
+    const torch::Tensor& weights,
+    const c10::optional<torch::Tensor>& query_seq_lengths,
+    const c10::optional<torch::Tensor>& key_seq_lengths,
+    const c10::optional<torch::Tensor>& block_table,
+    c10::string_view layout_query,
+    c10::string_view layout_key,
+    int64_t selected_count,
+    int64_t sparse_mode,
+    int64_t pre_tokens,
+    int64_t next_tokens,
+    bool return_value,
+    torch::Tensor& sparse_indices_out,
+    torch::Tensor& sparse_values_out);
 at::Tensor hc_pre_inv_rms(const at::Tensor& x, double epsilon);
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> gamma_add_rms_norm(
@@ -294,6 +311,23 @@ at::Tensor sparse_flash_attention(
     c10::string_view layout_query,
     c10::string_view layout_kv,
     int64_t sparse_mode);
+
+at::Tensor sparse_flash_attention_out(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const at::Tensor& sparse_indices,
+    const c10::optional<at::Tensor>& block_table,
+    const c10::optional<at::Tensor>& actual_seq_lengths_query,
+    const c10::optional<at::Tensor>& actual_seq_lengths_kv,
+    const c10::optional<at::Tensor>& query_rope,
+    const c10::optional<at::Tensor>& key_rope,
+    double scale_value,
+    int64_t sparse_block_size,
+    c10::string_view layout_query,
+    c10::string_view layout_kv,
+    int64_t sparse_mode,
+    at::Tensor& output);
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mla_preprocess(
     const at::Tensor& input,

--- a/xllm/core/layers/common/CMakeLists.txt
+++ b/xllm/core/layers/common/CMakeLists.txt
@@ -24,6 +24,7 @@ cc_library(
     attention_metadata.h
     attention_metadata_builder.h
     kv_shard_batch_metadata.h
+    expanded_decode_metadata_builder.h
     dsa_metadata.h
     dsa_metadata_builder.h
     dsa_topk_share_plan.h
@@ -50,6 +51,7 @@ cc_library(
     activation.cpp
     attention_metadata_builder.cpp
     kv_shard_batch_metadata.cpp
+    expanded_decode_metadata_builder.cpp
     dsa_metadata_builder.cpp
     dp_utils.cpp
     add_matmul.cpp

--- a/xllm/core/layers/common/CMakeLists.txt
+++ b/xllm/core/layers/common/CMakeLists.txt
@@ -23,6 +23,7 @@ cc_library(
     activation.h
     attention_metadata.h
     attention_metadata_builder.h
+    expanded_decode_metadata_builder.h
     dsa_metadata.h
     dsa_metadata_builder.h
     dsa_topk_share_plan.h
@@ -48,6 +49,7 @@ cc_library(
     deep_ep.cpp
     activation.cpp
     attention_metadata_builder.cpp
+    expanded_decode_metadata_builder.cpp
     dsa_metadata_builder.cpp
     dp_utils.cpp
     add_matmul.cpp

--- a/xllm/core/layers/common/attention_metadata.h
+++ b/xllm/core/layers/common/attention_metadata.h
@@ -33,6 +33,18 @@ namespace ffi = tvm::ffi;
 
 namespace xllm::layer {
 
+struct ExpandedDecodeMetadata {
+  bool enabled = false;
+  torch::Tensor kv_seq_lens;
+  torch::Tensor block_table;
+  torch::Tensor paged_kv_indptr;
+  torch::Tensor paged_kv_indices;
+  torch::Tensor paged_kv_last_page_len;
+  torch::Tensor paged_attention_tiling_data;
+  torch::Tensor kv_seq_lens_host;
+  std::vector<int32_t> kv_seq_lens_host_vec;
+};
+
 #if defined(USE_CUDA) || defined(USE_MUSA)
 struct PlanInfo {
   int32_t layer_id = -1;
@@ -99,11 +111,7 @@ struct AttentionMetadata {
 
   // Spec-verify ACL graph can run full attention as expanded decode while GDN
   // layers keep the original spec-verify metadata.
-  bool use_expanded_decode_for_spec_verify_attention = false;
-  torch::Tensor expanded_kv_seq_lens;
-  torch::Tensor expanded_block_table;
-  torch::Tensor expanded_paged_attention_tiling_data;
-  torch::Tensor expanded_kv_seq_lens_host;
+  ExpandedDecodeMetadata expanded_decode;
 
   // for mrope
   torch::Tensor mrope_cos;

--- a/xllm/core/layers/common/attention_metadata.h
+++ b/xllm/core/layers/common/attention_metadata.h
@@ -32,6 +32,18 @@ namespace ffi = tvm::ffi;
 
 namespace xllm::layer {
 
+struct ExpandedDecodeMetadata {
+  bool enabled = false;
+  torch::Tensor kv_seq_lens;
+  torch::Tensor block_table;
+  torch::Tensor paged_kv_indptr;
+  torch::Tensor paged_kv_indices;
+  torch::Tensor paged_kv_last_page_len;
+  torch::Tensor paged_attention_tiling_data;
+  torch::Tensor kv_seq_lens_host;
+  std::vector<int32_t> kv_seq_lens_host_vec;
+};
+
 #if defined(USE_CUDA) || defined(USE_MUSA)
 struct PlanInfo {
   int32_t layer_id = -1;
@@ -96,11 +108,7 @@ struct AttentionMetadata {
 
   // Spec-verify ACL graph can run full attention as expanded decode while GDN
   // layers keep the original spec-verify metadata.
-  bool use_expanded_decode_for_spec_verify_attention = false;
-  torch::Tensor expanded_kv_seq_lens;
-  torch::Tensor expanded_block_table;
-  torch::Tensor expanded_paged_attention_tiling_data;
-  torch::Tensor expanded_kv_seq_lens_host;
+  ExpandedDecodeMetadata expanded_decode;
 
   // for mrope
   torch::Tensor mrope_cos;

--- a/xllm/core/layers/common/attention_metadata_builder.cpp
+++ b/xllm/core/layers/common/attention_metadata_builder.cpp
@@ -54,6 +54,18 @@ AttentionMetadata build_attention_metadata(
   AttentionMetadata attn_metadata;
   attn_metadata.q_cu_seq_lens = params.attention.device.q_seq_lens;
   attn_metadata.kv_cu_seq_lens = params.attention.device.kv_seq_lens;
+#if defined(USE_NPU)
+  // BatchInputBuilder supplies per-sequence KV lengths on NPU.  Expose the
+  // cumulative form separately so Python graph execution can consume the
+  // scheduler-owned tensor without rebuilding it in the model path.
+  if (attn_metadata.kv_cu_seq_lens.defined() &&
+      attn_metadata.kv_cu_seq_lens.numel() == params.meta.num_sequences) {
+    torch::Tensor kv_seq_lens = attn_metadata.kv_cu_seq_lens.to(torch::kInt32);
+    torch::Tensor kv_cumsum = torch::cumsum(kv_seq_lens, /*dim=*/0);
+    attn_metadata.kv_cu_seq_lens = torch::cat(
+        {torch::zeros({1}, kv_seq_lens.options()), kv_cumsum}, /*dim=*/0);
+  }
+#endif
   attn_metadata.max_query_len = params.meta.q_max_seq_len;
   attn_metadata.max_seq_len = params.meta.kv_max_seq_len;
   if (!params.attention.host.kv_seq_lens.empty()) {

--- a/xllm/core/layers/common/attention_metadata_builder.cpp
+++ b/xllm/core/layers/common/attention_metadata_builder.cpp
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "attention_metadata_builder.h"
+#include "layers/common/attention_metadata_builder.h"
 
 #include <glog/logging.h>
 
@@ -21,12 +21,13 @@ limitations under the License.
 #include <numeric>
 #include <vector>
 
-#include "attention_metadata.h"
 #include "core/common/global_flags.h"
 #include "core/framework/config/execution_config.h"
 #include "core/framework/config/rec_config.h"
 #include "framework/model/model_args.h"
 #include "framework/model/model_input_params.h"
+#include "layers/common/attention_metadata.h"
+#include "layers/common/expanded_decode_metadata_builder.h"
 
 namespace xllm::layer {
 
@@ -88,6 +89,7 @@ AttentionMetadata build_attention_metadata(
   attn_metadata.use_dense_flash_attention =
       params.graph.use_dense_flash_attention;
 #endif
+  attn_metadata.expanded_decode = ExpandedDecodeMetadataBuilder::build(params);
 
   // for flashinfer
   attn_metadata.paged_kv_indptr = params.attention.device.paged_kv_indptr;
@@ -116,18 +118,6 @@ AttentionMetadata build_attention_metadata(
 
 #if defined(USE_NPU)
   attn_metadata.is_spec_verify = params.is_spec_verify;
-  attn_metadata.use_expanded_decode_for_spec_verify_attention =
-      params.graph.use_expanded_decode_for_spec_verify_attention;
-  if (attn_metadata.use_expanded_decode_for_spec_verify_attention) {
-    attn_metadata.expanded_kv_seq_lens = params.graph.expanded_kv_seq_lens;
-    attn_metadata.expanded_block_table = params.graph.expanded_block_tables;
-    attn_metadata.expanded_paged_attention_tiling_data =
-        params.graph.expanded_tiling_data;
-    if (!params.graph.expanded_kv_seq_lens_vec.empty()) {
-      attn_metadata.expanded_kv_seq_lens_host =
-          torch::tensor(params.graph.expanded_kv_seq_lens_vec, torch::kInt);
-    }
-  }
   // Determine if we should use ACL graph mode:
   // - --enable_graph=true
   // - Must be decode phase or spec-verify chunked prefill

--- a/xllm/core/layers/common/attention_metadata_builder.cpp
+++ b/xllm/core/layers/common/attention_metadata_builder.cpp
@@ -112,6 +112,18 @@ AttentionMetadata build_attention_metadata(
   AttentionMetadata attn_metadata;
   attn_metadata.q_cu_seq_lens = params.attention.device.q_seq_lens;
   attn_metadata.kv_cu_seq_lens = params.attention.device.kv_seq_lens;
+#if defined(USE_NPU)
+  // BatchInputBuilder supplies per-sequence KV lengths on NPU.  Expose the
+  // cumulative form separately so Python graph execution can consume the
+  // scheduler-owned tensor without rebuilding it in the model path.
+  if (attn_metadata.kv_cu_seq_lens.defined() &&
+      attn_metadata.kv_cu_seq_lens.numel() == params.meta.num_sequences) {
+    torch::Tensor kv_seq_lens = attn_metadata.kv_cu_seq_lens.to(torch::kInt32);
+    torch::Tensor kv_cumsum = torch::cumsum(kv_seq_lens, /*dim=*/0);
+    attn_metadata.kv_cu_seq_lens = torch::cat(
+        {torch::zeros({1}, kv_seq_lens.options()), kv_cumsum}, /*dim=*/0);
+  }
+#endif
   attn_metadata.max_query_len = params.meta.q_max_seq_len;
   attn_metadata.max_seq_len = params.meta.kv_max_seq_len;
   if (!params.attention.host.kv_seq_lens.empty()) {

--- a/xllm/core/layers/common/attention_metadata_builder.cpp
+++ b/xllm/core/layers/common/attention_metadata_builder.cpp
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "attention_metadata_builder.h"
+#include "layers/common/attention_metadata_builder.h"
 
 #include <glog/logging.h>
 
@@ -21,12 +21,13 @@ limitations under the License.
 #include <numeric>
 #include <vector>
 
-#include "attention_metadata.h"
 #include "core/common/global_flags.h"
 #include "core/framework/config/execution_config.h"
 #include "core/framework/config/rec_config.h"
 #include "framework/model/model_args.h"
 #include "framework/model/model_input_params.h"
+#include "layers/common/attention_metadata.h"
+#include "layers/common/expanded_decode_metadata_builder.h"
 
 namespace xllm::layer {
 
@@ -146,6 +147,7 @@ AttentionMetadata build_attention_metadata(
   attn_metadata.use_dense_flash_attention =
       params.graph.use_dense_flash_attention;
 #endif
+  attn_metadata.expanded_decode = ExpandedDecodeMetadataBuilder::build(params);
 
   // for flashinfer
   attn_metadata.paged_kv_indptr = params.attention.device.paged_kv_indptr;
@@ -174,18 +176,6 @@ AttentionMetadata build_attention_metadata(
 
 #if defined(USE_NPU)
   attn_metadata.is_spec_verify = params.is_spec_verify;
-  attn_metadata.use_expanded_decode_for_spec_verify_attention =
-      params.graph.use_expanded_decode_for_spec_verify_attention;
-  if (attn_metadata.use_expanded_decode_for_spec_verify_attention) {
-    attn_metadata.expanded_kv_seq_lens = params.graph.expanded_kv_seq_lens;
-    attn_metadata.expanded_block_table = params.graph.expanded_block_tables;
-    attn_metadata.expanded_paged_attention_tiling_data =
-        params.graph.expanded_tiling_data;
-    if (!params.graph.expanded_kv_seq_lens_vec.empty()) {
-      attn_metadata.expanded_kv_seq_lens_host =
-          torch::tensor(params.graph.expanded_kv_seq_lens_vec, torch::kInt);
-    }
-  }
   // Determine if we should use ACL graph mode:
   // - --enable_graph=true
   // - Must be decode phase or spec-verify chunked prefill

--- a/xllm/core/layers/common/expanded_decode_metadata_builder.cpp
+++ b/xllm/core/layers/common/expanded_decode_metadata_builder.cpp
@@ -1,0 +1,290 @@
+/* Copyright 2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "layers/common/expanded_decode_metadata_builder.h"
+
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <numeric>
+#include <utility>
+#include <vector>
+
+#include "framework/model/model_input_params.h"
+
+namespace xllm::layer {
+namespace {
+
+std::vector<int32_t> expand_host_kv_seq_lens(
+    const std::vector<int32_t>& kv_seq_lens) {
+  std::vector<int32_t> expanded;
+  expanded.reserve(kv_seq_lens.size() * 2);
+  for (int32_t kv_seq_len : kv_seq_lens) {
+    CHECK_GT(kv_seq_len, 0) << "KV sequence length must be positive";
+    expanded.emplace_back(kv_seq_len - 1);
+    expanded.emplace_back(kv_seq_len);
+  }
+  return expanded;
+}
+
+std::vector<int32_t> build_page_counts(const std::vector<int32_t>& kv_seq_lens,
+                                       int32_t block_size,
+                                       int64_t block_table_capacity) {
+  std::vector<int32_t> page_counts;
+  page_counts.reserve(kv_seq_lens.size());
+  for (int32_t kv_seq_len : kv_seq_lens) {
+    const int32_t effective_kv_seq_len = std::max(kv_seq_len, 1);
+    const int32_t page_count =
+        (effective_kv_seq_len + block_size - 1) / block_size;
+    CHECK_LE(page_count, block_table_capacity)
+        << "Expanded KV length exceeds block-table capacity";
+    page_counts.emplace_back(page_count);
+  }
+  return page_counts;
+}
+
+std::vector<int32_t> build_indptr(const std::vector<int32_t>& page_counts) {
+  std::vector<int32_t> indptr;
+  indptr.reserve(page_counts.size() + 1);
+  indptr.emplace_back(0);
+  for (int32_t page_count : page_counts) {
+    CHECK_GT(page_count, 0);
+    indptr.emplace_back(indptr.back() + page_count);
+  }
+  return indptr;
+}
+
+std::vector<int32_t> build_last_page_lens(
+    const std::vector<int32_t>& kv_seq_lens,
+    int32_t block_size) {
+  std::vector<int32_t> last_page_lens;
+  last_page_lens.reserve(kv_seq_lens.size());
+  for (int32_t kv_seq_len : kv_seq_lens) {
+    const int32_t effective_kv_seq_len = std::max(kv_seq_len, 1);
+    last_page_lens.emplace_back((effective_kv_seq_len - 1) % block_size + 1);
+  }
+  return last_page_lens;
+}
+
+}  // namespace
+
+void ExpandedDecodeMetadataBuilder::populate(ModelInputParams& target,
+                                             const ModelInputParams& source,
+                                             const torch::Tensor& kv_seq_lens,
+                                             int32_t block_size) {
+  const torch::Tensor& source_block_tables =
+      source.attention.device.block_tables;
+  CHECK(source_block_tables.defined());
+  CHECK_EQ(source_block_tables.dim(), 2);
+  CHECK_EQ(kv_seq_lens.dim(), 1);
+  CHECK_EQ(source_block_tables.size(0), kv_seq_lens.size(0));
+  CHECK_GT(block_size, 0);
+  CHECK_GT(source_block_tables.size(1), 0);
+
+  const std::vector<int32_t>& source_host_kv_seq_lens =
+      source.attention.host.kv_seq_lens;
+  CHECK_EQ(source_host_kv_seq_lens.size(),
+           static_cast<size_t>(kv_seq_lens.numel()))
+      << "Scheduler host KV lengths must match device sequence count";
+  std::vector<int32_t> expanded_host_kv_seq_lens =
+      expand_host_kv_seq_lens(source_host_kv_seq_lens);
+  torch::Tensor expanded_kv_seq_lens =
+      torch::stack({kv_seq_lens - 1, kv_seq_lens}, /*dim=*/1).flatten();
+  torch::Tensor expanded_block_tables =
+      source_block_tables.repeat_interleave(/*repeats=*/2, /*dim=*/0);
+  populate_expanded_layout(target,
+                           expanded_kv_seq_lens,
+                           expanded_block_tables,
+                           std::move(expanded_host_kv_seq_lens),
+                           block_size);
+
+  target.attention.device.block_tables = expanded_block_tables.contiguous();
+  target.attention.device.paged_kv_indptr =
+      target.graph.expanded_paged_kv_indptr;
+  target.attention.device.paged_kv_indices =
+      target.graph.expanded_paged_kv_indices;
+  target.attention.device.paged_kv_last_page_len =
+      target.graph.expanded_paged_kv_last_page_len;
+  if (source.attention.host.block_tables.defined() &&
+      source.attention.host.block_tables.device().is_cpu()) {
+    target.attention.host.block_tables =
+        source.attention.host.block_tables.repeat_interleave(/*repeats=*/2,
+                                                             /*dim=*/0);
+  }
+}
+
+void ExpandedDecodeMetadataBuilder::populate_expanded_layout(
+    ModelInputParams& target,
+    const torch::Tensor& expanded_kv_seq_lens,
+    const torch::Tensor& expanded_block_tables,
+    std::vector<int32_t> expanded_host_kv_seq_lens,
+    int32_t block_size) {
+  CHECK(expanded_kv_seq_lens.defined());
+  CHECK(expanded_block_tables.defined());
+  CHECK_EQ(expanded_kv_seq_lens.dim(), 1);
+  CHECK_EQ(expanded_block_tables.dim(), 2);
+  CHECK_EQ(expanded_block_tables.size(0), expanded_kv_seq_lens.numel());
+  CHECK_EQ(expanded_host_kv_seq_lens.size(),
+           static_cast<size_t>(expanded_kv_seq_lens.numel()));
+  CHECK_GT(expanded_block_tables.size(1), 0);
+  CHECK_GT(block_size, 0);
+
+  const std::vector<int32_t> page_counts = build_page_counts(
+      expanded_host_kv_seq_lens, block_size, expanded_block_tables.size(1));
+  const std::vector<int32_t> indptr = build_indptr(page_counts);
+  const std::vector<int32_t> last_page_lens =
+      build_last_page_lens(expanded_host_kv_seq_lens, block_size);
+  CHECK_EQ(indptr.front(), 0);
+  CHECK(std::is_sorted(indptr.begin(), indptr.end()));
+  CHECK_EQ(indptr.back(),
+           std::accumulate(page_counts.begin(), page_counts.end(), int32_t{0}));
+  for (int32_t last_page_len : last_page_lens) {
+    CHECK_GE(last_page_len, 1);
+    CHECK_LE(last_page_len, block_size);
+  }
+
+  torch::Tensor page_counts_tensor = torch::tensor(
+      page_counts, expanded_block_tables.options().dtype(torch::kInt32));
+  torch::Tensor page_offsets = torch::arange(expanded_block_tables.size(1),
+                                             expanded_block_tables.options());
+  torch::Tensor valid_pages =
+      page_offsets.unsqueeze(0) < page_counts_tensor.unsqueeze(1);
+
+  target.graph.expanded_paged_kv_indices =
+      expanded_block_tables.masked_select(valid_pages).contiguous();
+  target.graph.expanded_paged_kv_indptr = torch::tensor(
+      indptr, expanded_block_tables.options().dtype(torch::kInt32));
+  target.graph.expanded_paged_kv_last_page_len = torch::tensor(
+      last_page_lens, expanded_block_tables.options().dtype(torch::kInt32));
+
+  target.graph.use_expanded_decode_for_spec_verify_attention = true;
+  target.graph.expanded_kv_seq_lens = expanded_kv_seq_lens;
+  target.graph.expanded_block_tables = expanded_block_tables;
+  target.graph.expanded_tiling_data = torch::Tensor();
+  target.graph.expanded_kv_seq_lens_vec = std::move(expanded_host_kv_seq_lens);
+
+  ExpandedDecodeMetadataBuilder::validate(
+      ExpandedDecodeMetadataBuilder::build(target),
+      expanded_kv_seq_lens.numel(),
+      block_size);
+}
+
+std::vector<int32_t> ExpandedDecodeMetadataBuilder::build_tokenwise_kv_seq_lens(
+    const std::vector<int32_t>& q_seq_lens,
+    const std::vector<int32_t>& kv_seq_lens) {
+  CHECK_EQ(q_seq_lens.size(), kv_seq_lens.size())
+      << "q/kv sequence lengths must both be sequence-scoped";
+  std::vector<int32_t> expanded_kv_seq_lens;
+  for (size_t seq_idx = 0; seq_idx < q_seq_lens.size(); ++seq_idx) {
+    const int32_t q_len = q_seq_lens[seq_idx];
+    const int32_t kv_len = kv_seq_lens[seq_idx];
+    CHECK_GE(q_len, 1) << "query sequence length must be positive";
+    CHECK_GE(kv_len, q_len) << "KV length must include query tokens";
+    for (int32_t token_idx = 0; token_idx < q_len; ++token_idx) {
+      expanded_kv_seq_lens.emplace_back(kv_len - q_len + token_idx + 1);
+    }
+  }
+  return expanded_kv_seq_lens;
+}
+
+ExpandedDecodeMetadata ExpandedDecodeMetadataBuilder::build(
+    const ModelInputParams& params) {
+  ExpandedDecodeMetadata metadata;
+  metadata.enabled = params.graph.use_expanded_decode_for_spec_verify_attention;
+  if (!metadata.enabled) {
+    return metadata;
+  }
+
+  metadata.kv_seq_lens = params.graph.expanded_kv_seq_lens;
+  metadata.block_table = params.graph.expanded_block_tables;
+  metadata.paged_kv_indptr = params.graph.expanded_paged_kv_indptr;
+  metadata.paged_kv_indices = params.graph.expanded_paged_kv_indices;
+  metadata.paged_kv_last_page_len =
+      params.graph.expanded_paged_kv_last_page_len;
+  metadata.paged_attention_tiling_data = params.graph.expanded_tiling_data;
+  metadata.kv_seq_lens_host_vec = params.graph.expanded_kv_seq_lens_vec;
+  if (!params.graph.expanded_kv_seq_lens_vec.empty()) {
+    metadata.kv_seq_lens_host =
+        torch::tensor(params.graph.expanded_kv_seq_lens_vec, torch::kInt32);
+  }
+  validate(metadata);
+  return metadata;
+}
+
+void ExpandedDecodeMetadataBuilder::validate(
+    const ExpandedDecodeMetadata& metadata,
+    int64_t expected_sequence_count,
+    int32_t block_size) {
+  if (!metadata.enabled) {
+    return;
+  }
+
+  CHECK(metadata.kv_seq_lens.defined());
+  CHECK(metadata.block_table.defined());
+  CHECK(metadata.paged_kv_indptr.defined());
+  CHECK(metadata.paged_kv_indices.defined());
+  CHECK(metadata.paged_kv_last_page_len.defined());
+  CHECK_EQ(metadata.kv_seq_lens.dim(), 1);
+  CHECK_EQ(metadata.block_table.dim(), 2);
+  const int64_t sequence_count = metadata.kv_seq_lens.numel();
+  if (expected_sequence_count >= 0) {
+    CHECK_EQ(sequence_count, expected_sequence_count);
+  }
+  CHECK_EQ(metadata.block_table.size(0), sequence_count);
+  CHECK_EQ(metadata.paged_kv_indptr.dim(), 1);
+  CHECK_EQ(metadata.paged_kv_indptr.numel(), sequence_count + 1);
+  CHECK_EQ(metadata.paged_kv_indices.dim(), 1);
+  CHECK_GT(metadata.paged_kv_indices.numel(), 0);
+  CHECK_EQ(metadata.paged_kv_last_page_len.dim(), 1);
+  CHECK_EQ(metadata.paged_kv_last_page_len.numel(), sequence_count);
+  if (metadata.kv_seq_lens_host.defined()) {
+    CHECK(metadata.kv_seq_lens_host.device().is_cpu());
+    CHECK_EQ(metadata.kv_seq_lens_host.dim(), 1);
+    CHECK_EQ(metadata.kv_seq_lens_host.numel(), sequence_count);
+  }
+  if (metadata.paged_kv_indptr.device().is_cpu()) {
+    const torch::Tensor& host_indptr = metadata.paged_kv_indptr;
+    CHECK_EQ(host_indptr[0].item<int32_t>(), 0);
+    const int64_t offset_count = host_indptr.numel() - 1;
+    CHECK(torch::all(host_indptr.narrow(0, 1, offset_count) >=
+                     host_indptr.narrow(0, 0, offset_count))
+              .item<bool>())
+        << "paged_kv_indptr must be monotonic";
+    CHECK_EQ(host_indptr[host_indptr.numel() - 1].item<int32_t>(),
+             metadata.paged_kv_indices.numel());
+  }
+  if (metadata.paged_kv_last_page_len.device().is_cpu()) {
+    const torch::Tensor& host_last_page_len = metadata.paged_kv_last_page_len;
+    CHECK(torch::all(host_last_page_len >= 1).item<bool>());
+    if (block_size > 0) {
+      CHECK(torch::all(host_last_page_len <= block_size).item<bool>());
+    }
+  }
+  if (!metadata.kv_seq_lens_host_vec.empty()) {
+    CHECK_EQ(metadata.kv_seq_lens_host_vec.size(),
+             static_cast<size_t>(sequence_count));
+    for (int32_t kv_seq_len : metadata.kv_seq_lens_host_vec) {
+      CHECK_GE(kv_seq_len, 0);
+      if (block_size > 0) {
+        const int32_t effective_kv_seq_len = std::max(kv_seq_len, 1);
+        const int32_t page_count =
+            (effective_kv_seq_len + block_size - 1) / block_size;
+        CHECK_LE(page_count, metadata.block_table.size(1));
+      }
+    }
+  }
+}
+
+}  // namespace xllm::layer

--- a/xllm/core/layers/common/expanded_decode_metadata_builder.h
+++ b/xllm/core/layers/common/expanded_decode_metadata_builder.h
@@ -1,0 +1,56 @@
+/* Copyright 2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <torch/torch.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "layers/common/attention_metadata.h"
+
+namespace xllm {
+struct ModelInputParams;
+
+namespace layer {
+
+class ExpandedDecodeMetadataBuilder final {
+ public:
+  static void populate(ModelInputParams& target,
+                       const ModelInputParams& source,
+                       const torch::Tensor& kv_seq_lens,
+                       int32_t block_size);
+
+  static void populate_expanded_layout(
+      ModelInputParams& target,
+      const torch::Tensor& expanded_kv_seq_lens,
+      const torch::Tensor& expanded_block_tables,
+      std::vector<int32_t> expanded_host_kv_seq_lens,
+      int32_t block_size);
+
+  static std::vector<int32_t> build_tokenwise_kv_seq_lens(
+      const std::vector<int32_t>& q_seq_lens,
+      const std::vector<int32_t>& kv_seq_lens);
+
+  static ExpandedDecodeMetadata build(const ModelInputParams& params);
+
+  static void validate(const ExpandedDecodeMetadata& metadata,
+                       int64_t expected_sequence_count = -1,
+                       int32_t block_size = 0);
+};
+
+}  // namespace layer
+}  // namespace xllm

--- a/xllm/core/layers/musa/flashinfer_attention.cpp
+++ b/xllm/core/layers/musa/flashinfer_attention.cpp
@@ -37,26 +37,24 @@ namespace {
 
 bool use_expanded_spec_decode_attention(
     const AttentionMetadata& attn_metadata) {
-  return attn_metadata.use_expanded_decode_for_spec_verify_attention &&
-         attn_metadata.expanded_paged_kv_indptr.defined() &&
-         attn_metadata.expanded_paged_kv_indptr.numel() >= 2;
+  const ExpandedDecodeMetadata& expanded = attn_metadata.expanded_decode;
+  return expanded.enabled && expanded.paged_kv_indptr.defined() &&
+         expanded.paged_kv_indptr.numel() >= 2;
 }
 
 AttentionMetadata build_expanded_decode_metadata(
     const AttentionMetadata& attn_metadata) {
   AttentionMetadata decode_meta = attn_metadata;
-  const int64_t expanded_batch =
-      attn_metadata.expanded_paged_kv_indptr.size(0) - 1;
-  const torch::Device expanded_device =
-      attn_metadata.expanded_paged_kv_indptr.device();
+  const ExpandedDecodeMetadata& expanded = attn_metadata.expanded_decode;
+  const int64_t expanded_batch = expanded.paged_kv_indptr.size(0) - 1;
+  const torch::Device expanded_device = expanded.paged_kv_indptr.device();
   const torch::TensorOptions expanded_int_options =
       torch::TensorOptions().dtype(torch::kInt32).device(expanded_device);
-  decode_meta.paged_kv_indptr = attn_metadata.expanded_paged_kv_indptr;
-  decode_meta.paged_kv_indices = attn_metadata.expanded_paged_kv_indices;
-  decode_meta.paged_kv_last_page_len =
-      attn_metadata.expanded_paged_kv_last_page_len;
-  decode_meta.block_table = attn_metadata.expanded_block_table;
-  decode_meta.kv_seq_lens = attn_metadata.expanded_kv_seq_lens;
+  decode_meta.paged_kv_indptr = expanded.paged_kv_indptr;
+  decode_meta.paged_kv_indices = expanded.paged_kv_indices;
+  decode_meta.paged_kv_last_page_len = expanded.paged_kv_last_page_len;
+  decode_meta.block_table = expanded.block_table;
+  decode_meta.kv_seq_lens = expanded.kv_seq_lens;
   decode_meta.qo_indptr =
       torch::arange(0, expanded_batch + 1, expanded_int_options);
   decode_meta.max_query_len = 1;
@@ -236,7 +234,7 @@ FlashInferAttentionImpl::forward(const AttentionMetadata& attn_metadata,
   qwen35_mtp_attention_debug_sync("attention_before_core");
   const bool spec_verify_expanded_decode =
       attn_metadata.is_chunked_prefill &&
-      (attn_metadata.use_expanded_decode_for_spec_verify_attention ||
+      (attn_metadata.expanded_decode.enabled ||
        use_expanded_spec_decode_attention(attn_metadata) ||
        attn_metadata.is_spec_verify);
   if (attn_metadata.is_prefill) {

--- a/xllm/core/layers/npu_torch/attention.cpp
+++ b/xllm/core/layers/npu_torch/attention.cpp
@@ -66,7 +66,7 @@ std::tuple<torch::Tensor, std::optional<torch::Tensor>> AttentionImpl::forward(
     xllm::kernel::reshape_paged_cache(reshape_paged_cache_params);
   }
 
-  if (attn_metadata.use_expanded_decode_for_spec_verify_attention) {
+  if (attn_metadata.expanded_decode.enabled) {
     decoder_forward(query, output, k_cache, v_cache, attn_metadata);
   } else if (only_prefill) {
     prefill_forward(query, key, value, output, k_cache, v_cache, attn_metadata);
@@ -146,13 +146,13 @@ void AttentionImpl::decoder_forward(torch::Tensor& query,
   torch::Tensor kv_seq_lens;
   torch::Tensor block_table = attn_metadata.block_table;
   torch::Tensor tiling_data = attn_metadata.paged_attention_tiling_data;
-  if (attn_metadata.use_expanded_decode_for_spec_verify_attention) {
-    block_table = attn_metadata.expanded_block_table;
-    tiling_data = attn_metadata.expanded_paged_attention_tiling_data;
-    if (attn_metadata.expanded_kv_seq_lens_host.defined()) {
-      kv_seq_lens = attn_metadata.expanded_kv_seq_lens_host;
+  if (attn_metadata.expanded_decode.enabled) {
+    block_table = attn_metadata.expanded_decode.block_table;
+    tiling_data = attn_metadata.expanded_decode.paged_attention_tiling_data;
+    if (attn_metadata.expanded_decode.kv_seq_lens_host.defined()) {
+      kv_seq_lens = attn_metadata.expanded_decode.kv_seq_lens_host;
     } else {
-      kv_seq_lens = attn_metadata.expanded_kv_seq_lens;
+      kv_seq_lens = attn_metadata.expanded_decode.kv_seq_lens;
     }
   } else if (attn_metadata.kv_seq_lens_host.defined()) {
     kv_seq_lens = attn_metadata.kv_seq_lens_host;

--- a/xllm/core/runtime/CMakeLists.txt
+++ b/xllm/core/runtime/CMakeLists.txt
@@ -21,6 +21,7 @@ cc_library(
     $<$<BOOL:${USE_CUDA}>:cuda_graph_executor_impl.h>
     $<$<BOOL:${USE_MUSA}>:musa_graph_executor_impl.h>
     py_executor_impl.h
+    py_attention_metadata.h
     $<$<BOOL:${USE_DCU}>:dcu_graph_executor_impl.h>
     worker.h
     worker_impl.h
@@ -56,6 +57,7 @@ cc_library(
     $<$<BOOL:${USE_CUDA}>:cuda_graph_executor_impl.cpp>
     $<$<BOOL:${USE_MUSA}>:musa_graph_executor_impl.cpp>
     py_executor_impl.cpp
+    py_attention_metadata.cpp
     $<$<BOOL:${USE_DCU}>:dcu_graph_executor_impl.cpp>
     worker.cpp
     worker_impl.cpp

--- a/xllm/core/runtime/acl_graph_persistent_param.cpp
+++ b/xllm/core/runtime/acl_graph_persistent_param.cpp
@@ -31,6 +31,7 @@ limitations under the License.
 #include "core/common/global_flags.h"
 #include "core/framework/config/speculative_config.h"
 #include "core/kernels/npu/tilelang/tilelang_ops_api.h"
+#include "core/layers/common/expanded_decode_metadata_builder.h"
 #include "core/runtime/mtp_async_state.h"
 #include "core/util/utils.h"
 
@@ -1318,14 +1319,15 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
           static_cast<uint32_t>(padded_batch_size));
     }
     if (use_expanded_spec_decode_attention) {
-      graph_params->graph.use_expanded_decode_for_spec_verify_attention = true;
-      graph_params->graph.expanded_kv_seq_lens = expanded_kv_seq_lens_.slice(
-          /*dim=*/0, /*start=*/0, /*end=*/padded_num_tokens);
-      graph_params->graph.expanded_block_tables =
-          expanded_block_tables_for_graph();
+      layer::ExpandedDecodeMetadataBuilder::populate_expanded_layout(
+          *graph_params,
+          expanded_kv_seq_lens_.slice(
+              /*dim=*/0, /*start=*/0, /*end=*/padded_num_tokens),
+          expanded_block_tables_for_graph(),
+          expanded_kv_seq_lens_vec,
+          options_.block_size());
       graph_params->graph.expanded_tiling_data =
           uses_paged_attention_tiling() ? tiling_data() : torch::Tensor();
-      graph_params->graph.expanded_kv_seq_lens_vec = expanded_kv_seq_lens_vec;
     }
     if (params.attention.device.q_cu_seq_lens.defined()) {
       const bool use_hybrid_query_start_loc = is_hybrid_linear_attention_;

--- a/xllm/core/runtime/llm_worker_impl.h
+++ b/xllm/core/runtime/llm_worker_impl.h
@@ -104,6 +104,10 @@ class LLMWorkerImpl : public WorkerImpl {
     return model_->dspark_markov_bias(previous_token_ids);
   }
 
+  bool share_weights_from(LLMWorkerImpl& source) {
+    return model_->share_weights_from(*source.model_);
+  }
+
   // DFlash-specific delegate: eagerly project target hidden into the draft's
   // per-layer KV cache. Runs outside the executor because the pass has no
   // attention and its shape doesn't match the decode graph. See CausalLM.

--- a/xllm/core/runtime/mtp_async_input_builder.cpp
+++ b/xllm/core/runtime/mtp_async_input_builder.cpp
@@ -23,6 +23,7 @@ limitations under the License.
 
 #include "core/runtime/forward_params.h"
 #include "core/runtime/mtp_async_state.h"
+#include "layers/common/expanded_decode_metadata_builder.h"
 
 namespace xllm::mtp_async {
 namespace {
@@ -56,10 +57,33 @@ void apply_device_row_metadata(ForwardInput& input,
 }
 
 #if defined(USE_NPU)
+void expand_decode_attention_metadata(ForwardInput& draft_input,
+                                      const ForwardInput& block_table_source,
+                                      const torch::Tensor& kv_seq_lens,
+                                      int32_t block_size) {
+  layer::ExpandedDecodeMetadataBuilder::populate(
+      draft_input.input_params,
+      block_table_source.input_params,
+      kv_seq_lens,
+      block_size);
+}
+
 void apply_mtp_prepare_output(
     ForwardInput& draft_input,
+    const ForwardInput& block_table_source,
     const kernel::npu::MtpPrepareNextDraftOutput& output,
-    bool use_chunked_prefill) {
+    bool use_chunked_prefill,
+    int32_t block_size) {
+  CHECK_EQ(output.token_ids.dim(), 1);
+  CHECK_EQ(output.positions.dim(), 1);
+  CHECK_EQ(output.cache_slots.dim(), 1);
+  CHECK_EQ(output.embeddings.dim(), 2);
+  CHECK_EQ(output.kv_seq_lens.dim(), 1);
+  const int64_t token_count = output.token_ids.numel();
+  CHECK_EQ(output.positions.numel(), token_count);
+  CHECK_EQ(output.cache_slots.numel(), token_count);
+  CHECK_EQ(output.embeddings.size(0), token_count);
+
   draft_input.token_ids = output.token_ids;
   draft_input.input_params.embedding.input_embedding = output.embeddings;
   draft_input.positions = output.positions;
@@ -72,6 +96,20 @@ void apply_mtp_prepare_output(
   }
   draft_input.input_params.attention.device.new_cache_slots =
       output.cache_slots;
+  if (!use_chunked_prefill) {
+    expand_decode_attention_metadata(
+        draft_input, block_table_source, output.kv_seq_lens, block_size);
+    const auto& attention = draft_input.input_params.attention.device;
+    CHECK_EQ(attention.kv_seq_lens.numel(), token_count);
+    CHECK_EQ(attention.new_cache_slots.numel(), token_count);
+    CHECK_EQ(attention.block_tables.size(0), token_count);
+    CHECK_EQ(attention.paged_kv_indptr.numel(), token_count + 1);
+    CHECK_EQ(attention.paged_kv_last_page_len.numel(), token_count);
+    CHECK_EQ(draft_input.input_params.graph.expanded_kv_seq_lens.numel(),
+             token_count);
+    CHECK_EQ(draft_input.input_params.graph.expanded_block_tables.size(0),
+             token_count);
+  }
 }
 #endif
 
@@ -98,7 +136,11 @@ void prepare_next_draft_from_accepted_state(
         block_table_source.input_params.attention.device.block_tables,
         block_size);
     if (output.has_value()) {
-      apply_mtp_prepare_output(draft_input, *output, use_chunked_prefill);
+      apply_mtp_prepare_output(draft_input,
+                               block_table_source,
+                               *output,
+                               use_chunked_prefill,
+                               block_size);
       return;
     }
   }
@@ -139,6 +181,15 @@ void prepare_next_draft_from_accepted_state(
       torch::stack({state.previous_embeddings, state.last_embeddings},
                    /*dim=*/1)
           .flatten(/*start_dim=*/0, /*end_dim=*/1);
+#if defined(USE_NPU)
+  if (!use_chunked_prefill) {
+    expand_decode_attention_metadata(
+        draft_input,
+        block_table_source,
+        state.base_kv_seq_lens.to(base_kv_seq_lens.options()),
+        block_size);
+  }
+#endif
 }
 
 }  // namespace xllm::mtp_async

--- a/xllm/core/runtime/mtp_async_state.cpp
+++ b/xllm/core/runtime/mtp_async_state.cpp
@@ -46,6 +46,9 @@ TargetSpecVerifyMode classify_target_spec_verify_mode(
       model_type == "qwen3_5_text" || model_type == "qwen3_5_moe_text") {
     return TargetSpecVerifyMode::QWEN3_5_EXPANDED_VERIFY;
   }
+  if (model_type == "deepseek_v32") {
+    return TargetSpecVerifyMode::DEEPSEEK_V32_EXPANDED_VERIFY;
+  }
   if (model_type == "mimo") {
     return TargetSpecVerifyMode::CAUSAL_CHUNKED_PREFILL;
   }

--- a/xllm/core/runtime/mtp_async_state.h
+++ b/xllm/core/runtime/mtp_async_state.h
@@ -27,6 +27,7 @@ enum class TargetSpecVerifyMode {
   GENERIC,
   CAUSAL_CHUNKED_PREFILL,
   QWEN3_5_EXPANDED_VERIFY,
+  DEEPSEEK_V32_EXPANDED_VERIFY,
 };
 
 // Keep target verification policy closed over model types with validated

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -29,12 +29,14 @@ limitations under the License.
 #include "core/framework/config/disagg_pd_config.h"
 #include "core/framework/config/kernel_config.h"
 #include "core/framework/config/kv_cache_config.h"
+#include "core/framework/config/model_config.h"
 #include "core/framework/config/speculative_config.h"
 #include "core/framework/kv_cache/kv_cache_estimation.h"
 #include "core/framework/model/mtp_utils.h"
 #include "core/framework/multimodal/mm_data.h"
 #if defined(USE_NPU)
 #include "core/kernels/npu/tilelang/tilelang_ops_api.h"
+#include "core/layers/common/expanded_decode_metadata_builder.h"
 #endif
 #include "core/layers/common/dsa_topk_share_plan.h"
 #include "core/runtime/mtp_async_input_builder.h"
@@ -220,6 +222,9 @@ void clear_expanded_spec_verify_graph_input(ModelInputParams& input_params) {
   input_params.graph.use_expanded_decode_for_spec_verify_attention = false;
   input_params.graph.expanded_kv_seq_lens = torch::Tensor();
   input_params.graph.expanded_block_tables = torch::Tensor();
+  input_params.graph.expanded_paged_kv_indptr = torch::Tensor();
+  input_params.graph.expanded_paged_kv_indices = torch::Tensor();
+  input_params.graph.expanded_paged_kv_last_page_len = torch::Tensor();
   input_params.graph.expanded_tiling_data = torch::Tensor();
   input_params.graph.expanded_kv_seq_lens_vec.clear();
 }
@@ -239,20 +244,9 @@ bool build_expanded_spec_verify_graph_host_input(
   if (q_seq_lens.empty() || kv_seq_lens.empty()) {
     return false;
   }
-  CHECK_EQ(q_seq_lens.size(), kv_seq_lens.size())
-      << "spec verify q/kv seq lens must both be sequence-scoped";
-  const int64_t batch_size = static_cast<int64_t>(q_seq_lens.size());
-
-  std::vector<int32_t> expanded_kv_seq_lens;
-  for (int64_t seq_idx = 0; seq_idx < batch_size; ++seq_idx) {
-    const int32_t q_len = q_seq_lens[static_cast<size_t>(seq_idx)];
-    const int32_t kv_len = kv_seq_lens[static_cast<size_t>(seq_idx)];
-    CHECK_GE(q_len, 1) << "spec verify q_len must be positive";
-    CHECK_GE(kv_len, q_len) << "kv_len must include validate query tokens";
-    for (int32_t token_idx = 0; token_idx < q_len; ++token_idx) {
-      expanded_kv_seq_lens.emplace_back(kv_len - q_len + token_idx + 1);
-    }
-  }
+  std::vector<int32_t> expanded_kv_seq_lens =
+      layer::ExpandedDecodeMetadataBuilder::build_tokenwise_kv_seq_lens(
+          q_seq_lens, kv_seq_lens);
   if (expanded_kv_seq_lens.empty()) {
     return false;
   }
@@ -264,7 +258,8 @@ bool build_expanded_spec_verify_graph_host_input(
 
 void bind_expanded_spec_verify_graph_input(ModelInputParams& input_params,
                                            const torch::Device& device,
-                                           bool kv_lens_already_bound) {
+                                           bool kv_lens_already_bound,
+                                           int32_t block_size) {
   if (!input_params.graph.use_expanded_decode_for_spec_verify_attention) {
     return;
   }
@@ -299,14 +294,21 @@ void bind_expanded_spec_verify_graph_input(ModelInputParams& input_params,
 
   // ATB consumes this tensor as dense row-major storage. Keep the generic
   // fallback contiguous; a zero-stride expand view is rejected at runtime.
-  input_params.graph.expanded_block_tables =
-      torch::stack(expanded_block_rows, 0);
+  torch::Tensor expanded_block_tables = torch::stack(expanded_block_rows, 0);
+  layer::ExpandedDecodeMetadataBuilder::populate_expanded_layout(
+      input_params,
+      input_params.graph.expanded_kv_seq_lens,
+      expanded_block_tables,
+      input_params.graph.expanded_kv_seq_lens_vec,
+      block_size);
 }
 
 void build_expanded_spec_verify_graph_input(ModelInputParams& input_params,
-                                            const torch::Device& device) {
+                                            const torch::Device& device,
+                                            int32_t block_size) {
   build_expanded_spec_verify_graph_host_input(input_params);
-  bind_expanded_spec_verify_graph_input(input_params, device, false);
+  bind_expanded_spec_verify_graph_input(
+      input_params, device, false, block_size);
 }
 #endif
 
@@ -680,8 +682,16 @@ int64_t MTPWorkerImpl::get_embedding_placeholder_size() {
 }
 
 bool MTPWorkerImpl::supports_explicit_spec_verify_replay_update() const {
+  if (target_spec_verify_mode_ ==
+      mtp_async::TargetSpecVerifyMode::QWEN3_5_EXPANDED_VERIFY) {
+    return true;
+  }
+  // The Python NPU paged-attention runner consumes expanded metadata and can
+  // replay its ACL graph for DeepSeek MLA. The native target executor has no
+  // corresponding MLA spec-verify graph path yet, so it remains generic.
   return target_spec_verify_mode_ ==
-         mtp_async::TargetSpecVerifyMode::QWEN3_5_EXPANDED_VERIFY;
+             mtp_async::TargetSpecVerifyMode::DEEPSEEK_V32_EXPANDED_VERIFY &&
+         ModelConfig::is_python_model_impl(context_.get_model_impl());
 }
 
 bool MTPWorkerImpl::should_use_explicit_spec_verify_replay_update(
@@ -733,7 +743,9 @@ int64_t MTPWorkerImpl::spec_verify_block_table_width(
 }
 
 bool MTPWorkerImpl::use_chunked_prefill_spec_verify_path() const {
-  return target_spec_verify_mode_ != mtp_async::TargetSpecVerifyMode::GENERIC;
+  return target_spec_verify_mode_ ==
+             mtp_async::TargetSpecVerifyMode::CAUSAL_CHUNKED_PREFILL ||
+         supports_explicit_spec_verify_replay_update();
 }
 
 bool MTPWorkerImpl::allocate_kv_cache(const KVCacheShape& kv_cache_shape) {
@@ -2227,12 +2239,19 @@ void MTPWorkerImpl::prepare_validate_inputs(const ForwardInput& input,
         attention.attention_buffer_capacity;
     input_params.graph.expanded_block_tables = expanded_block_tables_flat.view(
         {expanded_block_rows, verify_block_table_width});
+    layer::ExpandedDecodeMetadataBuilder::populate_expanded_layout(
+        input_params,
+        input_params.graph.expanded_kv_seq_lens,
+        input_params.graph.expanded_block_tables,
+        input_params.graph.expanded_kv_seq_lens_vec,
+        options_.block_size());
     input_params.graph.input_tokens_override = validate_input.token_ids;
     input_params.graph.spec_verify_source_addresses_stable = true;
   } else {
     input_params.attention.rebuild_device_buffer(device_);
     if (supports_explicit_spec_verify_replay_update()) {
-      build_expanded_spec_verify_graph_input(input_params, device_);
+      build_expanded_spec_verify_graph_input(
+          input_params, device_, options_.block_size());
     }
   }
 #else

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -592,25 +592,29 @@ bool MTPWorkerImpl::init_model(const std::string& model_weights_path,
     // Other MTP drafts retain their existing target-weight sharing contract;
     // only their transformer body is replicated with TP1 parallel arguments.
     if (!draft_owns_shared_weights) {
+      const bool python_weights_shared =
+          draft_impl_->share_weights_from(*impl_);
+      if (!python_weights_shared) {
 #if defined(USE_NPU)
-      if (::xllm::KernelConfig::get_instance().npu_kernel_backend() !=
-          "TORCH") {
-        auto head = impl_->get_npu_lm_head();
-        draft_impl_->set_npu_lm_head(head);
-        auto word_embedding = impl_->get_npu_word_embedding();
-        draft_impl_->set_npu_word_embedding(word_embedding);
-      } else {
+        if (::xllm::KernelConfig::get_instance().npu_kernel_backend() !=
+            "TORCH") {
+          auto head = impl_->get_npu_lm_head();
+          draft_impl_->set_npu_lm_head(head);
+          auto word_embedding = impl_->get_npu_word_embedding();
+          draft_impl_->set_npu_word_embedding(word_embedding);
+        } else {
+          auto head = impl_->get_lm_head();
+          draft_impl_->set_lm_head(head);
+          auto word_embedding = impl_->get_word_embedding();
+          draft_impl_->set_word_embedding(word_embedding);
+        }
+#else
         auto head = impl_->get_lm_head();
         draft_impl_->set_lm_head(head);
         auto word_embedding = impl_->get_word_embedding();
         draft_impl_->set_word_embedding(word_embedding);
-      }
-#else
-      auto head = impl_->get_lm_head();
-      draft_impl_->set_lm_head(head);
-      auto word_embedding = impl_->get_word_embedding();
-      draft_impl_->set_word_embedding(word_embedding);
 #endif
+      }
     }
   }
 #if defined(USE_NPU)

--- a/xllm/core/runtime/py_attention_metadata.cpp
+++ b/xllm/core/runtime/py_attention_metadata.cpp
@@ -1,0 +1,258 @@
+/* Copyright 2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "core/runtime/py_attention_metadata.h"
+
+#include <pybind11/stl.h>
+#include <torch/extension.h>
+
+#include <utility>
+
+#include "core/framework/model/model_input_params.h"
+#include "core/layers/common/attention_metadata.h"
+
+namespace py = pybind11;
+
+namespace xllm {
+
+void register_attention_metadata_views(py::module_& module) {
+  py::class_<PyExpandedDecodeMetadataView>(module, "ExpandedDecodeMetadataView")
+      .def_property_readonly("enabled", &PyExpandedDecodeMetadataView::enabled)
+      .def_property_readonly("kv_seq_lens",
+                             &PyExpandedDecodeMetadataView::kv_seq_lens)
+      .def_property_readonly("block_table",
+                             &PyExpandedDecodeMetadataView::block_table)
+      .def_property_readonly("paged_kv_indptr",
+                             &PyExpandedDecodeMetadataView::paged_kv_indptr)
+      .def_property_readonly("paged_kv_indices",
+                             &PyExpandedDecodeMetadataView::paged_kv_indices)
+      .def_property_readonly(
+          "paged_kv_last_page_len",
+          &PyExpandedDecodeMetadataView::paged_kv_last_page_len)
+      .def_property_readonly(
+          "paged_attention_tiling_data",
+          &PyExpandedDecodeMetadataView::paged_attention_tiling_data)
+      .def_property_readonly("kv_seq_lens_host",
+                             &PyExpandedDecodeMetadataView::kv_seq_lens_host)
+      .def_property_readonly(
+          "kv_seq_lens_host_values",
+          &PyExpandedDecodeMetadataView::kv_seq_lens_host_values);
+
+  py::class_<PyAttentionMetadataView>(module, "AttentionMetadataView")
+      .def_property_readonly("slot_mapping",
+                             &PyAttentionMetadataView::slot_mapping)
+      .def_property_readonly("paged_kv_indptr",
+                             &PyAttentionMetadataView::paged_kv_indptr)
+      .def_property_readonly("paged_kv_indices",
+                             &PyAttentionMetadataView::paged_kv_indices)
+      .def_property_readonly("paged_kv_last_page_len",
+                             &PyAttentionMetadataView::paged_kv_last_page_len)
+      .def_property_readonly("qo_indptr", &PyAttentionMetadataView::qo_indptr)
+      .def_property_readonly("q_cu_seq_lens",
+                             &PyAttentionMetadataView::q_cu_seq_lens)
+      .def_property_readonly("kv_cu_seq_lens",
+                             &PyAttentionMetadataView::kv_cu_seq_lens)
+      .def_property_readonly("kv_seq_lens_host",
+                             &PyAttentionMetadataView::kv_seq_lens_host)
+      .def_property_readonly("kv_seq_lens_host_values",
+                             &PyAttentionMetadataView::kv_seq_lens_host_values)
+      .def_property_readonly("block_table",
+                             &PyAttentionMetadataView::block_table)
+      .def_property_readonly("kv_seq_lens",
+                             &PyAttentionMetadataView::kv_seq_lens)
+      .def_property_readonly("linear_state_indices",
+                             &PyAttentionMetadataView::linear_state_indices)
+      .def_property_readonly("has_initial_state",
+                             &PyAttentionMetadataView::has_initial_state)
+      .def_property_readonly("dp_token_counts",
+                             &PyAttentionMetadataView::dp_token_counts)
+      .def_property_readonly("q_seq_lens", &PyAttentionMetadataView::q_seq_lens)
+      .def_property_readonly("expanded_decode_metadata",
+                             &PyAttentionMetadataView::expanded_decode_metadata)
+      .def_property_readonly("is_prefill", &PyAttentionMetadataView::is_prefill)
+      .def_property_readonly("is_chunked_prefill",
+                             &PyAttentionMetadataView::is_chunked_prefill);
+}
+
+PyExpandedDecodeMetadataView::PyExpandedDecodeMetadataView(
+    std::shared_ptr<layer::AttentionMetadata> metadata)
+    : metadata_(std::move(metadata)) {}
+
+bool PyExpandedDecodeMetadataView::enabled() const {
+  return metadata().enabled;
+}
+
+py::object PyExpandedDecodeMetadataView::kv_seq_lens() const {
+  return metadata().kv_seq_lens.defined() ? py::cast(metadata().kv_seq_lens)
+                                          : py::none();
+}
+
+py::object PyExpandedDecodeMetadataView::block_table() const {
+  return metadata().block_table.defined() ? py::cast(metadata().block_table)
+                                          : py::none();
+}
+
+py::object PyExpandedDecodeMetadataView::paged_kv_indptr() const {
+  return metadata().paged_kv_indptr.defined()
+             ? py::cast(metadata().paged_kv_indptr)
+             : py::none();
+}
+
+py::object PyExpandedDecodeMetadataView::paged_kv_indices() const {
+  return metadata().paged_kv_indices.defined()
+             ? py::cast(metadata().paged_kv_indices)
+             : py::none();
+}
+
+py::object PyExpandedDecodeMetadataView::paged_kv_last_page_len() const {
+  return metadata().paged_kv_last_page_len.defined()
+             ? py::cast(metadata().paged_kv_last_page_len)
+             : py::none();
+}
+
+py::object PyExpandedDecodeMetadataView::paged_attention_tiling_data() const {
+  return metadata().paged_attention_tiling_data.defined()
+             ? py::cast(metadata().paged_attention_tiling_data)
+             : py::none();
+}
+
+py::object PyExpandedDecodeMetadataView::kv_seq_lens_host() const {
+  return metadata().kv_seq_lens_host.defined()
+             ? py::cast(metadata().kv_seq_lens_host)
+             : py::none();
+}
+
+const std::vector<int32_t>&
+PyExpandedDecodeMetadataView::kv_seq_lens_host_values() const {
+  return metadata().kv_seq_lens_host_vec;
+}
+
+const layer::ExpandedDecodeMetadata& PyExpandedDecodeMetadataView::metadata()
+    const {
+  return metadata_->expanded_decode;
+}
+
+PyAttentionMetadataView::PyAttentionMetadataView(
+    std::shared_ptr<layer::AttentionMetadata> metadata)
+    : metadata_(std::move(metadata)),
+      kv_seq_lens_host_(make_kv_seq_lens_host(metadata_)) {}
+
+PyAttentionMetadataView::PyAttentionMetadataView(
+    std::shared_ptr<layer::AttentionMetadata> metadata,
+    const ModelInputParams& params)
+    : PyAttentionMetadataView(std::move(metadata)) {
+  linear_state_indices_ = params.embedding.linear_state_indices;
+  dp_token_counts_ = params.parallel.raw_dp_global_token_nums.empty()
+                         ? params.parallel.dp_global_token_nums
+                         : params.parallel.raw_dp_global_token_nums;
+}
+
+const torch::Tensor& PyAttentionMetadataView::slot_mapping() const {
+  return metadata_->slot_mapping;
+}
+
+const torch::Tensor& PyAttentionMetadataView::paged_kv_indptr() const {
+  return metadata_->paged_kv_indptr;
+}
+
+const torch::Tensor& PyAttentionMetadataView::paged_kv_indices() const {
+  return metadata_->paged_kv_indices;
+}
+
+const torch::Tensor& PyAttentionMetadataView::paged_kv_last_page_len() const {
+  return metadata_->paged_kv_last_page_len;
+}
+
+py::object PyAttentionMetadataView::qo_indptr() const {
+  if (!metadata_->qo_indptr.has_value() || !metadata_->qo_indptr->defined()) {
+    return py::none();
+  }
+  return py::cast(*metadata_->qo_indptr);
+}
+
+py::object PyAttentionMetadataView::q_cu_seq_lens() const {
+  return optional_tensor(metadata_->q_cu_seq_lens);
+}
+
+py::object PyAttentionMetadataView::kv_cu_seq_lens() const {
+  return optional_tensor(metadata_->kv_cu_seq_lens);
+}
+
+py::object PyAttentionMetadataView::kv_seq_lens_host() const {
+  return optional_tensor(kv_seq_lens_host_);
+}
+
+const std::vector<int32_t>& PyAttentionMetadataView::kv_seq_lens_host_values()
+    const {
+  return metadata_->kv_seq_lens_vec;
+}
+
+py::object PyAttentionMetadataView::block_table() const {
+  return optional_tensor(metadata_->block_table);
+}
+
+py::object PyAttentionMetadataView::kv_seq_lens() const {
+  return optional_tensor(metadata_->kv_seq_lens);
+}
+
+py::object PyAttentionMetadataView::linear_state_indices() const {
+  return optional_tensor(linear_state_indices_);
+}
+
+py::object PyAttentionMetadataView::has_initial_state() const {
+  return optional_tensor(metadata_->has_initial_states);
+}
+
+const std::vector<int32_t>& PyAttentionMetadataView::dp_token_counts() const {
+  return dp_token_counts_;
+}
+
+py::object PyAttentionMetadataView::q_seq_lens() const {
+  return optional_tensor(metadata_->q_seq_lens);
+}
+
+PyExpandedDecodeMetadataView PyAttentionMetadataView::expanded_decode_metadata()
+    const {
+  return PyExpandedDecodeMetadataView(metadata_);
+}
+
+bool PyAttentionMetadataView::is_prefill() const {
+  return metadata_->is_prefill;
+}
+
+bool PyAttentionMetadataView::is_chunked_prefill() const {
+  return metadata_->is_chunked_prefill;
+}
+
+torch::Tensor PyAttentionMetadataView::make_kv_seq_lens_host(
+    const std::shared_ptr<layer::AttentionMetadata>& metadata) {
+  if (metadata->kv_seq_lens_vec.empty()) {
+    return torch::Tensor();
+  }
+
+  std::shared_ptr<layer::AttentionMetadata> owner = metadata;
+  return torch::from_blob(
+      metadata->kv_seq_lens_vec.data(),
+      {static_cast<int64_t>(metadata->kv_seq_lens_vec.size())},
+      [owner = std::move(owner)](void*) mutable { owner.reset(); },
+      torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU));
+}
+
+py::object PyAttentionMetadataView::optional_tensor(
+    const torch::Tensor& tensor) {
+  return tensor.defined() ? py::cast(tensor) : py::none();
+}
+
+}  // namespace xllm

--- a/xllm/core/runtime/py_attention_metadata.cpp
+++ b/xllm/core/runtime/py_attention_metadata.cpp
@@ -1,0 +1,229 @@
+/* Copyright 2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "core/runtime/py_attention_metadata.h"
+
+#include <pybind11/stl.h>
+#include <torch/extension.h>
+
+#include <utility>
+
+#include "core/layers/common/attention_metadata.h"
+
+namespace py = pybind11;
+
+namespace xllm {
+
+void register_attention_metadata_views(py::module_& module) {
+  py::class_<PyExpandedDecodeMetadataView>(module, "ExpandedDecodeMetadataView")
+      .def_property_readonly("enabled", &PyExpandedDecodeMetadataView::enabled)
+      .def_property_readonly("kv_seq_lens",
+                             &PyExpandedDecodeMetadataView::kv_seq_lens)
+      .def_property_readonly("block_table",
+                             &PyExpandedDecodeMetadataView::block_table)
+      .def_property_readonly("paged_kv_indptr",
+                             &PyExpandedDecodeMetadataView::paged_kv_indptr)
+      .def_property_readonly("paged_kv_indices",
+                             &PyExpandedDecodeMetadataView::paged_kv_indices)
+      .def_property_readonly(
+          "paged_kv_last_page_len",
+          &PyExpandedDecodeMetadataView::paged_kv_last_page_len)
+      .def_property_readonly(
+          "paged_attention_tiling_data",
+          &PyExpandedDecodeMetadataView::paged_attention_tiling_data)
+      .def_property_readonly("kv_seq_lens_host",
+                             &PyExpandedDecodeMetadataView::kv_seq_lens_host)
+      .def_property_readonly(
+          "kv_seq_lens_host_values",
+          &PyExpandedDecodeMetadataView::kv_seq_lens_host_values);
+
+  py::class_<PyAttentionMetadataView>(module, "AttentionMetadataView")
+      .def_property_readonly("slot_mapping",
+                             &PyAttentionMetadataView::slot_mapping)
+      .def_property_readonly("paged_kv_indptr",
+                             &PyAttentionMetadataView::paged_kv_indptr)
+      .def_property_readonly("paged_kv_indices",
+                             &PyAttentionMetadataView::paged_kv_indices)
+      .def_property_readonly("paged_kv_last_page_len",
+                             &PyAttentionMetadataView::paged_kv_last_page_len)
+      .def_property_readonly("qo_indptr", &PyAttentionMetadataView::qo_indptr)
+      .def_property_readonly("q_cu_seq_lens",
+                             &PyAttentionMetadataView::q_cu_seq_lens)
+      .def_property_readonly("kv_cu_seq_lens",
+                             &PyAttentionMetadataView::kv_cu_seq_lens)
+      .def_property_readonly("kv_seq_lens_host",
+                             &PyAttentionMetadataView::kv_seq_lens_host)
+      .def_property_readonly("kv_seq_lens_host_values",
+                             &PyAttentionMetadataView::kv_seq_lens_host_values)
+      .def_property_readonly("block_table",
+                             &PyAttentionMetadataView::block_table)
+      .def_property_readonly("kv_seq_lens",
+                             &PyAttentionMetadataView::kv_seq_lens)
+      .def_property_readonly("q_seq_lens", &PyAttentionMetadataView::q_seq_lens)
+      .def_property_readonly("expanded_decode_metadata",
+                             &PyAttentionMetadataView::expanded_decode_metadata)
+      .def_property_readonly("is_prefill", &PyAttentionMetadataView::is_prefill)
+      .def_property_readonly("is_chunked_prefill",
+                             &PyAttentionMetadataView::is_chunked_prefill);
+}
+
+PyExpandedDecodeMetadataView::PyExpandedDecodeMetadataView(
+    std::shared_ptr<layer::AttentionMetadata> metadata)
+    : metadata_(std::move(metadata)) {}
+
+bool PyExpandedDecodeMetadataView::enabled() const {
+  return metadata().enabled;
+}
+
+py::object PyExpandedDecodeMetadataView::kv_seq_lens() const {
+  return metadata().kv_seq_lens.defined() ? py::cast(metadata().kv_seq_lens)
+                                          : py::none();
+}
+
+py::object PyExpandedDecodeMetadataView::block_table() const {
+  return metadata().block_table.defined() ? py::cast(metadata().block_table)
+                                          : py::none();
+}
+
+py::object PyExpandedDecodeMetadataView::paged_kv_indptr() const {
+  return metadata().paged_kv_indptr.defined()
+             ? py::cast(metadata().paged_kv_indptr)
+             : py::none();
+}
+
+py::object PyExpandedDecodeMetadataView::paged_kv_indices() const {
+  return metadata().paged_kv_indices.defined()
+             ? py::cast(metadata().paged_kv_indices)
+             : py::none();
+}
+
+py::object PyExpandedDecodeMetadataView::paged_kv_last_page_len() const {
+  return metadata().paged_kv_last_page_len.defined()
+             ? py::cast(metadata().paged_kv_last_page_len)
+             : py::none();
+}
+
+py::object PyExpandedDecodeMetadataView::paged_attention_tiling_data() const {
+  return metadata().paged_attention_tiling_data.defined()
+             ? py::cast(metadata().paged_attention_tiling_data)
+             : py::none();
+}
+
+py::object PyExpandedDecodeMetadataView::kv_seq_lens_host() const {
+  return metadata().kv_seq_lens_host.defined()
+             ? py::cast(metadata().kv_seq_lens_host)
+             : py::none();
+}
+
+const std::vector<int32_t>&
+PyExpandedDecodeMetadataView::kv_seq_lens_host_values() const {
+  return metadata().kv_seq_lens_host_vec;
+}
+
+const layer::ExpandedDecodeMetadata& PyExpandedDecodeMetadataView::metadata()
+    const {
+  return metadata_->expanded_decode;
+}
+
+PyAttentionMetadataView::PyAttentionMetadataView(
+    std::shared_ptr<layer::AttentionMetadata> metadata)
+    : metadata_(std::move(metadata)),
+      kv_seq_lens_host_(make_kv_seq_lens_host(metadata_)) {}
+
+const torch::Tensor& PyAttentionMetadataView::slot_mapping() const {
+  return metadata_->slot_mapping;
+}
+
+const torch::Tensor& PyAttentionMetadataView::paged_kv_indptr() const {
+  return metadata_->paged_kv_indptr;
+}
+
+const torch::Tensor& PyAttentionMetadataView::paged_kv_indices() const {
+  return metadata_->paged_kv_indices;
+}
+
+const torch::Tensor& PyAttentionMetadataView::paged_kv_last_page_len() const {
+  return metadata_->paged_kv_last_page_len;
+}
+
+py::object PyAttentionMetadataView::qo_indptr() const {
+  if (!metadata_->qo_indptr.has_value() || !metadata_->qo_indptr->defined()) {
+    return py::none();
+  }
+  return py::cast(*metadata_->qo_indptr);
+}
+
+py::object PyAttentionMetadataView::q_cu_seq_lens() const {
+  return optional_tensor(metadata_->q_cu_seq_lens);
+}
+
+py::object PyAttentionMetadataView::kv_cu_seq_lens() const {
+  return optional_tensor(metadata_->kv_cu_seq_lens);
+}
+
+py::object PyAttentionMetadataView::kv_seq_lens_host() const {
+  return optional_tensor(kv_seq_lens_host_);
+}
+
+const std::vector<int32_t>& PyAttentionMetadataView::kv_seq_lens_host_values()
+    const {
+  return metadata_->kv_seq_lens_vec;
+}
+
+py::object PyAttentionMetadataView::block_table() const {
+  return optional_tensor(metadata_->block_table);
+}
+
+py::object PyAttentionMetadataView::kv_seq_lens() const {
+  return optional_tensor(metadata_->kv_seq_lens);
+}
+
+py::object PyAttentionMetadataView::q_seq_lens() const {
+  return optional_tensor(metadata_->q_seq_lens);
+}
+
+PyExpandedDecodeMetadataView PyAttentionMetadataView::expanded_decode_metadata()
+    const {
+  return PyExpandedDecodeMetadataView(metadata_);
+}
+
+bool PyAttentionMetadataView::is_prefill() const {
+  return metadata_->is_prefill;
+}
+
+bool PyAttentionMetadataView::is_chunked_prefill() const {
+  return metadata_->is_chunked_prefill;
+}
+
+torch::Tensor PyAttentionMetadataView::make_kv_seq_lens_host(
+    const std::shared_ptr<layer::AttentionMetadata>& metadata) {
+  if (metadata->kv_seq_lens_vec.empty()) {
+    return torch::Tensor();
+  }
+
+  std::shared_ptr<layer::AttentionMetadata> owner = metadata;
+  return torch::from_blob(
+      metadata->kv_seq_lens_vec.data(),
+      {static_cast<int64_t>(metadata->kv_seq_lens_vec.size())},
+      [owner = std::move(owner)](void*) mutable { owner.reset(); },
+      torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU));
+}
+
+py::object PyAttentionMetadataView::optional_tensor(
+    const torch::Tensor& tensor) {
+  return tensor.defined() ? py::cast(tensor) : py::none();
+}
+
+}  // namespace xllm

--- a/xllm/core/runtime/py_attention_metadata.h
+++ b/xllm/core/runtime/py_attention_metadata.h
@@ -1,0 +1,94 @@
+/* Copyright 2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <torch/torch.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace xllm::layer {
+struct AttentionMetadata;
+struct ExpandedDecodeMetadata;
+}  // namespace xllm::layer
+
+namespace xllm {
+
+struct ModelInputParams;
+
+void register_attention_metadata_views(pybind11::module_& module);
+
+class PyExpandedDecodeMetadataView final {
+ public:
+  explicit PyExpandedDecodeMetadataView(
+      std::shared_ptr<layer::AttentionMetadata> metadata);
+
+  bool enabled() const;
+  pybind11::object kv_seq_lens() const;
+  pybind11::object block_table() const;
+  pybind11::object paged_kv_indptr() const;
+  pybind11::object paged_kv_indices() const;
+  pybind11::object paged_kv_last_page_len() const;
+  pybind11::object paged_attention_tiling_data() const;
+  pybind11::object kv_seq_lens_host() const;
+  const std::vector<int32_t>& kv_seq_lens_host_values() const;
+
+ private:
+  const layer::ExpandedDecodeMetadata& metadata() const;
+
+  std::shared_ptr<layer::AttentionMetadata> metadata_;
+};
+
+class PyAttentionMetadataView final {
+ public:
+  explicit PyAttentionMetadataView(
+      std::shared_ptr<layer::AttentionMetadata> metadata);
+  PyAttentionMetadataView(std::shared_ptr<layer::AttentionMetadata> metadata,
+                          const ModelInputParams& params);
+
+  const torch::Tensor& slot_mapping() const;
+  const torch::Tensor& paged_kv_indptr() const;
+  const torch::Tensor& paged_kv_indices() const;
+  const torch::Tensor& paged_kv_last_page_len() const;
+  pybind11::object qo_indptr() const;
+  pybind11::object q_cu_seq_lens() const;
+  pybind11::object kv_cu_seq_lens() const;
+  pybind11::object kv_seq_lens_host() const;
+  const std::vector<int32_t>& kv_seq_lens_host_values() const;
+  pybind11::object block_table() const;
+  pybind11::object kv_seq_lens() const;
+  pybind11::object linear_state_indices() const;
+  pybind11::object has_initial_state() const;
+  const std::vector<int32_t>& dp_token_counts() const;
+  pybind11::object q_seq_lens() const;
+  PyExpandedDecodeMetadataView expanded_decode_metadata() const;
+  bool is_prefill() const;
+  bool is_chunked_prefill() const;
+
+ private:
+  static torch::Tensor make_kv_seq_lens_host(
+      const std::shared_ptr<layer::AttentionMetadata>& metadata);
+  static pybind11::object optional_tensor(const torch::Tensor& tensor);
+
+  std::shared_ptr<layer::AttentionMetadata> metadata_;
+  torch::Tensor kv_seq_lens_host_;
+  torch::Tensor linear_state_indices_;
+  std::vector<int32_t> dp_token_counts_;
+};
+
+}  // namespace xllm

--- a/xllm/core/runtime/py_attention_metadata.h
+++ b/xllm/core/runtime/py_attention_metadata.h
@@ -1,0 +1,85 @@
+/* Copyright 2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <torch/torch.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace xllm::layer {
+struct AttentionMetadata;
+struct ExpandedDecodeMetadata;
+}  // namespace xllm::layer
+
+namespace xllm {
+
+void register_attention_metadata_views(pybind11::module_& module);
+
+class PyExpandedDecodeMetadataView final {
+ public:
+  explicit PyExpandedDecodeMetadataView(
+      std::shared_ptr<layer::AttentionMetadata> metadata);
+
+  bool enabled() const;
+  pybind11::object kv_seq_lens() const;
+  pybind11::object block_table() const;
+  pybind11::object paged_kv_indptr() const;
+  pybind11::object paged_kv_indices() const;
+  pybind11::object paged_kv_last_page_len() const;
+  pybind11::object paged_attention_tiling_data() const;
+  pybind11::object kv_seq_lens_host() const;
+  const std::vector<int32_t>& kv_seq_lens_host_values() const;
+
+ private:
+  const layer::ExpandedDecodeMetadata& metadata() const;
+
+  std::shared_ptr<layer::AttentionMetadata> metadata_;
+};
+
+class PyAttentionMetadataView final {
+ public:
+  explicit PyAttentionMetadataView(
+      std::shared_ptr<layer::AttentionMetadata> metadata);
+
+  const torch::Tensor& slot_mapping() const;
+  const torch::Tensor& paged_kv_indptr() const;
+  const torch::Tensor& paged_kv_indices() const;
+  const torch::Tensor& paged_kv_last_page_len() const;
+  pybind11::object qo_indptr() const;
+  pybind11::object q_cu_seq_lens() const;
+  pybind11::object kv_cu_seq_lens() const;
+  pybind11::object kv_seq_lens_host() const;
+  const std::vector<int32_t>& kv_seq_lens_host_values() const;
+  pybind11::object block_table() const;
+  pybind11::object kv_seq_lens() const;
+  pybind11::object q_seq_lens() const;
+  PyExpandedDecodeMetadataView expanded_decode_metadata() const;
+  bool is_prefill() const;
+  bool is_chunked_prefill() const;
+
+ private:
+  static torch::Tensor make_kv_seq_lens_host(
+      const std::shared_ptr<layer::AttentionMetadata>& metadata);
+  static pybind11::object optional_tensor(const torch::Tensor& tensor);
+
+  std::shared_ptr<layer::AttentionMetadata> metadata_;
+  torch::Tensor kv_seq_lens_host_;
+};
+
+}  // namespace xllm

--- a/xllm/core/runtime/py_executor_impl.cpp
+++ b/xllm/core/runtime/py_executor_impl.cpp
@@ -205,6 +205,9 @@ ModelOutput PyExecutorImpl::run(const torch::Tensor& tokens,
   }
 
   py::object py_metadata = py::cast(AttentionMetadataView(attn_metadata));
+  py::object input_embedding = params.embedding.input_embedding.defined()
+                                   ? py::cast(params.embedding.input_embedding)
+                                   : py::none();
 
   py::object py_sync = py::none();
 #if defined(USE_NPU)
@@ -214,9 +217,8 @@ ModelOutput PyExecutorImpl::run(const torch::Tensor& tokens,
 #endif
 
   // Execute: one C++ -> Python call per step.
-  py::object hidden_obj =
-      py_executor_.attr("execute")(tokens, positions, py_metadata, py_sync);
-
+  py::object hidden_obj = py_executor_.attr("execute")(
+      tokens, positions, py_metadata, input_embedding, py_sync);
   return ModelOutput(hidden_obj.cast<torch::Tensor>());
 }
 

--- a/xllm/core/runtime/py_executor_impl.cpp
+++ b/xllm/core/runtime/py_executor_impl.cpp
@@ -13,11 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "py_executor_impl.h"
+#include "core/runtime/py_executor_impl.h"
 
+#include <Python.h>
 #include <glog/logging.h>
 #include <pybind11/embed.h>
-#include <pybind11/stl.h>
 #include <torch/extension.h>
 
 #include <memory>
@@ -26,6 +26,7 @@ limitations under the License.
 #include "common/metrics.h"
 #include "core/layers/common/attention_metadata.h"
 #include "core/layers/common/attention_metadata_builder.h"
+#include "core/runtime/py_attention_metadata.h"
 #include "models/llm/py_causal_lm.h"
 
 #if defined(USE_NPU)
@@ -37,97 +38,24 @@ limitations under the License.
 namespace py = pybind11;
 
 namespace xllm {
-
 namespace {
 
-class AttentionMetadataView final {
- public:
-  explicit AttentionMetadataView(
-      std::shared_ptr<layer::AttentionMetadata> metadata)
-      : metadata_(std::move(metadata)),
-        kv_seq_lens_host_(make_kv_seq_lens_host(metadata_)) {}
-
-  const torch::Tensor& slot_mapping() const { return metadata_->slot_mapping; }
-  const torch::Tensor& paged_kv_indptr() const {
-    return metadata_->paged_kv_indptr;
+void clear_python_object(py::object& object) {
+  if (!object) {
+    return;
   }
-  const torch::Tensor& paged_kv_indices() const {
-    return metadata_->paged_kv_indices;
+  if (!Py_IsInitialized()) {
+    (void)object.release();
+    return;
   }
-  const torch::Tensor& paged_kv_last_page_len() const {
-    return metadata_->paged_kv_last_page_len;
-  }
-  py::object qo_indptr() const {
-    if (!metadata_->qo_indptr.has_value() || !metadata_->qo_indptr->defined()) {
-      return py::none();
-    }
-    return py::cast(*metadata_->qo_indptr);
-  }
-  py::object q_cu_seq_lens() const {
-    return optional_tensor(metadata_->q_cu_seq_lens);
-  }
-  py::object kv_cu_seq_lens() const {
-    return optional_tensor(metadata_->kv_cu_seq_lens);
-  }
-  py::object kv_seq_lens_host() const {
-    return optional_tensor(kv_seq_lens_host_);
-  }
-  py::object block_table() const {
-    return optional_tensor(metadata_->block_table);
-  }
-  py::object kv_seq_lens() const {
-    return optional_tensor(metadata_->kv_seq_lens);
-  }
-  bool is_prefill() const { return metadata_->is_prefill; }
-  bool is_chunked_prefill() const { return metadata_->is_chunked_prefill; }
-
- private:
-  static torch::Tensor make_kv_seq_lens_host(
-      const std::shared_ptr<layer::AttentionMetadata>& metadata) {
-    if (metadata->kv_seq_lens_vec.empty()) {
-      return torch::Tensor();
-    }
-
-    std::shared_ptr<layer::AttentionMetadata> owner = metadata;
-    return torch::from_blob(
-        metadata->kv_seq_lens_vec.data(),
-        {static_cast<int64_t>(metadata->kv_seq_lens_vec.size())},
-        [owner = std::move(owner)](void*) mutable { owner.reset(); },
-        torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU));
-  }
-
-  static py::object optional_tensor(const torch::Tensor& tensor) {
-    return tensor.defined() ? py::cast(tensor) : py::none();
-  }
-
-  std::shared_ptr<layer::AttentionMetadata> metadata_;
-  torch::Tensor kv_seq_lens_host_;
-};
+  py::gil_scoped_acquire gil;
+  object = py::object();
+}
 
 }  // namespace
 
 PYBIND11_EMBEDDED_MODULE(xllm_runtime, m) {
-  py::class_<AttentionMetadataView>(m, "AttentionMetadataView")
-      .def_property_readonly("slot_mapping",
-                             &AttentionMetadataView::slot_mapping)
-      .def_property_readonly("paged_kv_indptr",
-                             &AttentionMetadataView::paged_kv_indptr)
-      .def_property_readonly("paged_kv_indices",
-                             &AttentionMetadataView::paged_kv_indices)
-      .def_property_readonly("paged_kv_last_page_len",
-                             &AttentionMetadataView::paged_kv_last_page_len)
-      .def_property_readonly("qo_indptr", &AttentionMetadataView::qo_indptr)
-      .def_property_readonly("q_cu_seq_lens",
-                             &AttentionMetadataView::q_cu_seq_lens)
-      .def_property_readonly("kv_cu_seq_lens",
-                             &AttentionMetadataView::kv_cu_seq_lens)
-      .def_property_readonly("kv_seq_lens_host",
-                             &AttentionMetadataView::kv_seq_lens_host)
-      .def_property_readonly("block_table", &AttentionMetadataView::block_table)
-      .def_property_readonly("kv_seq_lens", &AttentionMetadataView::kv_seq_lens)
-      .def_property_readonly("is_prefill", &AttentionMetadataView::is_prefill)
-      .def_property_readonly("is_chunked_prefill",
-                             &AttentionMetadataView::is_chunked_prefill);
+  register_attention_metadata_views(m);
 
 #if defined(USE_NPU)
   py::class_<NPULayerSynchronizerImpl,
@@ -161,10 +89,7 @@ PyExecutorImpl::PyExecutorImpl(CausalLM* model,
                                             options_.max_seqs_per_batch());
 }
 
-PyExecutorImpl::~PyExecutorImpl() {
-  py::gil_scoped_acquire gil;
-  py_executor_ = py::object();
-}
+PyExecutorImpl::~PyExecutorImpl() { clear_python_object(py_executor_); }
 
 ForwardInput PyExecutorImpl::prepare_inputs(Batch& batch) {
   return batch.prepare_forward_input(
@@ -204,7 +129,7 @@ ModelOutput PyExecutorImpl::run(const torch::Tensor& tokens,
         << "KV cache layer count changed after initial bind";
   }
 
-  py::object py_metadata = py::cast(AttentionMetadataView(attn_metadata));
+  py::object py_metadata = py::cast(PyAttentionMetadataView(attn_metadata));
   py::object input_embedding = params.embedding.input_embedding.defined()
                                    ? py::cast(params.embedding.input_embedding)
                                    : py::none();

--- a/xllm/core/runtime/py_executor_impl.cpp
+++ b/xllm/core/runtime/py_executor_impl.cpp
@@ -13,11 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "py_executor_impl.h"
+#include "core/runtime/py_executor_impl.h"
 
+#include <Python.h>
 #include <glog/logging.h>
 #include <pybind11/embed.h>
-#include <pybind11/stl.h>
 #include <torch/extension.h>
 
 #include <memory>
@@ -27,6 +27,7 @@ limitations under the License.
 #include "common/metrics.h"
 #include "core/layers/common/attention_metadata.h"
 #include "core/layers/common/attention_metadata_builder.h"
+#include "core/runtime/py_attention_metadata.h"
 #include "models/llm/py_causal_lm.h"
 
 #if defined(USE_NPU)
@@ -38,119 +39,28 @@ limitations under the License.
 namespace py = pybind11;
 
 namespace xllm {
-
 namespace {
 
 py::object optional_tensor(const torch::Tensor& tensor) {
   return tensor.defined() ? py::cast(tensor) : py::none();
 }
 
-class AttentionMetadataView final {
- public:
-  explicit AttentionMetadataView(
-      std::shared_ptr<layer::AttentionMetadata> metadata,
-      const ModelInputParams& params)
-      : metadata_(std::move(metadata)),
-        kv_seq_lens_host_(make_kv_seq_lens_host(metadata_)),
-        linear_state_indices_(params.embedding.linear_state_indices),
-        dp_token_counts_(params.parallel.raw_dp_global_token_nums.empty()
-                             ? params.parallel.dp_global_token_nums
-                             : params.parallel.raw_dp_global_token_nums) {}
-
-  const torch::Tensor& slot_mapping() const { return metadata_->slot_mapping; }
-  const torch::Tensor& paged_kv_indptr() const {
-    return metadata_->paged_kv_indptr;
+void clear_python_object(py::object& object) {
+  if (!object) {
+    return;
   }
-  const torch::Tensor& paged_kv_indices() const {
-    return metadata_->paged_kv_indices;
+  if (!Py_IsInitialized()) {
+    (void)object.release();
+    return;
   }
-  const torch::Tensor& paged_kv_last_page_len() const {
-    return metadata_->paged_kv_last_page_len;
-  }
-  py::object qo_indptr() const {
-    if (!metadata_->qo_indptr.has_value() || !metadata_->qo_indptr->defined()) {
-      return py::none();
-    }
-    return py::cast(*metadata_->qo_indptr);
-  }
-  py::object q_cu_seq_lens() const {
-    return optional_tensor(metadata_->q_cu_seq_lens);
-  }
-  py::object kv_cu_seq_lens() const {
-    return optional_tensor(metadata_->kv_cu_seq_lens);
-  }
-  py::object kv_seq_lens_host() const {
-    return optional_tensor(kv_seq_lens_host_);
-  }
-  py::object block_table() const {
-    return optional_tensor(metadata_->block_table);
-  }
-  py::object kv_seq_lens() const {
-    return optional_tensor(metadata_->kv_seq_lens);
-  }
-  py::object linear_state_indices() const {
-    return optional_tensor(linear_state_indices_);
-  }
-  py::object has_initial_state() const {
-    return optional_tensor(metadata_->has_initial_states);
-  }
-  const std::vector<int32_t>& dp_token_counts() const {
-    return dp_token_counts_;
-  }
-  bool is_prefill() const { return metadata_->is_prefill; }
-  bool is_chunked_prefill() const { return metadata_->is_chunked_prefill; }
-
- private:
-  static torch::Tensor make_kv_seq_lens_host(
-      const std::shared_ptr<layer::AttentionMetadata>& metadata) {
-    if (metadata->kv_seq_lens_vec.empty()) {
-      return torch::Tensor();
-    }
-
-    std::shared_ptr<layer::AttentionMetadata> owner = metadata;
-    return torch::from_blob(
-        metadata->kv_seq_lens_vec.data(),
-        {static_cast<int64_t>(metadata->kv_seq_lens_vec.size())},
-        [owner = std::move(owner)](void*) mutable { owner.reset(); },
-        torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU));
-  }
-
-  std::shared_ptr<layer::AttentionMetadata> metadata_;
-  torch::Tensor kv_seq_lens_host_;
-  torch::Tensor linear_state_indices_;
-  std::vector<int32_t> dp_token_counts_;
-};
+  py::gil_scoped_acquire gil;
+  object = py::object();
+}
 
 }  // namespace
 
 PYBIND11_EMBEDDED_MODULE(xllm_runtime, m) {
-  py::class_<AttentionMetadataView>(m, "AttentionMetadataView")
-      .def_property_readonly("slot_mapping",
-                             &AttentionMetadataView::slot_mapping)
-      .def_property_readonly("paged_kv_indptr",
-                             &AttentionMetadataView::paged_kv_indptr)
-      .def_property_readonly("paged_kv_indices",
-                             &AttentionMetadataView::paged_kv_indices)
-      .def_property_readonly("paged_kv_last_page_len",
-                             &AttentionMetadataView::paged_kv_last_page_len)
-      .def_property_readonly("qo_indptr", &AttentionMetadataView::qo_indptr)
-      .def_property_readonly("q_cu_seq_lens",
-                             &AttentionMetadataView::q_cu_seq_lens)
-      .def_property_readonly("kv_cu_seq_lens",
-                             &AttentionMetadataView::kv_cu_seq_lens)
-      .def_property_readonly("kv_seq_lens_host",
-                             &AttentionMetadataView::kv_seq_lens_host)
-      .def_property_readonly("block_table", &AttentionMetadataView::block_table)
-      .def_property_readonly("kv_seq_lens", &AttentionMetadataView::kv_seq_lens)
-      .def_property_readonly("linear_state_indices",
-                             &AttentionMetadataView::linear_state_indices)
-      .def_property_readonly("has_initial_state",
-                             &AttentionMetadataView::has_initial_state)
-      .def_property_readonly("dp_token_counts",
-                             &AttentionMetadataView::dp_token_counts)
-      .def_property_readonly("is_prefill", &AttentionMetadataView::is_prefill)
-      .def_property_readonly("is_chunked_prefill",
-                             &AttentionMetadataView::is_chunked_prefill);
+  register_attention_metadata_views(m);
 
 #if defined(USE_NPU)
   py::class_<NPULayerSynchronizerImpl,
@@ -185,10 +95,7 @@ PyExecutorImpl::PyExecutorImpl(CausalLM* model,
                                             options_.max_seqs_per_batch());
 }
 
-PyExecutorImpl::~PyExecutorImpl() {
-  py::gil_scoped_acquire gil;
-  py_executor_ = py::object();
-}
+PyExecutorImpl::~PyExecutorImpl() { clear_python_object(py_executor_); }
 
 ForwardInput PyExecutorImpl::prepare_inputs(Batch& batch) {
   return batch.prepare_forward_input(
@@ -234,7 +141,7 @@ ModelOutput PyExecutorImpl::run(const torch::Tensor& tokens,
   }
 
   py::object py_metadata =
-      py::cast(AttentionMetadataView(attn_metadata, params));
+      py::cast(PyAttentionMetadataView(attn_metadata, params));
   py::object input_embedding = params.embedding.input_embedding.defined()
                                    ? py::cast(params.embedding.input_embedding)
                                    : py::none();

--- a/xllm/core/runtime/py_executor_impl.cpp
+++ b/xllm/core/runtime/py_executor_impl.cpp
@@ -235,6 +235,9 @@ ModelOutput PyExecutorImpl::run(const torch::Tensor& tokens,
 
   py::object py_metadata =
       py::cast(AttentionMetadataView(attn_metadata, params));
+  py::object input_embedding = params.embedding.input_embedding.defined()
+                                   ? py::cast(params.embedding.input_embedding)
+                                   : py::none();
 
   py::object py_sync = py::none();
 #if defined(USE_NPU)
@@ -244,9 +247,8 @@ ModelOutput PyExecutorImpl::run(const torch::Tensor& tokens,
 #endif
 
   // Execute: one C++ -> Python call per step.
-  py::object hidden_obj =
-      py_executor_.attr("execute")(tokens, positions, py_metadata, py_sync);
-
+  py::object hidden_obj = py_executor_.attr("execute")(
+      tokens, positions, py_metadata, input_embedding, py_sync);
   return ModelOutput(hidden_obj.cast<torch::Tensor>());
 }
 

--- a/xllm/models/llm/py_causal_lm.cpp
+++ b/xllm/models/llm/py_causal_lm.cpp
@@ -125,4 +125,18 @@ torch::Tensor PyCausalLM::logits(const torch::Tensor& hidden_states,
   return out.cast<torch::Tensor>();
 }
 
+bool PyCausalLM::share_weights_from(CausalLM& source) {
+  auto* source_model = dynamic_cast<PyCausalLM*>(&source);
+  if (source_model == nullptr) {
+    return false;
+  }
+
+  py::gil_scoped_acquire gil;
+  py_model_.attr("lm_head") = source_model->py_model_.attr("lm_head");
+  py::object draft_body = py_model_.attr("model");
+  py::object target_body = source_model->py_model_.attr("model");
+  draft_body.attr("embed_tokens") = target_body.attr("embed_tokens");
+  return true;
+}
+
 }  // namespace xllm

--- a/xllm/models/llm/py_causal_lm.cpp
+++ b/xllm/models/llm/py_causal_lm.cpp
@@ -188,4 +188,18 @@ torch::Tensor PyCausalLM::logits(const torch::Tensor& hidden_states,
   return out.cast<torch::Tensor>();
 }
 
+bool PyCausalLM::share_weights_from(CausalLM& source) {
+  auto* source_model = dynamic_cast<PyCausalLM*>(&source);
+  if (source_model == nullptr) {
+    return false;
+  }
+
+  py::gil_scoped_acquire gil;
+  py_model_.attr("lm_head") = source_model->py_model_.attr("lm_head");
+  py::object draft_body = py_model_.attr("model");
+  py::object target_body = source_model->py_model_.attr("model");
+  draft_body.attr("embed_tokens") = target_body.attr("embed_tokens");
+  return true;
+}
+
 }  // namespace xllm

--- a/xllm/models/llm/py_causal_lm.cpp
+++ b/xllm/models/llm/py_causal_lm.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "models/llm/py_causal_lm.h"
 
+#include <Python.h>
 #include <glog/logging.h>
 #include <pybind11/stl.h>
 #include <torch/extension.h>
@@ -32,6 +33,36 @@ limitations under the License.
 namespace py = pybind11;
 
 namespace xllm {
+namespace detail {
+
+void share_python_model_weights(py::object& draft_model,
+                                const py::object& target_model) {
+  draft_model.attr("lm_head") = target_model.attr("lm_head");
+  py::object draft_body = draft_model.attr("model");
+  py::object target_body = target_model.attr("model");
+  draft_body.attr("embed_tokens") = target_body.attr("embed_tokens");
+}
+
+}  // namespace detail
+
+namespace {
+
+void clear_python_object(py::object& object) {
+  if (!object) {
+    return;
+  }
+  if (!Py_IsInitialized()) {
+    // CPython has already torn down its GIL. Avoid decref during C++ static
+    // destruction; the process is exiting and the reference cannot be safely
+    // released anymore.
+    (void)object.release();
+    return;
+  }
+  py::gil_scoped_acquire gil;
+  object = py::object();
+}
+
+}  // namespace
 
 PyCausalLM::PyCausalLM(const ModelContext& context)
     : model_args_(context.get_model_args()),
@@ -125,9 +156,8 @@ PyCausalLM::PyCausalLM(const ModelContext& context)
 }
 
 PyCausalLM::~PyCausalLM() {
-  py::gil_scoped_acquire gil;
-  py_model_ = py::object();
-  config_dict_ = py::object();
+  clear_python_object(py_model_);
+  clear_python_object(config_dict_);
 }
 
 py::dict PyCausalLM::build_config_dict(
@@ -195,10 +225,7 @@ bool PyCausalLM::share_weights_from(CausalLM& source) {
   }
 
   py::gil_scoped_acquire gil;
-  py_model_.attr("lm_head") = source_model->py_model_.attr("lm_head");
-  py::object draft_body = py_model_.attr("model");
-  py::object target_body = source_model->py_model_.attr("model");
-  draft_body.attr("embed_tokens") = target_body.attr("embed_tokens");
+  detail::share_python_model_weights(py_model_, source_model->py_model_);
   return true;
 }
 

--- a/xllm/models/llm/py_causal_lm.cpp
+++ b/xllm/models/llm/py_causal_lm.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "models/llm/py_causal_lm.h"
 
+#include <Python.h>
 #include <glog/logging.h>
 #include <pybind11/stl.h>
 #include <torch/extension.h>
@@ -32,6 +33,36 @@ limitations under the License.
 namespace py = pybind11;
 
 namespace xllm {
+namespace detail {
+
+void share_python_model_weights(py::object& draft_model,
+                                const py::object& target_model) {
+  draft_model.attr("lm_head") = target_model.attr("lm_head");
+  py::object draft_body = draft_model.attr("model");
+  py::object target_body = target_model.attr("model");
+  draft_body.attr("embed_tokens") = target_body.attr("embed_tokens");
+}
+
+}  // namespace detail
+
+namespace {
+
+void clear_python_object(py::object& object) {
+  if (!object) {
+    return;
+  }
+  if (!Py_IsInitialized()) {
+    // CPython has already torn down its GIL. Avoid decref during C++ static
+    // destruction; the process is exiting and the reference cannot be safely
+    // released anymore.
+    (void)object.release();
+    return;
+  }
+  py::gil_scoped_acquire gil;
+  object = py::object();
+}
+
+}  // namespace
 
 PyCausalLM::PyCausalLM(const ModelContext& context)
     : model_args_(context.get_model_args()),
@@ -68,9 +99,8 @@ PyCausalLM::PyCausalLM(const ModelContext& context)
 }
 
 PyCausalLM::~PyCausalLM() {
-  py::gil_scoped_acquire gil;
-  py_model_ = py::object();
-  config_dict_ = py::object();
+  clear_python_object(py_model_);
+  clear_python_object(config_dict_);
 }
 
 py::dict PyCausalLM::build_config_dict(
@@ -132,10 +162,7 @@ bool PyCausalLM::share_weights_from(CausalLM& source) {
   }
 
   py::gil_scoped_acquire gil;
-  py_model_.attr("lm_head") = source_model->py_model_.attr("lm_head");
-  py::object draft_body = py_model_.attr("model");
-  py::object target_body = source_model->py_model_.attr("model");
-  draft_body.attr("embed_tokens") = target_body.attr("embed_tokens");
+  detail::share_python_model_weights(py_model_, source_model->py_model_);
   return true;
 }
 

--- a/xllm/models/llm/py_causal_lm.h
+++ b/xllm/models/llm/py_causal_lm.h
@@ -50,6 +50,8 @@ class __attribute__((visibility("hidden"))) PyCausalLM : public CausalLM {
   void prepare_expert_weight(int32_t, const std::vector<int32_t>&) override {}
   void update_expert_weight(int32_t) override {}
 
+  bool share_weights_from(CausalLM& source) override;
+
   pybind11::object& python_model() { return py_model_; }
   const pybind11::object& config_dict() const { return config_dict_; }
 

--- a/xllm/models/llm/py_causal_lm.h
+++ b/xllm/models/llm/py_causal_lm.h
@@ -29,6 +29,11 @@ namespace xllm {
 
 class ProcessGroup;
 
+namespace detail {
+void share_python_model_weights(pybind11::object& draft_model,
+                                const pybind11::object& target_model);
+}  // namespace detail
+
 class __attribute__((visibility("hidden"))) PyCausalLM : public CausalLM {
  public:
   explicit PyCausalLM(const ModelContext& context);

--- a/xllm/models/model_registry.cpp
+++ b/xllm/models/model_registry.cpp
@@ -118,8 +118,9 @@ bool resolve_model_registration(const std::string& model_type,
         is_torch_only_model_type(model_type) ? kTorchBackend : kAtbBackend;
   } else if (model_type == "qwen3" || model_type == "qwen3_moe" ||
              model_type == "deepseek_v32" || model_type == "glm_moe_dsa" ||
-             model_type == "qwen3_vl") {
-    // qwen3/qwen3_moe/deepseek_v32/glm_moe_dsa/qwen3_vl support both backends.
+             model_type == "qwen3_vl" || model_type == "deepseek_v32_mtp") {
+    // qwen3/qwen3_moe/deepseek_v32/glm_moe_dsa/qwen3_vl/deepseek_v32_mtp
+    // support both backends.
   } else if (is_torch_only_model_type(model_type)) {
     if (backend != kTorchBackend) {
       if (error_message != nullptr) {

--- a/xllm/python/attention/backend.py
+++ b/xllm/python/attention/backend.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Callable, Protocol
 
 import torch
 
@@ -58,6 +58,7 @@ class MlaIndexContext:
     block_table: torch.Tensor | None
     actual_seq_q: torch.Tensor
     actual_seq_kv: torch.Tensor
+    update_index_cache: Callable[[torch.Tensor], None]
 
 
 class AttentionBackend(ABC):

--- a/xllm/python/attention/backend.py
+++ b/xllm/python/attention/backend.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Protocol, Sequence
+from typing import TYPE_CHECKING, Callable, Protocol, Sequence
 
 import torch
 
@@ -100,6 +100,7 @@ class MlaIndexContext:
     block_table: torch.Tensor | None
     actual_seq_q: torch.Tensor
     actual_seq_kv: torch.Tensor
+    update_index_cache: Callable[[torch.Tensor], None]
 
 
 class AttentionBackend(ABC):

--- a/xllm/python/attention/backend.py
+++ b/xllm/python/attention/backend.py
@@ -20,6 +20,10 @@ from typing import TYPE_CHECKING, Callable, Protocol, Sequence
 
 import torch
 
+from xllm.python.attention.expanded_decode_metadata import (
+    ExpandedDecodeMetadataLike,
+)
+
 if TYPE_CHECKING:
     from xllm.python.layers.attention import Attention
 
@@ -74,6 +78,7 @@ class AttentionMetadata(Protocol):
     q_cu_seq_lens: torch.Tensor | None
     kv_cu_seq_lens: torch.Tensor | None
     kv_seq_lens_host: torch.Tensor | None
+    kv_seq_lens_host_values: list[int] | None
     paged_kv_indptr_host: torch.Tensor | None
     paged_kv_last_page_len_host: torch.Tensor | None
     block_table: torch.Tensor | None
@@ -81,6 +86,8 @@ class AttentionMetadata(Protocol):
     linear_state_indices: torch.Tensor | None
     has_initial_state: torch.Tensor | None
     dp_token_counts: Sequence[int]
+    q_seq_lens: torch.Tensor | None
+    expanded_decode_metadata: ExpandedDecodeMetadataLike
     is_prefill: bool
     is_chunked_prefill: bool
 

--- a/xllm/python/attention/backend.py
+++ b/xllm/python/attention/backend.py
@@ -20,6 +20,10 @@ from typing import TYPE_CHECKING, Callable, Protocol
 
 import torch
 
+from xllm.python.attention.expanded_decode_metadata import (
+    ExpandedDecodeMetadataLike,
+)
+
 if TYPE_CHECKING:
     from xllm.python.layers.attention import Attention
 
@@ -35,10 +39,13 @@ class AttentionMetadata(Protocol):
     q_cu_seq_lens: torch.Tensor | None
     kv_cu_seq_lens: torch.Tensor | None
     kv_seq_lens_host: torch.Tensor | None
+    kv_seq_lens_host_values: list[int] | None
     paged_kv_indptr_host: torch.Tensor | None
     paged_kv_last_page_len_host: torch.Tensor | None
     block_table: torch.Tensor | None
     kv_seq_lens: torch.Tensor | None
+    q_seq_lens: torch.Tensor | None
+    expanded_decode_metadata: ExpandedDecodeMetadataLike
     is_prefill: bool
     is_chunked_prefill: bool
 

--- a/xllm/python/attention/expanded_decode_metadata.py
+++ b/xllm/python/attention/expanded_decode_metadata.py
@@ -1,0 +1,177 @@
+# Copyright 2026 The xLLM Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://github.com/jd-opensource/xllm/blob/main/LICENSE
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import torch
+
+
+class ExpandedDecodeMetadataLike(Protocol):
+    enabled: bool
+    kv_seq_lens: torch.Tensor | None
+    block_table: torch.Tensor | None
+    paged_kv_indptr: torch.Tensor | None
+    paged_kv_indices: torch.Tensor | None
+    paged_kv_last_page_len: torch.Tensor | None
+    paged_attention_tiling_data: torch.Tensor | None
+    kv_seq_lens_host: torch.Tensor | None
+    kv_seq_lens_host_values: list[int] | None
+
+
+@dataclass(frozen=True, slots=True)
+class ExpandedDecodeMetadata:
+    kv_seq_lens: torch.Tensor
+    block_table: torch.Tensor
+    paged_kv_indptr: torch.Tensor
+    paged_kv_indices: torch.Tensor
+    paged_kv_last_page_len: torch.Tensor
+    paged_attention_tiling_data: torch.Tensor | None
+    kv_seq_lens_host: torch.Tensor | None
+    kv_seq_lens_host_values: list[int] | None
+    enabled: bool = True
+
+
+def resolve_expanded_decode_metadata(
+    metadata: object,
+    *,
+    block_size: int = 0,
+) -> ExpandedDecodeMetadata | None:
+    expanded = getattr(metadata, "expanded_decode_metadata", None)
+    if expanded is None or not bool(getattr(expanded, "enabled", True)):
+        return None
+
+    required = {
+        "kv_seq_lens": expanded.kv_seq_lens,
+        "block_table": expanded.block_table,
+        "paged_kv_indptr": expanded.paged_kv_indptr,
+        "paged_kv_indices": expanded.paged_kv_indices,
+        "paged_kv_last_page_len": expanded.paged_kv_last_page_len,
+    }
+    missing = [name for name, tensor in required.items() if tensor is None]
+    if missing:
+        raise RuntimeError(
+            "expanded decode metadata is missing: " + ", ".join(missing)
+        )
+
+    host_values_source = getattr(expanded, "kv_seq_lens_host_values", None)
+    host_values = (
+        list(host_values_source) if host_values_source is not None else None
+    )
+    resolved = ExpandedDecodeMetadata(
+        kv_seq_lens=expanded.kv_seq_lens.to(torch.int32),
+        block_table=expanded.block_table.to(torch.int32),
+        paged_kv_indptr=expanded.paged_kv_indptr,
+        paged_kv_indices=expanded.paged_kv_indices,
+        paged_kv_last_page_len=expanded.paged_kv_last_page_len,
+        paged_attention_tiling_data=expanded.paged_attention_tiling_data,
+        kv_seq_lens_host=expanded.kv_seq_lens_host,
+        kv_seq_lens_host_values=host_values,
+    )
+    _validate_expanded_decode_metadata(
+        resolved,
+        slot_mapping=getattr(metadata, "slot_mapping", None),
+        block_size=block_size,
+    )
+    return resolved
+
+
+def _validate_expanded_decode_metadata(
+    metadata: ExpandedDecodeMetadata,
+    *,
+    slot_mapping: torch.Tensor | None,
+    block_size: int,
+) -> None:
+    if metadata.block_table.dim() != 2:
+        raise RuntimeError("expanded decode block_table must be two-dimensional")
+    sequence_count = metadata.block_table.shape[0]
+    if (
+        slot_mapping is None
+        or slot_mapping.dim() != 1
+        or slot_mapping.numel() != sequence_count
+    ):
+        raise RuntimeError(
+            "expanded decode slot_mapping must contain one slot per token"
+        )
+    per_sequence_tensors = (
+        ("kv_seq_lens", metadata.kv_seq_lens),
+        ("paged_kv_last_page_len", metadata.paged_kv_last_page_len),
+    )
+    if metadata.kv_seq_lens_host is not None:
+        per_sequence_tensors += (
+            ("kv_seq_lens_host", metadata.kv_seq_lens_host),
+        )
+    for name, tensor in per_sequence_tensors:
+        if tensor.dim() != 1 or tensor.numel() != sequence_count:
+            raise RuntimeError(
+                f"expanded decode {name} must contain one value per sequence"
+            )
+    if (
+        metadata.kv_seq_lens_host_values is not None
+        and len(metadata.kv_seq_lens_host_values) != sequence_count
+    ):
+        raise RuntimeError(
+            "expanded decode kv_seq_lens_host_values must contain one value "
+            "per sequence"
+        )
+    if (
+        metadata.paged_kv_indptr.dim() != 1
+        or metadata.paged_kv_indptr.numel() != sequence_count + 1
+    ):
+        raise RuntimeError(
+            "expanded decode paged_kv_indptr must contain one offset per "
+            "sequence plus the terminal offset"
+        )
+    if (
+        metadata.paged_kv_indices.dim() != 1
+        or metadata.paged_kv_indices.numel() == 0
+    ):
+        raise RuntimeError(
+            "expanded decode paged_kv_indices must be a non-empty flat page list"
+        )
+
+    if metadata.paged_kv_indptr.device.type == "cpu":
+        indptr = metadata.paged_kv_indptr
+        if int(indptr[0]) != 0:
+            raise RuntimeError("expanded decode paged_kv_indptr must start at zero")
+        if not bool(torch.all(indptr[1:] >= indptr[:-1])):
+            raise RuntimeError("expanded decode paged_kv_indptr must be monotonic")
+        if int(indptr[-1]) != metadata.paged_kv_indices.numel():
+            raise RuntimeError(
+                "expanded decode terminal page offset must match page count"
+            )
+    if metadata.paged_kv_last_page_len.device.type == "cpu":
+        last_page_lens = metadata.paged_kv_last_page_len
+        if not bool(torch.all(last_page_lens >= 1)):
+            raise RuntimeError(
+                "expanded decode last-page lengths must be positive"
+            )
+        if block_size > 0 and not bool(torch.all(last_page_lens <= block_size)):
+            raise RuntimeError(
+                "expanded decode last-page lengths must not exceed block size"
+            )
+    if metadata.kv_seq_lens_host_values is not None and block_size > 0:
+        block_table_capacity = metadata.block_table.shape[1]
+        for kv_seq_len in metadata.kv_seq_lens_host_values:
+            if kv_seq_len < 0:
+                raise RuntimeError(
+                    "expanded decode host KV lengths must be non-negative"
+                )
+            page_count = (max(kv_seq_len, 1) + block_size - 1) // block_size
+            if page_count > block_table_capacity:
+                raise RuntimeError(
+                    "expanded decode page count exceeds block-table capacity"
+                )

--- a/xllm/python/attention/npu_paged_attention.py
+++ b/xllm/python/attention/npu_paged_attention.py
@@ -32,6 +32,9 @@ from xllm.python.attention.backend import (
     KVCache,
     MlaIndexContext,
 )
+from xllm.python.attention.expanded_decode_metadata import (
+    resolve_expanded_decode_metadata,
+)
 from xllm.python.model_executor.forward_context import (
     AclGraphTask,
     get_execution_buffer,
@@ -74,6 +77,11 @@ class NpuPagedAttentionBackend(AttentionBackend):
         self._graph_lses: dict[int, torch.Tensor] = {}
         self._current_graph_output: torch.Tensor | None = None
         self._current_graph_lse: torch.Tensor | None = None
+        self._use_expanded_decode = False
+        self._block_table_i32: torch.Tensor | None = None
+        self._actual_seq_lens: list[int] | None = None
+        self._actual_seq_q: list[int] | torch.Tensor = []
+        self._actual_seq_kv: list[int] | torch.Tensor = []
         self._mla_actual_seq_q: torch.Tensor | None = None
         self._mla_actual_seq_kv: torch.Tensor | None = None
         self._causal_mask = (
@@ -102,6 +110,23 @@ class NpuPagedAttentionBackend(AttentionBackend):
     def bind_kv_caches(self, kv_caches: list[KVCache]) -> None:
         self._kv_caches = kv_caches
 
+    @staticmethod
+    def _query_sequence_ends(
+        q_cu_seq_lens: torch.Tensor | None,
+        batch_size: int,
+    ) -> torch.Tensor | None:
+        """Accept both NPU q-cumulative layouts used by the runtime."""
+        if q_cu_seq_lens is None:
+            return None
+        if q_cu_seq_lens.numel() == batch_size:
+            return q_cu_seq_lens.to(torch.int32)
+        if q_cu_seq_lens.numel() == batch_size + 1:
+            return q_cu_seq_lens[1:].to(torch.int32)
+        raise RuntimeError(
+            "q cumulative sequence lengths must contain either one value per "
+            "sequence or a leading zero plus one value per sequence"
+        )
+
     def prepare(
         self,
         metadata: AttentionMetadata,
@@ -109,34 +134,61 @@ class NpuPagedAttentionBackend(AttentionBackend):
         graph_mode: bool = False,
     ) -> None:
         self._metadata = metadata
-        if metadata.q_cu_seq_lens is not None:
-            self._actual_seq_lens: list[int] | None = (
-                metadata.q_cu_seq_lens[1:].cpu().tolist()
+        expanded = resolve_expanded_decode_metadata(
+            metadata, block_size=self.page_size
+        )
+        self._use_expanded_decode = expanded is not None
+        block_table = (
+            expanded.block_table if expanded is not None else metadata.block_table
+        )
+        kv_seq_lens = (
+            expanded.kv_seq_lens if expanded is not None else metadata.kv_seq_lens
+        )
+        kv_seq_lens_host_values = (
+            expanded.kv_seq_lens_host_values
+            if expanded is not None
+            else getattr(metadata, "kv_seq_lens_host_values", None)
+        )
+
+        if block_table is not None:
+            self._block_table_i32 = block_table.to(torch.int32)
+            real_batch = block_table.shape[0]
+        else:
+            self._block_table_i32 = None
+            real_batch = 0
+
+        if self._use_expanded_decode or graph_mode or self._is_mla:
+            self._actual_seq_lens = None
+        elif metadata.q_cu_seq_lens is not None:
+            q_seq_lens = getattr(metadata, "q_seq_lens", None)
+            if q_seq_lens is not None:
+                batch_size = q_seq_lens.numel()
+            elif metadata.block_table is not None:
+                batch_size = metadata.block_table.shape[0]
+            else:
+                batch_size = max(metadata.q_cu_seq_lens.numel() - 1, 0)
+            q_seq_ends = self._query_sequence_ends(
+                metadata.q_cu_seq_lens,
+                batch_size,
             )
+            self._actual_seq_lens = q_seq_ends.cpu().tolist()
         else:
             self._actual_seq_lens = None
 
-        if metadata.block_table is not None:
-            self._block_table_i32 = metadata.block_table.to(torch.int32)
-
-            real_batch = metadata.block_table.shape[0]
-
-            kv_host = metadata.kv_seq_lens_host
-            if kv_host is not None:
-                kv_host = kv_host.cpu()
-                if kv_host.numel() == real_batch + 1:
-                    per_seq_kv = kv_host[1:] - kv_host[:-1]
-                else:
-                    per_seq_kv = kv_host
-            else:
-                per_seq_kv = torch.ones(real_batch, dtype=torch.int32)
-
-            kv_list = per_seq_kv[:real_batch].tolist()
-
+        if self._block_table_i32 is not None and not self._is_mla:
+            if kv_seq_lens_host_values is None:
+                raise RuntimeError(
+                    "decode attention requires scheduler-provided host KV lengths"
+                )
+            if len(kv_seq_lens_host_values) != real_batch:
+                raise RuntimeError(
+                    "host KV lengths must have one entry per block-table row"
+                )
             self._actual_seq_q: list[int] = list(range(1, real_batch + 1))
-            self._actual_seq_kv: list[int] = kv_list
+            self._actual_seq_kv: list[int] = list(kv_seq_lens_host_values)
         else:
-            self._block_table_i32 = None
+            self._actual_seq_q = []
+            self._actual_seq_kv = []
 
         if (
             graph_mode
@@ -188,13 +240,20 @@ class NpuPagedAttentionBackend(AttentionBackend):
 
         # Pre-cache MLA (sparse SFA) seq-lens once per step; shared by
         # execute_mla / mla_index_context instead of re-derived per layer.
-        if metadata.kv_seq_lens is not None:
-            kv_seq_lens = metadata.kv_seq_lens
+        if self._is_mla and kv_seq_lens is not None:
             mla_device = kv_seq_lens.device
             actual_seq_kv = kv_seq_lens.to(torch.int32).to(mla_device)
-            if metadata.q_cu_seq_lens is not None:
-                actual_seq_q = metadata.q_cu_seq_lens[1:].to(
-                    torch.int32
+            if self._use_expanded_decode:
+                actual_seq_q = torch.arange(
+                    1,
+                    actual_seq_kv.numel() + 1,
+                    dtype=torch.int32,
+                    device=mla_device,
+                )
+            elif metadata.q_cu_seq_lens is not None:
+                actual_seq_q = self._query_sequence_ends(
+                    metadata.q_cu_seq_lens,
+                    int(actual_seq_kv.numel()),
                 ).to(mla_device)
             else:
                 batch = kv_seq_lens.size(0)
@@ -244,6 +303,8 @@ class NpuPagedAttentionBackend(AttentionBackend):
         q_3d = q.view(num_tokens, self.num_heads, self.head_dim).contiguous()
 
         if metadata.is_prefill or metadata.is_chunked_prefill:
+            if self._use_expanded_decode:
+                return self._decode(q_3d, k_cache, v_cache, metadata, num_tokens)
             return self._prefill(q_3d, k_3d, v_3d, metadata, num_tokens)
         return self._decode(q_3d, k_cache, v_cache, metadata, num_tokens)
 
@@ -266,6 +327,8 @@ class NpuPagedAttentionBackend(AttentionBackend):
             )
         layer_id = layer.layer_id
         nope_cache, rope_cache, _ = self._kv_caches[layer_id]
+        if self._block_table_i32 is None:
+            raise RuntimeError("MLA requires a block table")
 
         torch.ops.xllm_ops.reshape_paged_cache(
             metadata.slot_mapping, k_latent_3d, k_pe_3d, nope_cache, rope_cache
@@ -276,18 +339,21 @@ class NpuPagedAttentionBackend(AttentionBackend):
             nope_cache,
             rope_cache,
             topk,
-            metadata.block_table,
+            self._block_table_i32,
             layer_id,
         )
 
     def mla_index_context(self, layer: "Attention") -> MlaIndexContext:
         metadata = self._metadata
         assert metadata is not None, "mla_index_context called before prepare()"
+        assert self._block_table_i32 is not None
+        assert self._mla_actual_seq_q is not None
+        assert self._mla_actual_seq_kv is not None
         _, _, index_cache = self._kv_caches[layer.layer_id]
         return MlaIndexContext(
             index_cache=index_cache,
             slot_mapping=metadata.slot_mapping,
-            block_table=metadata.block_table,
+            block_table=self._block_table_i32,
             actual_seq_q=self._mla_actual_seq_q,
             actual_seq_kv=self._mla_actual_seq_kv,
             update_index_cache=lambda values: self._update_mla_index_cache(

--- a/xllm/python/attention/npu_paged_attention.py
+++ b/xllm/python/attention/npu_paged_attention.py
@@ -32,6 +32,9 @@ from xllm.python.attention.backend import (
     LayerCache,
     MlaIndexContext,
 )
+from xllm.python.attention.expanded_decode_metadata import (
+    resolve_expanded_decode_metadata,
+)
 from xllm.python.model_executor.forward_context import (
     AclGraphTask,
     get_execution_buffer,
@@ -84,6 +87,11 @@ class NpuPagedAttentionBackend(AttentionBackend):
         self._graph_lses: dict[int, torch.Tensor] = {}
         self._current_graph_output: torch.Tensor | None = None
         self._current_graph_lse: torch.Tensor | None = None
+        self._use_expanded_decode = False
+        self._block_table_i32: torch.Tensor | None = None
+        self._actual_seq_lens: list[int] | None = None
+        self._actual_seq_q: list[int] | torch.Tensor = []
+        self._actual_seq_kv: list[int] | torch.Tensor = []
         self._mla_actual_seq_q: torch.Tensor | None = None
         self._mla_actual_seq_kv: torch.Tensor | None = None
         self._causal_mask = (
@@ -114,6 +122,23 @@ class NpuPagedAttentionBackend(AttentionBackend):
     def bind_kv_caches(self, kv_caches: list[LayerCache]) -> None:
         self._kv_caches = kv_caches
 
+    @staticmethod
+    def _query_sequence_ends(
+        q_cu_seq_lens: torch.Tensor | None,
+        batch_size: int,
+    ) -> torch.Tensor | None:
+        """Accept both NPU q-cumulative layouts used by the runtime."""
+        if q_cu_seq_lens is None:
+            return None
+        if q_cu_seq_lens.numel() == batch_size:
+            return q_cu_seq_lens.to(torch.int32)
+        if q_cu_seq_lens.numel() == batch_size + 1:
+            return q_cu_seq_lens[1:].to(torch.int32)
+        raise RuntimeError(
+            "q cumulative sequence lengths must contain either one value per "
+            "sequence or a leading zero plus one value per sequence"
+        )
+
     def prepare(
         self,
         metadata: AttentionMetadata,
@@ -121,34 +146,61 @@ class NpuPagedAttentionBackend(AttentionBackend):
         graph_mode: bool = False,
     ) -> None:
         self._metadata = metadata
-        if metadata.q_cu_seq_lens is not None:
-            self._actual_seq_lens: list[int] | None = (
-                metadata.q_cu_seq_lens[1:].cpu().tolist()
+        expanded = resolve_expanded_decode_metadata(
+            metadata, block_size=self.page_size
+        )
+        self._use_expanded_decode = expanded is not None
+        block_table = (
+            expanded.block_table if expanded is not None else metadata.block_table
+        )
+        kv_seq_lens = (
+            expanded.kv_seq_lens if expanded is not None else metadata.kv_seq_lens
+        )
+        kv_seq_lens_host_values = (
+            expanded.kv_seq_lens_host_values
+            if expanded is not None
+            else getattr(metadata, "kv_seq_lens_host_values", None)
+        )
+
+        if block_table is not None:
+            self._block_table_i32 = block_table.to(torch.int32)
+            real_batch = block_table.shape[0]
+        else:
+            self._block_table_i32 = None
+            real_batch = 0
+
+        if self._use_expanded_decode or graph_mode or self._is_mla:
+            self._actual_seq_lens = None
+        elif metadata.q_cu_seq_lens is not None:
+            q_seq_lens = getattr(metadata, "q_seq_lens", None)
+            if q_seq_lens is not None:
+                batch_size = q_seq_lens.numel()
+            elif metadata.block_table is not None:
+                batch_size = metadata.block_table.shape[0]
+            else:
+                batch_size = max(metadata.q_cu_seq_lens.numel() - 1, 0)
+            q_seq_ends = self._query_sequence_ends(
+                metadata.q_cu_seq_lens,
+                batch_size,
             )
+            self._actual_seq_lens = q_seq_ends.cpu().tolist()
         else:
             self._actual_seq_lens = None
 
-        if metadata.block_table is not None:
-            self._block_table_i32 = metadata.block_table.to(torch.int32)
-
-            real_batch = metadata.block_table.shape[0]
-
-            kv_host = metadata.kv_seq_lens_host
-            if kv_host is not None:
-                kv_host = kv_host.cpu()
-                if kv_host.numel() == real_batch + 1:
-                    per_seq_kv = kv_host[1:] - kv_host[:-1]
-                else:
-                    per_seq_kv = kv_host
-            else:
-                per_seq_kv = torch.ones(real_batch, dtype=torch.int32)
-
-            kv_list = per_seq_kv[:real_batch].tolist()
-
+        if self._block_table_i32 is not None and not self._is_mla:
+            if kv_seq_lens_host_values is None:
+                raise RuntimeError(
+                    "decode attention requires scheduler-provided host KV lengths"
+                )
+            if len(kv_seq_lens_host_values) != real_batch:
+                raise RuntimeError(
+                    "host KV lengths must have one entry per block-table row"
+                )
             self._actual_seq_q: list[int] = list(range(1, real_batch + 1))
-            self._actual_seq_kv: list[int] = kv_list
+            self._actual_seq_kv: list[int] = list(kv_seq_lens_host_values)
         else:
-            self._block_table_i32 = None
+            self._actual_seq_q = []
+            self._actual_seq_kv = []
 
         if (
             graph_mode
@@ -200,13 +252,20 @@ class NpuPagedAttentionBackend(AttentionBackend):
 
         # Pre-cache MLA (sparse SFA) seq-lens once per step; shared by
         # execute_mla / mla_index_context instead of re-derived per layer.
-        if metadata.kv_seq_lens is not None:
-            kv_seq_lens = metadata.kv_seq_lens
+        if self._is_mla and kv_seq_lens is not None:
             mla_device = kv_seq_lens.device
             actual_seq_kv = kv_seq_lens.to(torch.int32).to(mla_device)
-            if metadata.q_cu_seq_lens is not None:
-                actual_seq_q = metadata.q_cu_seq_lens[1:].to(
-                    torch.int32
+            if self._use_expanded_decode:
+                actual_seq_q = torch.arange(
+                    1,
+                    actual_seq_kv.numel() + 1,
+                    dtype=torch.int32,
+                    device=mla_device,
+                )
+            elif metadata.q_cu_seq_lens is not None:
+                actual_seq_q = self._query_sequence_ends(
+                    metadata.q_cu_seq_lens,
+                    int(actual_seq_kv.numel()),
                 ).to(mla_device)
             else:
                 batch = kv_seq_lens.size(0)
@@ -259,6 +318,8 @@ class NpuPagedAttentionBackend(AttentionBackend):
         q_3d = q.view(num_tokens, self.num_heads, self.head_dim).contiguous()
 
         if metadata.is_prefill or metadata.is_chunked_prefill:
+            if self._use_expanded_decode:
+                return self._decode(q_3d, k_cache, v_cache, metadata, num_tokens)
             return self._prefill(
                 q_3d, k_3d, v_3d, k_cache, v_cache, metadata, num_tokens
             )
@@ -287,6 +348,8 @@ class NpuPagedAttentionBackend(AttentionBackend):
         nope_cache, rope_cache = layer_cache.key, layer_cache.value
         if nope_cache is None or rope_cache is None:
             raise RuntimeError(f"MLA latent cache is missing for layer {layer_id}")
+        if self._block_table_i32 is None:
+            raise RuntimeError("MLA requires a block table")
 
         torch.ops.xllm_ops.reshape_paged_cache(
             metadata.slot_mapping, k_latent_3d, k_pe_3d, nope_cache, rope_cache
@@ -297,13 +360,16 @@ class NpuPagedAttentionBackend(AttentionBackend):
             nope_cache,
             rope_cache,
             topk,
-            metadata.block_table,
+            self._block_table_i32,
             layer_id,
         )
 
     def mla_index_context(self, layer: "Attention") -> MlaIndexContext:
         metadata = self._metadata
         assert metadata is not None, "mla_index_context called before prepare()"
+        assert self._block_table_i32 is not None
+        assert self._mla_actual_seq_q is not None
+        assert self._mla_actual_seq_kv is not None
         index_cache = self._kv_caches[layer.layer_id].index
         if index_cache is None:
             raise RuntimeError(
@@ -312,7 +378,7 @@ class NpuPagedAttentionBackend(AttentionBackend):
         return MlaIndexContext(
             index_cache=index_cache,
             slot_mapping=metadata.slot_mapping,
-            block_table=metadata.block_table,
+            block_table=self._block_table_i32,
             actual_seq_q=self._mla_actual_seq_q,
             actual_seq_kv=self._mla_actual_seq_kv,
             update_index_cache=lambda values: self._update_mla_index_cache(

--- a/xllm/python/attention/npu_paged_attention.py
+++ b/xllm/python/attention/npu_paged_attention.py
@@ -34,6 +34,7 @@ from xllm.python.attention.backend import (
 )
 from xllm.python.model_executor.forward_context import (
     AclGraphTask,
+    get_execution_buffer,
     get_forward_context,
 )
 
@@ -71,6 +72,10 @@ class NpuPagedAttentionBackend(AttentionBackend):
         self.sliding_window = sliding_window
         self.dtype = dtype
         self.device = device
+        # DeepSeek-V3.2 MLA uses a 512-wide latent cache and the sparse MLA
+        # operators.  Ascend FIA graph tiling does not support that head
+        # dimension, so it must not be initialized for this backend instance.
+        self._is_mla = head_dim > 192 and num_kv_heads == 1
 
         self._kv_caches: list[LayerCache] = []
         self._metadata: AttentionMetadata | None = None
@@ -101,6 +106,10 @@ class NpuPagedAttentionBackend(AttentionBackend):
             return 1
         key_cache = self._kv_caches[0].key
         return key_cache.shape[1] if key_cache is not None else 1
+
+    @property
+    def is_mla(self) -> bool:
+        return self._is_mla
 
     def bind_kv_caches(self, kv_caches: list[LayerCache]) -> None:
         self._kv_caches = kv_caches
@@ -141,7 +150,11 @@ class NpuPagedAttentionBackend(AttentionBackend):
         else:
             self._block_table_i32 = None
 
-        if graph_mode and self._block_table_i32 is not None:
+        if (
+            graph_mode
+            and self._block_table_i32 is not None
+            and not self._is_mla
+        ):
             graph_batch_size = self._block_table_i32.shape[0]
             if self._graph_workspace is None:
                 block_size = self.page_size
@@ -190,16 +203,31 @@ class NpuPagedAttentionBackend(AttentionBackend):
         if metadata.kv_seq_lens is not None:
             kv_seq_lens = metadata.kv_seq_lens
             mla_device = kv_seq_lens.device
-            self._mla_actual_seq_kv = kv_seq_lens.to(torch.int32).to(mla_device)
+            actual_seq_kv = kv_seq_lens.to(torch.int32).to(mla_device)
             if metadata.q_cu_seq_lens is not None:
-                self._mla_actual_seq_q = metadata.q_cu_seq_lens[1:].to(
+                actual_seq_q = metadata.q_cu_seq_lens[1:].to(
                     torch.int32
                 ).to(mla_device)
             else:
                 batch = kv_seq_lens.size(0)
-                self._mla_actual_seq_q = torch.arange(
+                actual_seq_q = torch.arange(
                     1, batch + 1, dtype=torch.int32, device=mla_device
                 )
+            if graph_mode:
+                graph_batch = int(actual_seq_kv.numel())
+                self._mla_actual_seq_q = get_execution_buffer(
+                    ("MLA_ACTUAL_SEQ_Q", graph_batch),
+                    lambda: torch.empty_like(actual_seq_q),
+                )
+                self._mla_actual_seq_kv = get_execution_buffer(
+                    ("MLA_ACTUAL_SEQ_KV", graph_batch),
+                    lambda: torch.empty_like(actual_seq_kv),
+                )
+                self._mla_actual_seq_q.copy_(actual_seq_q)
+                self._mla_actual_seq_kv.copy_(actual_seq_kv)
+            else:
+                self._mla_actual_seq_q = actual_seq_q
+                self._mla_actual_seq_kv = actual_seq_kv
         else:
             self._mla_actual_seq_q = None
             self._mla_actual_seq_kv = None
@@ -264,7 +292,13 @@ class NpuPagedAttentionBackend(AttentionBackend):
             metadata.slot_mapping, k_latent_3d, k_pe_3d, nope_cache, rope_cache
         )
         return self._mla_sparse(
-            q_latent, q_pe, nope_cache, rope_cache, topk, metadata.block_table
+            q_latent,
+            q_pe,
+            nope_cache,
+            rope_cache,
+            topk,
+            metadata.block_table,
+            layer_id,
         )
 
     def mla_index_context(self, layer: "Attention") -> MlaIndexContext:
@@ -281,6 +315,22 @@ class NpuPagedAttentionBackend(AttentionBackend):
             block_table=metadata.block_table,
             actual_seq_q=self._mla_actual_seq_q,
             actual_seq_kv=self._mla_actual_seq_kv,
+            update_index_cache=lambda values: self._update_mla_index_cache(
+                index_cache, metadata.slot_mapping, values
+            ),
+        )
+
+    @staticmethod
+    def _update_mla_index_cache(
+        index_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        values: torch.Tensor,
+    ) -> None:
+        cache_view = index_cache.view(-1, index_cache.size(-1))
+        kernels.scatter_nd_update(
+            cache_view,
+            slot_mapping.reshape(-1, 1).clamp_min(0),
+            values,
         )
 
     def _mla_sparse(
@@ -291,16 +341,20 @@ class NpuPagedAttentionBackend(AttentionBackend):
         rope_cache: torch.Tensor,
         topk: torch.Tensor,
         block_table: torch.Tensor,
+        layer_id: int,
     ) -> torch.Tensor:
-        out = torch.ops.xllm_ops.sparse_flash_attention(
+        out = get_execution_buffer(
+            ("SFA_OUTPUT", layer_id) + tuple(q_latent.shape),
+            lambda: torch.empty_like(q_latent),
+        )
+        return kernels.sparse_flash_attention_out(
             q_latent, nope_cache, nope_cache, topk,
             block_table,
             self._mla_actual_seq_q,
             self._mla_actual_seq_kv,
             q_pe, rope_cache, self.scale, 1,
-            "TND", "PA_BSND", 3,
-        )
-        return out  # [T, H, kv_lora]
+            "TND", "PA_BSND", 3, out,
+        )  # [T, H, kv_lora]
 
     # ------------------------------------------------------------------
     # Prefill: packed TND with causal mask

--- a/xllm/python/attention/npu_paged_attention.py
+++ b/xllm/python/attention/npu_paged_attention.py
@@ -34,6 +34,7 @@ from xllm.python.attention.backend import (
 )
 from xllm.python.model_executor.forward_context import (
     AclGraphTask,
+    get_execution_buffer,
     get_forward_context,
 )
 
@@ -61,6 +62,10 @@ class NpuPagedAttentionBackend(AttentionBackend):
         self.sliding_window = sliding_window
         self.dtype = dtype
         self.device = device
+        # DeepSeek-V3.2 MLA uses a 512-wide latent cache and the sparse MLA
+        # operators.  Ascend FIA graph tiling does not support that head
+        # dimension, so it must not be initialized for this backend instance.
+        self._is_mla = head_dim > 192 and num_kv_heads == 1
 
         self._kv_caches: list[KVCache] = []
         self._metadata: AttentionMetadata | None = None
@@ -89,6 +94,10 @@ class NpuPagedAttentionBackend(AttentionBackend):
         if not self._kv_caches:
             return 1
         return self._kv_caches[0][0].shape[1]
+
+    @property
+    def is_mla(self) -> bool:
+        return self._is_mla
 
     def bind_kv_caches(self, kv_caches: list[KVCache]) -> None:
         self._kv_caches = kv_caches
@@ -129,7 +138,11 @@ class NpuPagedAttentionBackend(AttentionBackend):
         else:
             self._block_table_i32 = None
 
-        if graph_mode and self._block_table_i32 is not None:
+        if (
+            graph_mode
+            and self._block_table_i32 is not None
+            and not self._is_mla
+        ):
             graph_batch_size = self._block_table_i32.shape[0]
             if self._graph_workspace is None:
                 block_size = self.page_size
@@ -178,16 +191,31 @@ class NpuPagedAttentionBackend(AttentionBackend):
         if metadata.kv_seq_lens is not None:
             kv_seq_lens = metadata.kv_seq_lens
             mla_device = kv_seq_lens.device
-            self._mla_actual_seq_kv = kv_seq_lens.to(torch.int32).to(mla_device)
+            actual_seq_kv = kv_seq_lens.to(torch.int32).to(mla_device)
             if metadata.q_cu_seq_lens is not None:
-                self._mla_actual_seq_q = metadata.q_cu_seq_lens[1:].to(
+                actual_seq_q = metadata.q_cu_seq_lens[1:].to(
                     torch.int32
                 ).to(mla_device)
             else:
                 batch = kv_seq_lens.size(0)
-                self._mla_actual_seq_q = torch.arange(
+                actual_seq_q = torch.arange(
                     1, batch + 1, dtype=torch.int32, device=mla_device
                 )
+            if graph_mode:
+                graph_batch = int(actual_seq_kv.numel())
+                self._mla_actual_seq_q = get_execution_buffer(
+                    ("MLA_ACTUAL_SEQ_Q", graph_batch),
+                    lambda: torch.empty_like(actual_seq_q),
+                )
+                self._mla_actual_seq_kv = get_execution_buffer(
+                    ("MLA_ACTUAL_SEQ_KV", graph_batch),
+                    lambda: torch.empty_like(actual_seq_kv),
+                )
+                self._mla_actual_seq_q.copy_(actual_seq_q)
+                self._mla_actual_seq_kv.copy_(actual_seq_kv)
+            else:
+                self._mla_actual_seq_q = actual_seq_q
+                self._mla_actual_seq_kv = actual_seq_kv
         else:
             self._mla_actual_seq_q = None
             self._mla_actual_seq_kv = None
@@ -243,7 +271,13 @@ class NpuPagedAttentionBackend(AttentionBackend):
             metadata.slot_mapping, k_latent_3d, k_pe_3d, nope_cache, rope_cache
         )
         return self._mla_sparse(
-            q_latent, q_pe, nope_cache, rope_cache, topk, metadata.block_table
+            q_latent,
+            q_pe,
+            nope_cache,
+            rope_cache,
+            topk,
+            metadata.block_table,
+            layer_id,
         )
 
     def mla_index_context(self, layer: "Attention") -> MlaIndexContext:
@@ -256,6 +290,22 @@ class NpuPagedAttentionBackend(AttentionBackend):
             block_table=metadata.block_table,
             actual_seq_q=self._mla_actual_seq_q,
             actual_seq_kv=self._mla_actual_seq_kv,
+            update_index_cache=lambda values: self._update_mla_index_cache(
+                index_cache, metadata.slot_mapping, values
+            ),
+        )
+
+    @staticmethod
+    def _update_mla_index_cache(
+        index_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        values: torch.Tensor,
+    ) -> None:
+        cache_view = index_cache.view(-1, index_cache.size(-1))
+        kernels.scatter_nd_update(
+            cache_view,
+            slot_mapping.reshape(-1, 1).clamp_min(0),
+            values,
         )
 
     def _mla_sparse(
@@ -266,16 +316,20 @@ class NpuPagedAttentionBackend(AttentionBackend):
         rope_cache: torch.Tensor,
         topk: torch.Tensor,
         block_table: torch.Tensor,
+        layer_id: int,
     ) -> torch.Tensor:
-        out = torch.ops.xllm_ops.sparse_flash_attention(
+        out = get_execution_buffer(
+            ("SFA_OUTPUT", layer_id) + tuple(q_latent.shape),
+            lambda: torch.empty_like(q_latent),
+        )
+        return kernels.sparse_flash_attention_out(
             q_latent, nope_cache, nope_cache, topk,
             block_table,
             self._mla_actual_seq_q,
             self._mla_actual_seq_kv,
             q_pe, rope_cache, self.scale, 1,
-            "TND", "PA_BSND", 3,
-        )
-        return out  # [T, H, kv_lora]
+            "TND", "PA_BSND", 3, out,
+        )  # [T, H, kv_lora]
 
     # ------------------------------------------------------------------
     # Prefill: packed TND with causal mask

--- a/xllm/python/kernels_cuda/__init__.py
+++ b/xllm/python/kernels_cuda/__init__.py
@@ -74,8 +74,10 @@ from .rotary_embedding import (
 )
 from .sparse_attention import (
     lightning_indexer,
+    lightning_indexer_out,
     scatter_nd_update,
     sparse_flash_attention,
+    sparse_flash_attention_out,
 )
 
 __all__ = [
@@ -99,8 +101,10 @@ __all__ = [
     "quantize_per_tensor",
     "dynamic_quant",
     "lightning_indexer",
+    "lightning_indexer_out",
     "scatter_nd_update",
     "sparse_flash_attention",
+    "sparse_flash_attention_out",
     "causal_conv1d_prefill",
     "causal_conv1d_decode",
     "resolve_gdn_prefill_backend",

--- a/xllm/python/kernels_cuda/sparse_attention.py
+++ b/xllm/python/kernels_cuda/sparse_attention.py
@@ -80,6 +80,47 @@ def lightning_indexer(
     )
 
 
+def lightning_indexer_out(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    weights: torch.Tensor,
+    query_seq_lengths: torch.Tensor | None,
+    key_seq_lengths: torch.Tensor | None,
+    block_table: torch.Tensor | None,
+    layout_query: str,
+    layout_key: str,
+    selected_count: int,
+    sparse_mode: int,
+    pre_tokens: int,
+    next_tokens: int,
+    return_value: bool,
+    sparse_indices_out: torch.Tensor,
+    sparse_values_out: torch.Tensor,
+) -> torch.Tensor:
+    """Select key blocks and write the result to caller-owned buffers."""
+    del (
+        query,
+        key,
+        weights,
+        query_seq_lengths,
+        key_seq_lengths,
+        block_table,
+        layout_query,
+        layout_key,
+        selected_count,
+        sparse_mode,
+        pre_tokens,
+        next_tokens,
+        return_value,
+        sparse_indices_out,
+        sparse_values_out,
+    )
+    raise NotImplementedError(
+        "lightning_indexer_out has no CUDA kernel; sparse attention on CUDA is "
+        "not supported yet"
+    )
+
+
 def scatter_nd_update(
     value: torch.Tensor,
     indices: torch.Tensor,
@@ -158,4 +199,51 @@ def sparse_flash_attention(
     )
 
 
-__all__ = ["lightning_indexer", "scatter_nd_update", "sparse_flash_attention"]
+def sparse_flash_attention_out(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    sparse_indices: torch.Tensor,
+    block_table: torch.Tensor | None,
+    actual_seq_lengths_query: torch.Tensor | None,
+    actual_seq_lengths_kv: torch.Tensor | None,
+    query_rope: torch.Tensor | None,
+    key_rope: torch.Tensor | None,
+    scale_value: float,
+    sparse_block_size: int,
+    layout_query: str,
+    layout_kv: str,
+    sparse_mode: int,
+    output: torch.Tensor,
+) -> torch.Tensor:
+    """Attend to selected blocks and write the result to ``output``."""
+    del (
+        query,
+        key,
+        value,
+        sparse_indices,
+        block_table,
+        actual_seq_lengths_query,
+        actual_seq_lengths_kv,
+        query_rope,
+        key_rope,
+        scale_value,
+        sparse_block_size,
+        layout_query,
+        layout_kv,
+        sparse_mode,
+        output,
+    )
+    raise NotImplementedError(
+        "sparse_flash_attention_out has no CUDA kernel; sparse attention on "
+        "CUDA is not supported yet"
+    )
+
+
+__all__ = [
+    "lightning_indexer",
+    "lightning_indexer_out",
+    "scatter_nd_update",
+    "sparse_flash_attention",
+    "sparse_flash_attention_out",
+]

--- a/xllm/python/kernels_npu/__init__.py
+++ b/xllm/python/kernels_npu/__init__.py
@@ -73,8 +73,10 @@ from .rotary_embedding import (
 )
 from .sparse_attention import (
     lightning_indexer,
+    lightning_indexer_out,
     scatter_nd_update,
     sparse_flash_attention,
+    sparse_flash_attention_out,
 )
 
 __all__ = [
@@ -98,8 +100,10 @@ __all__ = [
     "quantize_per_tensor",
     "dynamic_quant",
     "lightning_indexer",
+    "lightning_indexer_out",
     "scatter_nd_update",
     "sparse_flash_attention",
+    "sparse_flash_attention_out",
     "causal_conv1d_prefill",
     "causal_conv1d_decode",
     "resolve_gdn_prefill_backend",

--- a/xllm/python/kernels_npu/_custom_op.py
+++ b/xllm/python/kernels_npu/_custom_op.py
@@ -214,6 +214,42 @@ def _lightning_indexer_fake(
     return query.new_zeros(out_shape, dtype=torch.int32)
 
 
+def _lightning_indexer_out_fake(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    weights: torch.Tensor,
+    query_seq_lengths: torch.Tensor | None,
+    key_seq_lengths: torch.Tensor | None,
+    block_table: torch.Tensor | None,
+    layout_query: str,
+    layout_key: str,
+    selected_count: int,
+    sparse_mode: int,
+    pre_tokens: int,
+    next_tokens: int,
+    return_value: bool,
+    sparse_indices_out: torch.Tensor,
+    sparse_values_out: torch.Tensor,
+) -> torch.Tensor:
+    del (
+        query,
+        key,
+        weights,
+        query_seq_lengths,
+        key_seq_lengths,
+        block_table,
+        layout_query,
+        layout_key,
+        selected_count,
+        sparse_mode,
+        pre_tokens,
+        next_tokens,
+        return_value,
+        sparse_values_out,
+    )
+    return sparse_indices_out
+
+
 def _scatter_nd_update_fake(
     var: torch.Tensor,
     indices: torch.Tensor,
@@ -256,6 +292,42 @@ def _sparse_flash_attention_fake(
     return query.new_empty(query.shape, dtype=query.dtype)
 
 
+def _sparse_flash_attention_out_fake(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    sparse_indices: torch.Tensor,
+    block_table: torch.Tensor | None,
+    actual_seq_lengths_query: torch.Tensor | None,
+    actual_seq_lengths_kv: torch.Tensor | None,
+    query_rope: torch.Tensor | None,
+    key_rope: torch.Tensor | None,
+    scale_value: float,
+    sparse_block_size: int,
+    layout_query: str,
+    layout_kv: str,
+    sparse_mode: int,
+    output: torch.Tensor,
+) -> torch.Tensor:
+    del (
+        query,
+        key,
+        value,
+        sparse_indices,
+        block_table,
+        actual_seq_lengths_query,
+        actual_seq_lengths_kv,
+        query_rope,
+        key_rope,
+        scale_value,
+        sparse_block_size,
+        layout_query,
+        layout_kv,
+        sparse_mode,
+    )
+    return output
+
+
 register_fake("xllm_ops::rms_norm", _rms_norm_fake)
 register_fake("xllm_ops::fused_add_rms_norm", _fused_add_rms_norm_fake)
 register_fake("xllm_ops::silu_and_mul", _silu_and_mul_fake)
@@ -267,5 +339,9 @@ register_fake("xllm_ops::quant_matmul", _quant_matmul_fake)
 register_fake("xllm_ops::quantize_per_tensor", _quantize_per_tensor_fake)
 register_fake("xllm_ops::dynamic_quant", _dynamic_quant_fake)
 register_fake("xllm_ops::lightning_indexer", _lightning_indexer_fake)
+register_fake("xllm_ops::lightning_indexer_out", _lightning_indexer_out_fake)
 register_fake("xllm_ops::scatter_nd_update", _scatter_nd_update_fake)
 register_fake("xllm_ops::sparse_flash_attention", _sparse_flash_attention_fake)
+register_fake(
+    "xllm_ops::sparse_flash_attention_out", _sparse_flash_attention_out_fake
+)

--- a/xllm/python/kernels_npu/sparse_attention.py
+++ b/xllm/python/kernels_npu/sparse_attention.py
@@ -71,6 +71,43 @@ def lightning_indexer(
     )
 
 
+def lightning_indexer_out(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    weights: torch.Tensor,
+    query_seq_lengths: torch.Tensor | None,
+    key_seq_lengths: torch.Tensor | None,
+    block_table: torch.Tensor | None,
+    layout_query: str,
+    layout_key: str,
+    selected_count: int,
+    sparse_mode: int,
+    pre_tokens: int,
+    next_tokens: int,
+    return_value: bool,
+    sparse_indices_out: torch.Tensor,
+    sparse_values_out: torch.Tensor,
+) -> torch.Tensor:
+    """Select key blocks and write the results to caller-owned buffers."""
+    return torch.ops.xllm_ops.lightning_indexer_out(
+        query,
+        key,
+        weights,
+        query_seq_lengths,
+        key_seq_lengths,
+        block_table,
+        layout_query,
+        layout_key,
+        selected_count,
+        sparse_mode,
+        pre_tokens,
+        next_tokens,
+        return_value,
+        sparse_indices_out,
+        sparse_values_out,
+    )
+
+
 def scatter_nd_update(
     value: torch.Tensor,
     indices: torch.Tensor,
@@ -141,4 +178,47 @@ def sparse_flash_attention(
     )
 
 
-__all__ = ["lightning_indexer", "scatter_nd_update", "sparse_flash_attention"]
+def sparse_flash_attention_out(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    sparse_indices: torch.Tensor,
+    block_table: torch.Tensor | None,
+    actual_seq_lengths_query: torch.Tensor | None,
+    actual_seq_lengths_kv: torch.Tensor | None,
+    query_rope: torch.Tensor | None,
+    key_rope: torch.Tensor | None,
+    scale_value: float,
+    sparse_block_size: int,
+    layout_query: str,
+    layout_kv: str,
+    sparse_mode: int,
+    output: torch.Tensor,
+) -> torch.Tensor:
+    """Attend to selected blocks and write the output into ``output``."""
+    return torch.ops.xllm_ops.sparse_flash_attention_out(
+        query,
+        key,
+        value,
+        sparse_indices,
+        block_table,
+        actual_seq_lengths_query,
+        actual_seq_lengths_kv,
+        query_rope,
+        key_rope,
+        scale_value,
+        sparse_block_size,
+        layout_query,
+        layout_kv,
+        sparse_mode,
+        output,
+    )
+
+
+__all__ = [
+    "lightning_indexer",
+    "lightning_indexer_out",
+    "scatter_nd_update",
+    "sparse_flash_attention",
+    "sparse_flash_attention_out",
+]

--- a/xllm/python/model_executor/executor.py
+++ b/xllm/python/model_executor/executor.py
@@ -198,15 +198,15 @@ class ModelExecutor:
             raise RuntimeError("KV caches are not bound")
 
         graph_runner = self.decode_graph_runner
-        if graph_runner is not None:
-            graph_runner.warmup(input_ids.device, input_ids.dtype)
-            # The graph runner only serves pure-decode steps (can_execute rejects
-            # prefill/chunked-prefill), while the layer synchronizer only drives
-            # KV-cache push during prefill, so decode has nothing to record.
-            if graph_runner.can_execute(input_ids, metadata, input_embedding):
-                return graph_runner.execute(
-                    input_ids, positions, metadata, input_embedding
-                )
+        if graph_runner is not None and graph_runner.can_execute(
+            input_ids, metadata, input_embedding
+        ):
+            graph_runner.warmup(
+                input_ids.device, input_ids.dtype, input_embedding
+            )
+            return graph_runner.execute(
+                input_ids, positions, metadata, input_embedding
+            )
         if self.inductor_runner is not None:
             return self.inductor_runner.execute(
                 input_ids,

--- a/xllm/python/model_executor/executor.py
+++ b/xllm/python/model_executor/executor.py
@@ -160,6 +160,7 @@ class ModelExecutor:
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         metadata: AttentionMetadata,
+        input_embedding: torch.Tensor | None = None,
         layer_synchronizer: LayerSynchronizer | None = None,
     ) -> torch.Tensor:
         if not self._kv_bound:
@@ -171,12 +172,22 @@ class ModelExecutor:
             # The graph runner only serves pure-decode steps (can_execute rejects
             # prefill/chunked-prefill), while the layer synchronizer only drives
             # KV-cache push during prefill, so decode has nothing to record.
-            if graph_runner.can_execute(input_ids, metadata):
-                return graph_runner.execute(input_ids, positions, metadata)
+            if graph_runner.can_execute(input_ids, metadata, input_embedding):
+                return graph_runner.execute(
+                    input_ids, positions, metadata, input_embedding
+                )
         if self.inductor_runner is not None:
             return self.inductor_runner.execute(
-                input_ids, positions, metadata, layer_synchronizer
+                input_ids,
+                positions,
+                metadata,
+                input_embedding,
+                layer_synchronizer,
             )
         return self.eager_runner.execute(
-            input_ids, positions, metadata, layer_synchronizer
+            input_ids,
+            positions,
+            metadata,
+            input_embedding,
+            layer_synchronizer,
         )

--- a/xllm/python/model_executor/executor.py
+++ b/xllm/python/model_executor/executor.py
@@ -191,6 +191,7 @@ class ModelExecutor:
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         metadata: AttentionMetadata,
+        input_embedding: torch.Tensor | None = None,
         layer_synchronizer: LayerSynchronizer | None = None,
     ) -> torch.Tensor:
         if not self._kv_bound:
@@ -202,12 +203,22 @@ class ModelExecutor:
             # The graph runner only serves pure-decode steps (can_execute rejects
             # prefill/chunked-prefill), while the layer synchronizer only drives
             # KV-cache push during prefill, so decode has nothing to record.
-            if graph_runner.can_execute(input_ids, metadata):
-                return graph_runner.execute(input_ids, positions, metadata)
+            if graph_runner.can_execute(input_ids, metadata, input_embedding):
+                return graph_runner.execute(
+                    input_ids, positions, metadata, input_embedding
+                )
         if self.inductor_runner is not None:
             return self.inductor_runner.execute(
-                input_ids, positions, metadata, layer_synchronizer
+                input_ids,
+                positions,
+                metadata,
+                input_embedding,
+                layer_synchronizer,
             )
         return self.eager_runner.execute(
-            input_ids, positions, metadata, layer_synchronizer
+            input_ids,
+            positions,
+            metadata,
+            input_embedding,
+            layer_synchronizer,
         )

--- a/xllm/python/model_executor/executor.py
+++ b/xllm/python/model_executor/executor.py
@@ -167,15 +167,15 @@ class ModelExecutor:
             raise RuntimeError("KV caches are not bound")
 
         graph_runner = self.decode_graph_runner
-        if graph_runner is not None:
-            graph_runner.warmup(input_ids.device, input_ids.dtype)
-            # The graph runner only serves pure-decode steps (can_execute rejects
-            # prefill/chunked-prefill), while the layer synchronizer only drives
-            # KV-cache push during prefill, so decode has nothing to record.
-            if graph_runner.can_execute(input_ids, metadata, input_embedding):
-                return graph_runner.execute(
-                    input_ids, positions, metadata, input_embedding
-                )
+        if graph_runner is not None and graph_runner.can_execute(
+            input_ids, metadata, input_embedding
+        ):
+            graph_runner.warmup(
+                input_ids.device, input_ids.dtype, input_embedding
+            )
+            return graph_runner.execute(
+                input_ids, positions, metadata, input_embedding
+            )
         if self.inductor_runner is not None:
             return self.inductor_runner.execute(
                 input_ids,

--- a/xllm/python/model_executor/forward_context.py
+++ b/xllm/python/model_executor/forward_context.py
@@ -49,6 +49,13 @@ class AclGraphTask:
 
 
 @dataclass(slots=True)
+class AclGraphExecutionState:
+    """Persistent tensors owned by one model-execution graph entry."""
+
+    persistent_buffers: dict[tuple[object, ...], object]
+
+
+@dataclass(slots=True)
 class AclGraphCaptureContext:
     stream: object
     tasks: list[AclGraphTask]
@@ -62,6 +69,7 @@ class ForwardContext:
     layer_caches: list[LayerCache]
     acl_graph: AclGraphCaptureContext | None = None
     layer_synchronizer: LayerSynchronizer | None = None
+    execution_state: AclGraphExecutionState | None = None
 
 
 _current_context: ContextVar[ForwardContext | None] = ContextVar(
@@ -89,3 +97,19 @@ def record_layer_event(layer_id: int) -> None:
     ctx = _current_context.get()
     if ctx is not None and ctx.layer_synchronizer is not None:
         ctx.layer_synchronizer.record_event(layer_id)
+
+
+def get_execution_buffer(
+    key: tuple[object, ...], factory: Callable[[], torch.Tensor]
+) -> torch.Tensor:
+    """Get a tensor owned by the active model execution graph entry."""
+    state = get_forward_context().execution_state
+    if state is None:
+        return factory()
+    buffer = state.persistent_buffers.get(key)
+    if buffer is None:
+        buffer = factory()
+        state.persistent_buffers[key] = buffer
+    if not isinstance(buffer, torch.Tensor):
+        raise TypeError("execution buffer must be a torch.Tensor")
+    return buffer

--- a/xllm/python/model_executor/forward_context.py
+++ b/xllm/python/model_executor/forward_context.py
@@ -45,6 +45,13 @@ class AclGraphTask:
 
 
 @dataclass(slots=True)
+class AclGraphExecutionState:
+    """Persistent tensors owned by one model-execution graph entry."""
+
+    persistent_buffers: dict[tuple[object, ...], object]
+
+
+@dataclass(slots=True)
 class AclGraphCaptureContext:
     stream: object
     tasks: list[AclGraphTask]
@@ -56,6 +63,7 @@ class ForwardContext:
     device: torch.device
     acl_graph: AclGraphCaptureContext | None = None
     layer_synchronizer: LayerSynchronizer | None = None
+    execution_state: AclGraphExecutionState | None = None
 
 
 _current_context: ContextVar[ForwardContext | None] = ContextVar(
@@ -83,3 +91,19 @@ def record_layer_event(layer_id: int) -> None:
     ctx = _current_context.get()
     if ctx is not None and ctx.layer_synchronizer is not None:
         ctx.layer_synchronizer.record_event(layer_id)
+
+
+def get_execution_buffer(
+    key: tuple[object, ...], factory: Callable[[], torch.Tensor]
+) -> torch.Tensor:
+    """Get a tensor owned by the active model execution graph entry."""
+    state = get_forward_context().execution_state
+    if state is None:
+        return factory()
+    buffer = state.persistent_buffers.get(key)
+    if buffer is None:
+        buffer = factory()
+        state.persistent_buffers[key] = buffer
+    if not isinstance(buffer, torch.Tensor):
+        raise TypeError("execution buffer must be a torch.Tensor")
+    return buffer

--- a/xllm/python/model_executor/runners/base.py
+++ b/xllm/python/model_executor/runners/base.py
@@ -20,6 +20,7 @@ import torch
 import torch.nn as nn
 
 from xllm.python.attention.backend import AttentionBackend, AttentionMetadata
+from xllm.python.model_executor.forward_context import LayerSynchronizer
 
 
 class BaseRunner(ABC):
@@ -36,5 +37,7 @@ class BaseRunner(ABC):
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         metadata: AttentionMetadata,
+        input_embedding: torch.Tensor | None = None,
+        layer_synchronizer: LayerSynchronizer | None = None,
     ) -> torch.Tensor:
         pass

--- a/xllm/python/model_executor/runners/base.py
+++ b/xllm/python/model_executor/runners/base.py
@@ -19,7 +19,12 @@ from abc import ABC, abstractmethod
 import torch
 import torch.nn as nn
 
-from xllm.python.attention.backend import AttentionBackend, AttentionMetadata, LayerCache
+from xllm.python.attention.backend import (
+    AttentionBackend,
+    AttentionMetadata,
+    LayerCache,
+)
+from xllm.python.model_executor.forward_context import LayerSynchronizer
 
 
 class BaseRunner(ABC):
@@ -40,5 +45,7 @@ class BaseRunner(ABC):
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         metadata: AttentionMetadata,
+        input_embedding: torch.Tensor | None = None,
+        layer_synchronizer: LayerSynchronizer | None = None,
     ) -> torch.Tensor:
         pass

--- a/xllm/python/model_executor/runners/decode_acl_graph.py
+++ b/xllm/python/model_executor/runners/decode_acl_graph.py
@@ -39,6 +39,7 @@ from xllm.python import kernels
 from xllm.python.attention.backend import AttentionBackend, AttentionMetadata
 from xllm.python.model_executor.forward_context import (
     AclGraphCaptureContext,
+    AclGraphExecutionState,
     AclGraphTask,
     ForwardContext,
     forward_context,
@@ -77,12 +78,20 @@ class _DecodeGraphEntry:
         "static_output",
         "static_input_ids",
         "static_positions",
+        "static_input_embedding",
         "static_metadata",
         "kv_seq_lens_delta",
-        "host_seq_lens",
-        "host_block_counts",
         "graph_tasks",
+        "execution_state",
     )
+
+
+_GraphKey = tuple[
+    int,
+    torch.dtype | None,
+    torch.device | None,
+    tuple[int, ...] | None,
+]
 
 
 class DecodeAclGraphRunner(BaseRunner):
@@ -99,7 +108,7 @@ class DecodeAclGraphRunner(BaseRunner):
         super().__init__(model, attention_backend, device)
         self.max_batch = max_batch
         self.max_model_len = max_model_len
-        self._graphs: dict[int, _DecodeGraphEntry] = {}
+        self._graphs: dict[_GraphKey, _DecodeGraphEntry] = {}
         self._paged_kv_indices_buffer: torch.Tensor | None = None
         self._max_blocks_per_sequence: int = 0
         self._stream: torch.npu.Stream | None = None
@@ -108,18 +117,35 @@ class DecodeAclGraphRunner(BaseRunner):
         self._warmed_up = False
 
     def can_execute(
-        self, input_ids: torch.Tensor, metadata: AttentionMetadata
+        self,
+        input_ids: torch.Tensor,
+        metadata: AttentionMetadata,
+        input_embedding: torch.Tensor | None = None,
     ) -> bool:
+        batch_size = input_ids.shape[0]
+        bucket_size = _decode_bucket(batch_size)
         return (
             not metadata.is_prefill
             and not metadata.is_chunked_prefill
-            and _decode_bucket(input_ids.shape[0]) <= self.max_batch
+            and bucket_size <= self.max_batch
         )
 
-    def warmup(self, device: torch.device, _dtype: torch.dtype) -> None:
+    def warmup(
+        self,
+        device: torch.device,
+        _dtype: torch.dtype,
+        input_embedding: torch.Tensor | None = None,
+    ) -> None:
         if self._warmed_up:
             return
         self._warmed_up = True
+
+        # MLA/SFA graph inputs include Lightning Indexer state and paged KV
+        # metadata.  Capturing these graphs with dummy warmup data would make
+        # the first real replay consume stale indexer/KV arguments.  Let the
+        # first real request lazily capture its bucket instead.
+        if getattr(self.attention_backend, "is_mla", False):
+            return
 
         buckets = [size for size in (1, 2, 4, 8) if size <= self.max_batch]
         buckets.extend(range(16, self.max_batch + 1, 16))
@@ -140,18 +166,27 @@ class DecodeAclGraphRunner(BaseRunner):
                 paged_kv_last_page_len=torch.ones(
                     batch_size, dtype=torch.int32, device=device
                 ),
-                kv_seq_lens_host=torch.arange(
-                    batch_size + 1, dtype=torch.int32, device="cpu"
-                ).mul_(2),
+                kv_seq_lens_host=torch.full(
+                    (batch_size,), 2, dtype=torch.int32, device="cpu"
+                ),
                 kv_cu_seq_lens=torch.arange(
                     batch_size + 1, dtype=torch.int32, device=device
                 ).mul_(2),
                 block_table=block_ids.unsqueeze(1),
             )
+            warmup_embedding = None
+            if input_embedding is not None:
+                warmup_embedding = torch.zeros(
+                    batch_size,
+                    input_embedding.shape[-1],
+                    dtype=input_embedding.dtype,
+                    device=device,
+                )
             self.execute(
                 torch.zeros(batch_size, dtype=torch.int32, device=device),
                 torch.zeros(batch_size, dtype=torch.int32, device=device),
                 metadata,
+                warmup_embedding,
             )
 
     def execute(
@@ -159,19 +194,21 @@ class DecodeAclGraphRunner(BaseRunner):
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         metadata: AttentionMetadata,
+        input_embedding: torch.Tensor | None = None,
     ) -> torch.Tensor:
         batch_size = input_ids.shape[0]
         padded_batch_size = _decode_bucket(batch_size)
         if padded_batch_size > self.max_batch:
             raise ValueError("decode batch exceeds ACL graph capacity")
 
-        entry = self._graphs.get(padded_batch_size)
+        graph_key = self._graph_key(padded_batch_size, input_embedding)
+        entry = self._graphs.get(graph_key)
         first_capture = entry is None
         if first_capture:
             entry = self._allocate_entry(
                 padded_batch_size, input_ids, positions, metadata
             )
-            self._graphs[padded_batch_size] = entry
+            self._graphs[graph_key] = entry
 
         if self._stream is None:
             self._stream = torch.npu.Stream(device=input_ids.device)
@@ -183,9 +220,21 @@ class DecodeAclGraphRunner(BaseRunner):
         assert self._update_stream is not None
         assert self._replay_done_event is not None
 
-        self._fill_entry(entry, input_ids, positions, metadata, batch_size)
+        self._fill_entry(
+            entry, input_ids, positions, metadata, batch_size, input_embedding
+        )
 
-        self.attention_backend.prepare(entry.static_metadata, graph_mode=True)
+        prepare_context = ForwardContext(
+            self.attention_backend,
+            self.device,
+            entry.static_metadata,
+            self.layer_caches,
+            execution_state=entry.execution_state,
+        )
+        with forward_context(prepare_context):
+            self.attention_backend.prepare(
+                entry.static_metadata, graph_mode=True
+            )
 
         if first_capture:
             self._capture(entry)
@@ -208,6 +257,21 @@ class DecodeAclGraphRunner(BaseRunner):
 
         torch.npu.current_stream().wait_stream(self._stream)
         return output
+
+    @staticmethod
+    def _graph_key(
+        padded_batch_size: int,
+        input_embedding: torch.Tensor | None,
+    ) -> _GraphKey:
+        """Return the capture shape key, including the MTP input path."""
+        if input_embedding is None:
+            return padded_batch_size, None, None, None
+        return (
+            padded_batch_size,
+            input_embedding.dtype,
+            input_embedding.device,
+            tuple(input_embedding.shape[1:]),
+        )
 
     def _allocate_entry(
         self,
@@ -241,12 +305,14 @@ class DecodeAclGraphRunner(BaseRunner):
         entry.graph = None
         entry.static_output = None
         entry.graph_tasks = []
+        entry.execution_state = AclGraphExecutionState({})
         entry.static_input_ids = torch.zeros(
             padded_batch_size, dtype=input_ids.dtype, device=device
         )
         entry.static_positions = torch.zeros(
             padded_batch_size, dtype=torch.int32, device=device
         )
+        entry.static_input_embedding = None
         entry.static_metadata = _StaticAttentionMetadata(
             slot_mapping=torch.zeros(
                 padded_batch_size,
@@ -276,19 +342,16 @@ class DecodeAclGraphRunner(BaseRunner):
                 padded_batch_size, dtype=torch.int32, device="cpu"
             ),
             kv_seq_lens_host=torch.zeros(
-                padded_batch_size + 1, dtype=torch.int32, device="cpu"
+                padded_batch_size, dtype=torch.int32, device="cpu"
             ),
             block_table=static_block_table,
         )
         entry.kv_seq_lens_delta = torch.empty(
             padded_batch_size, dtype=torch.int32, device=device
         )
-        entry.host_seq_lens = torch.empty(
-            padded_batch_size, dtype=torch.int32, device="cpu"
-        )
-        entry.host_block_counts = torch.empty(
-            padded_batch_size, dtype=torch.int32, device="cpu"
-        )
+        # The graph metadata update writes per-sequence KV lengths into this
+        # buffer.  MLA/SFA consumes the same stable buffer as its key lengths.
+        entry.static_metadata.kv_seq_lens = entry.kv_seq_lens_delta
         return entry
 
     def _fill_entry(
@@ -298,19 +361,26 @@ class DecodeAclGraphRunner(BaseRunner):
         positions: torch.Tensor,
         metadata: AttentionMetadata,
         batch_size: int,
+        input_embedding: torch.Tensor | None,
     ) -> None:
         padded_batch_size = entry.batch_size
         static_metadata = entry.static_metadata
-        if metadata.kv_cu_seq_lens is None:
+        if metadata.kv_seq_lens is None and metadata.kv_cu_seq_lens is None:
             raise RuntimeError(
-                "decode ACL graph requires device cumulative KV lengths"
+                "decode ACL graph requires device KV lengths"
             )
+        cumulative_kv_seq_lens = metadata.kv_cu_seq_lens
+        if cumulative_kv_seq_lens is None:
+            raise RuntimeError(
+                "decode ACL graph requires C++ cumulative KV lengths"
+            )
+        cumulative_kv_seq_lens = cumulative_kv_seq_lens.to(torch.int32)
         graph_positions = positions.to(torch.int32).contiguous()
         kernels.update_decode_graph_metadata(
             input_ids,
             graph_positions,
             metadata.slot_mapping,
-            metadata.kv_cu_seq_lens,
+            cumulative_kv_seq_lens,
             metadata.paged_kv_indptr,
             metadata.paged_kv_indices,
             metadata.paged_kv_last_page_len,
@@ -325,6 +395,31 @@ class DecodeAclGraphRunner(BaseRunner):
             padded_batch_size,
         )
         self._fill_host_metadata(entry, metadata, batch_size)
+
+        if input_embedding is not None:
+            if input_embedding.shape[0] != batch_size:
+                raise ValueError(
+                    "ACL graph input_embedding token count must match input_ids"
+                )
+            if entry.static_input_embedding is None:
+                entry.static_input_embedding = torch.zeros(
+                    entry.batch_size,
+                    input_embedding.shape[-1],
+                    dtype=input_embedding.dtype,
+                    device=input_embedding.device,
+                )
+            elif (
+                entry.static_input_embedding.shape[1:]
+                != input_embedding.shape[1:]
+            ):
+                raise ValueError(
+                    "ACL graph input_embedding shape changed for a graph bucket"
+                )
+            entry.static_input_embedding[:batch_size].copy_(input_embedding)
+            if entry.batch_size > batch_size:
+                entry.static_input_embedding[batch_size:].zero_()
+        elif entry.static_input_embedding is not None:
+            entry.static_input_embedding.zero_()
 
         if (
             metadata.block_table is not None
@@ -341,91 +436,31 @@ class DecodeAclGraphRunner(BaseRunner):
             if padded_batch_size > batch_size:
                 static_metadata.block_table[batch_size:].zero_()
 
+        # Padded lanes must remain valid inputs for sparse MLA tiling.  Their
+        # token and slot mapping are dummy values, so one KV token is safe.
+        if padded_batch_size > batch_size:
+            entry.kv_seq_lens_delta[batch_size:].fill_(1)
+
     def _fill_host_metadata(
         self,
         entry: _DecodeGraphEntry,
         metadata: AttentionMetadata,
         batch_size: int,
     ) -> None:
-        cumulative_seq_lens = metadata.kv_seq_lens_host
-        if cumulative_seq_lens is None:
+        kv_seq_lens = metadata.kv_seq_lens_host
+        if kv_seq_lens is None:
             raise RuntimeError("decode ACL graph requires host KV lengths")
-        cumulative_seq_lens = cumulative_seq_lens.cpu()
-        if cumulative_seq_lens.numel() == batch_size:
-            cum = torch.zeros(
-                batch_size + 1,
-                dtype=cumulative_seq_lens.dtype,
-                device=cumulative_seq_lens.device,
-            )
-            cum[1:] = torch.cumsum(cumulative_seq_lens, dim=0)
-            cumulative_seq_lens = cum
-        if cumulative_seq_lens.numel() != batch_size + 1:
+        kv_seq_lens = kv_seq_lens.cpu()
+        if kv_seq_lens.numel() != batch_size:
             raise RuntimeError(
-                "decode ACL graph requires cumulative host KV lengths"
+                "decode ACL graph requires per-sequence host KV lengths"
             )
 
         padded_batch_size = entry.batch_size
         static_metadata = entry.static_metadata
-        torch.sub(
-            cumulative_seq_lens[1:],
-            cumulative_seq_lens[:-1],
-            out=entry.host_seq_lens[:batch_size],
-        )
+        static_metadata.kv_seq_lens_host[:batch_size].copy_(kv_seq_lens)
         if padded_batch_size > batch_size:
-            entry.host_seq_lens[batch_size:padded_batch_size].fill_(1)
-        torch.cumsum(
-            entry.host_seq_lens,
-            dim=0,
-            out=static_metadata.kv_seq_lens_host[1:],
-        )
-
-        page_size = self.attention_backend.page_size
-        if page_size == 1:
-            static_metadata.paged_kv_indptr_host[: batch_size + 1].copy_(
-                cumulative_seq_lens
-            )
-            static_metadata.paged_kv_last_page_len_host.fill_(1)
-        else:
-            torch.add(
-                entry.host_seq_lens,
-                page_size - 1,
-                out=entry.host_block_counts,
-            )
-            torch.div(
-                entry.host_block_counts,
-                page_size,
-                rounding_mode="floor",
-                out=entry.host_block_counts,
-            )
-            torch.cumsum(
-                entry.host_block_counts,
-                dim=0,
-                out=static_metadata.paged_kv_indptr_host[1:],
-            )
-            torch.sub(
-                entry.host_seq_lens,
-                1,
-                out=static_metadata.paged_kv_last_page_len_host,
-            )
-            torch.remainder(
-                static_metadata.paged_kv_last_page_len_host,
-                page_size,
-                out=static_metadata.paged_kv_last_page_len_host,
-            )
-            torch.add(
-                static_metadata.paged_kv_last_page_len_host,
-                1,
-                out=static_metadata.paged_kv_last_page_len_host,
-            )
-            if padded_batch_size > batch_size:
-                static_metadata.paged_kv_last_page_len_host[
-                    batch_size:padded_batch_size
-                ].fill_(1)
-
-        if page_size == 1 and padded_batch_size > batch_size:
-            static_metadata.paged_kv_indptr_host[
-                batch_size + 1 : padded_batch_size + 1
-            ].fill_(int(cumulative_seq_lens[-1]))
+            static_metadata.kv_seq_lens_host[batch_size:].fill_(1)
 
     def _capture(self, entry: _DecodeGraphEntry) -> None:
         context = ForwardContext(
@@ -433,10 +468,11 @@ class DecodeAclGraphRunner(BaseRunner):
             self.device,
             entry.static_metadata,
             self.layer_caches,
+            execution_state=entry.execution_state,
         )
         with forward_context(context):
             for _ in range(_CAPTURE_WARMUP_STEPS):
-                self.model(entry.static_input_ids, entry.static_positions)
+                self._forward_static(entry)
         torch.npu.synchronize()
         entry.graph = torch.npu.NPUGraph()
         capture_context = AclGraphCaptureContext(self._stream, [])
@@ -446,13 +482,21 @@ class DecodeAclGraphRunner(BaseRunner):
             entry.static_metadata,
             self.layer_caches,
             acl_graph=capture_context,
+            execution_state=entry.execution_state,
         )
         with forward_context(context):
             with torch.npu.graph(entry.graph, stream=self._stream):
-                entry.static_output = self.model(
-                    entry.static_input_ids, entry.static_positions
-                )
+                entry.static_output = self._forward_static(entry)
         entry.graph_tasks = capture_context.tasks
+
+    def _forward_static(self, entry: _DecodeGraphEntry) -> torch.Tensor:
+        if entry.static_input_embedding is None:
+            return self.model(entry.static_input_ids, entry.static_positions)
+        return self.model(
+            entry.static_input_ids,
+            entry.static_positions,
+            entry.static_input_embedding,
+        )
 
     @staticmethod
     def _update_graph_tasks(

--- a/xllm/python/model_executor/runners/decode_acl_graph.py
+++ b/xllm/python/model_executor/runners/decode_acl_graph.py
@@ -37,6 +37,10 @@ import torch.nn as nn
 
 from xllm.python import kernels
 from xllm.python.attention.backend import AttentionBackend, AttentionMetadata
+from xllm.python.attention.expanded_decode_metadata import (
+    ExpandedDecodeMetadata,
+    resolve_expanded_decode_metadata,
+)
 from xllm.python.model_executor.forward_context import (
     AclGraphCaptureContext,
     AclGraphExecutionState,
@@ -61,12 +65,16 @@ class _StaticAttentionMetadata:
     q_cu_seq_lens: torch.Tensor | None = None
     kv_cu_seq_lens: torch.Tensor | None = None
     kv_seq_lens_host: torch.Tensor | None = None
+    kv_seq_lens_host_values: list[int] | None = None
     paged_kv_indptr_host: torch.Tensor | None = None
     paged_kv_last_page_len_host: torch.Tensor | None = None
     block_table: torch.Tensor | None = None
     kv_seq_lens: torch.Tensor | None = None
     linear_state_indices: torch.Tensor | None = None
     has_initial_state: torch.Tensor | None = None
+    dp_token_counts: tuple[int, ...] = ()
+    q_seq_lens: torch.Tensor | None = None
+    expanded_decode_metadata: ExpandedDecodeMetadata | None = None
     is_prefill: bool = False
     is_chunked_prefill: bool = False
 
@@ -88,6 +96,7 @@ class _DecodeGraphEntry:
 
 _GraphKey = tuple[
     int,
+    bool,
     torch.dtype | None,
     torch.device | None,
     tuple[int, ...] | None,
@@ -122,12 +131,237 @@ class DecodeAclGraphRunner(BaseRunner):
         metadata: AttentionMetadata,
         input_embedding: torch.Tensor | None = None,
     ) -> bool:
-        batch_size = input_ids.shape[0]
+        if input_ids.dim() != 1:
+            return False
+        batch_size = input_ids.numel()
         bucket_size = _decode_bucket(batch_size)
+        is_expanded_spec_verify = (
+            resolve_expanded_decode_metadata(metadata) is not None
+        )
         return (
-            not metadata.is_prefill
-            and not metadata.is_chunked_prefill
+            (
+                (not metadata.is_prefill and not metadata.is_chunked_prefill)
+                or is_expanded_spec_verify
+            )
+            and self._has_compatible_decode_metadata(input_ids, metadata)
+            and (
+                input_embedding is None
+                or input_embedding.shape[0] == batch_size
+            )
             and bucket_size <= self.max_batch
+        )
+
+    def _decode_metadata(
+        self, metadata: AttentionMetadata
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        list[int] | None,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+    ]:
+        """Return per-row KV and paging metadata for decode graph replay."""
+        expanded = resolve_expanded_decode_metadata(
+            metadata, block_size=self.attention_backend.page_size
+        )
+        block_table = (
+            expanded.block_table if expanded is not None else metadata.block_table
+        )
+        kv_seq_lens = (
+            expanded.kv_seq_lens if expanded is not None else metadata.kv_seq_lens
+        )
+        kv_seq_lens_host_values = (
+            expanded.kv_seq_lens_host_values
+            if expanded is not None
+            else getattr(metadata, "kv_seq_lens_host_values", None)
+        )
+        if block_table is None or kv_seq_lens is None:
+            raise RuntimeError("decode graph requires block and KV metadata")
+        block_table = block_table.to(torch.int32)
+        kv_seq_lens = kv_seq_lens.to(torch.int32)
+        is_mla = getattr(self.attention_backend, "is_mla", False)
+        if kv_seq_lens_host_values is None and not is_mla:
+            raise RuntimeError(
+                "decode graph requires scheduler-provided host KV lengths"
+            )
+
+        paged_kv_indptr = (
+            expanded.paged_kv_indptr
+            if expanded is not None
+            else metadata.paged_kv_indptr
+        )
+        paged_kv_indices = (
+            expanded.paged_kv_indices
+            if expanded is not None
+            else metadata.paged_kv_indices
+        )
+        paged_kv_last_page_len = (
+            expanded.paged_kv_last_page_len
+            if expanded is not None
+            else metadata.paged_kv_last_page_len
+        )
+        if (
+            paged_kv_indptr is None
+            or paged_kv_indices is None
+            or paged_kv_last_page_len is None
+        ):
+            raise RuntimeError("decode graph requires paged KV metadata")
+        self._validate_decode_metadata_shapes(
+            block_table,
+            kv_seq_lens,
+            kv_seq_lens_host_values,
+            paged_kv_indptr,
+            paged_kv_indices,
+            paged_kv_last_page_len,
+        )
+        return (
+            block_table,
+            kv_seq_lens,
+            kv_seq_lens_host_values,
+            paged_kv_indptr,
+            paged_kv_indices,
+            paged_kv_last_page_len,
+        )
+
+    @staticmethod
+    def _validate_decode_metadata_shapes(
+        block_table: torch.Tensor,
+        kv_seq_lens: torch.Tensor,
+        kv_seq_lens_host_values: list[int] | None,
+        paged_kv_indptr: torch.Tensor,
+        paged_kv_indices: torch.Tensor,
+        paged_kv_last_page_len: torch.Tensor,
+    ) -> None:
+        if block_table.dim() != 2:
+            raise RuntimeError("decode block_table must be two-dimensional")
+        sequence_count = block_table.shape[0]
+        per_sequence_tensors = (
+            ("kv_seq_lens", kv_seq_lens),
+            ("paged_kv_last_page_len", paged_kv_last_page_len),
+        )
+        for name, tensor in per_sequence_tensors:
+            if tensor.dim() != 1 or tensor.numel() != sequence_count:
+                raise RuntimeError(
+                    f"decode {name} must contain one value per sequence"
+                )
+        if (
+            kv_seq_lens_host_values is not None
+            and len(kv_seq_lens_host_values) != sequence_count
+        ):
+            raise RuntimeError(
+                "decode kv_seq_lens_host_values must contain one value per "
+                "sequence"
+            )
+        if (
+            paged_kv_indptr.dim() != 1
+            or paged_kv_indptr.numel() != sequence_count + 1
+        ):
+            raise RuntimeError(
+                "decode paged_kv_indptr must contain one offset per sequence "
+                "plus the terminal offset"
+            )
+        if paged_kv_indices.dim() != 1 or paged_kv_indices.numel() == 0:
+            raise RuntimeError(
+                "decode paged_kv_indices must be a non-empty flat page list"
+            )
+
+    @staticmethod
+    def _validate_decode_token_layout(
+        input_ids: torch.Tensor,
+        positions: torch.Tensor | None,
+        slot_mapping: torch.Tensor,
+        sequence_count: int,
+    ) -> None:
+        if input_ids.dim() != 1 or input_ids.numel() != sequence_count:
+            raise RuntimeError(
+                "ACL graph decode input_ids must contain one token per sequence"
+            )
+        if slot_mapping.dim() != 1 or slot_mapping.numel() != sequence_count:
+            raise RuntimeError(
+                "ACL graph decode slot_mapping must contain one slot per token"
+            )
+        if positions is not None and (
+            positions.dim() != 1 or positions.numel() != sequence_count
+        ):
+            raise RuntimeError(
+                "ACL graph decode positions must contain one value per token"
+            )
+
+    def _has_compatible_decode_metadata(
+        self,
+        input_ids: torch.Tensor,
+        metadata: AttentionMetadata,
+    ) -> bool:
+        """Check the one-token-per-sequence contract of ACL decode graphs."""
+        try:
+            (
+                block_table,
+                _,
+                _,
+                _,
+                _,
+                _,
+            ) = self._decode_metadata(metadata)
+            self._validate_decode_token_layout(
+                input_ids,
+                None,
+                metadata.slot_mapping,
+                block_table.shape[0],
+            )
+        except (RuntimeError, ValueError):
+            return False
+        batch_size = input_ids.numel()
+        is_expanded = resolve_expanded_decode_metadata(metadata) is not None
+        if not is_expanded and metadata.kv_cu_seq_lens is not None:
+            if metadata.kv_cu_seq_lens.numel() not in (
+                batch_size,
+                batch_size + 1,
+            ):
+                return False
+        if metadata.q_cu_seq_lens is not None and not is_expanded:
+            if metadata.q_cu_seq_lens.numel() not in (
+                batch_size,
+                batch_size + 1,
+            ):
+                return False
+        return True
+
+    @staticmethod
+    def _cumulative_lengths(
+        sequence_lengths: torch.Tensor,
+        cumulative_lengths: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """Normalize NPU sequence ends to a cumulative tensor with a zero."""
+        batch_size = sequence_lengths.numel()
+        if cumulative_lengths is None:
+            return torch.cat(
+                (
+                    torch.zeros(
+                        1,
+                        dtype=torch.int32,
+                        device=sequence_lengths.device,
+                    ),
+                    torch.cumsum(sequence_lengths, dim=0),
+                )
+            )
+        cumulative_lengths = cumulative_lengths.to(torch.int32)
+        if cumulative_lengths.numel() == batch_size + 1:
+            return cumulative_lengths
+        if cumulative_lengths.numel() == batch_size:
+            return torch.cat(
+                (
+                    torch.zeros(
+                        1,
+                        dtype=torch.int32,
+                        device=cumulative_lengths.device,
+                    ),
+                    cumulative_lengths,
+                )
+            )
+        raise RuntimeError(
+            "cumulative sequence lengths must contain either one value per "
+            "sequence or a leading zero plus one value per sequence"
         )
 
     def warmup(
@@ -169,6 +403,7 @@ class DecodeAclGraphRunner(BaseRunner):
                 kv_seq_lens_host=torch.full(
                     (batch_size,), 2, dtype=torch.int32, device="cpu"
                 ),
+                kv_seq_lens_host_values=[2] * batch_size,
                 kv_cu_seq_lens=torch.arange(
                     batch_size + 1, dtype=torch.int32, device=device
                 ).mul_(2),
@@ -201,7 +436,10 @@ class DecodeAclGraphRunner(BaseRunner):
         if padded_batch_size > self.max_batch:
             raise ValueError("decode batch exceeds ACL graph capacity")
 
-        graph_key = self._graph_key(padded_batch_size, input_embedding)
+        is_expanded = resolve_expanded_decode_metadata(metadata) is not None
+        graph_key = self._graph_key(
+            padded_batch_size, is_expanded, input_embedding
+        )
         entry = self._graphs.get(graph_key)
         first_capture = entry is None
         if first_capture:
@@ -261,13 +499,15 @@ class DecodeAclGraphRunner(BaseRunner):
     @staticmethod
     def _graph_key(
         padded_batch_size: int,
+        is_expanded: bool,
         input_embedding: torch.Tensor | None,
     ) -> _GraphKey:
-        """Return the capture shape key, including the MTP input path."""
+        """Return the key for a shape- and metadata-specific graph."""
         if input_embedding is None:
-            return padded_batch_size, None, None, None
+            return padded_batch_size, is_expanded, None, None, None
         return (
             padded_batch_size,
+            is_expanded,
             input_embedding.dtype,
             input_embedding.device,
             tuple(input_embedding.shape[1:]),
@@ -281,6 +521,14 @@ class DecodeAclGraphRunner(BaseRunner):
         metadata: AttentionMetadata,
     ) -> _DecodeGraphEntry:
         device = input_ids.device
+        (
+            _,
+            _,
+            _,
+            paged_kv_indptr,
+            paged_kv_indices,
+            paged_kv_last_page_len,
+        ) = self._decode_metadata(metadata)
         if self._paged_kv_indices_buffer is None:
             page_size = self.attention_backend.page_size
             max_blocks_per_sequence = (
@@ -288,7 +536,7 @@ class DecodeAclGraphRunner(BaseRunner):
             ) // page_size
             self._paged_kv_indices_buffer = torch.zeros(
                 self.max_batch * max_blocks_per_sequence,
-                dtype=metadata.paged_kv_indices.dtype,
+                dtype=paged_kv_indices.dtype,
                 device=device,
             )
             self._max_blocks_per_sequence = max_blocks_per_sequence
@@ -321,13 +569,13 @@ class DecodeAclGraphRunner(BaseRunner):
             ),
             paged_kv_indptr=torch.zeros(
                 padded_batch_size + 1,
-                dtype=metadata.paged_kv_indptr.dtype,
+                dtype=paged_kv_indptr.dtype,
                 device=device,
             ),
             paged_kv_indices=self._paged_kv_indices_buffer,
             paged_kv_last_page_len=torch.zeros(
                 padded_batch_size,
-                dtype=metadata.paged_kv_last_page_len.dtype,
+                dtype=paged_kv_last_page_len.dtype,
                 device=device,
             ),
             kv_cu_seq_lens=torch.zeros(
@@ -341,17 +589,35 @@ class DecodeAclGraphRunner(BaseRunner):
             paged_kv_last_page_len_host=torch.ones(
                 padded_batch_size, dtype=torch.int32, device="cpu"
             ),
-            kv_seq_lens_host=torch.zeros(
-                padded_batch_size, dtype=torch.int32, device="cpu"
-            ),
+            kv_seq_lens_host_values=[1] * padded_batch_size,
             block_table=static_block_table,
         )
+        is_expanded = resolve_expanded_decode_metadata(metadata) is not None
         entry.kv_seq_lens_delta = torch.empty(
             padded_batch_size, dtype=torch.int32, device=device
         )
         # The graph metadata update writes per-sequence KV lengths into this
         # buffer.  MLA/SFA consumes the same stable buffer as its key lengths.
         entry.static_metadata.kv_seq_lens = entry.kv_seq_lens_delta
+        if is_expanded:
+            entry.static_metadata.expanded_decode_metadata = (
+                ExpandedDecodeMetadata(
+                    kv_seq_lens=entry.kv_seq_lens_delta,
+                    block_table=entry.static_metadata.block_table,
+                    paged_kv_indptr=entry.static_metadata.paged_kv_indptr,
+                    paged_kv_indices=entry.static_metadata.paged_kv_indices,
+                    paged_kv_last_page_len=(
+                        entry.static_metadata.paged_kv_last_page_len
+                    ),
+                    paged_attention_tiling_data=None,
+                    kv_seq_lens_host=None,
+                    kv_seq_lens_host_values=(
+                        None
+                        if getattr(self.attention_backend, "is_mla", False)
+                        else entry.static_metadata.kv_seq_lens_host_values
+                    ),
+                )
+            )
         return entry
 
     def _fill_entry(
@@ -365,25 +631,38 @@ class DecodeAclGraphRunner(BaseRunner):
     ) -> None:
         padded_batch_size = entry.batch_size
         static_metadata = entry.static_metadata
-        if metadata.kv_seq_lens is None and metadata.kv_cu_seq_lens is None:
+        (
+            block_table,
+            kv_seq_lens,
+            kv_seq_lens_host_values,
+            paged_kv_indptr,
+            paged_kv_indices,
+            paged_kv_last_page_len,
+        ) = self._decode_metadata(metadata)
+        if batch_size != block_table.shape[0]:
             raise RuntimeError(
-                "decode ACL graph requires device KV lengths"
+                "ACL graph decode batch size must match metadata sequences"
             )
-        cumulative_kv_seq_lens = metadata.kv_cu_seq_lens
-        if cumulative_kv_seq_lens is None:
-            raise RuntimeError(
-                "decode ACL graph requires C++ cumulative KV lengths"
-            )
-        cumulative_kv_seq_lens = cumulative_kv_seq_lens.to(torch.int32)
+        self._validate_decode_token_layout(
+            input_ids,
+            positions,
+            metadata.slot_mapping,
+            block_table.shape[0],
+        )
+        is_expanded = resolve_expanded_decode_metadata(metadata) is not None
+        cumulative_kv_seq_lens = self._cumulative_lengths(
+            kv_seq_lens,
+            None if is_expanded else metadata.kv_cu_seq_lens,
+        )
         graph_positions = positions.to(torch.int32).contiguous()
         kernels.update_decode_graph_metadata(
             input_ids,
             graph_positions,
             metadata.slot_mapping,
             cumulative_kv_seq_lens,
-            metadata.paged_kv_indptr,
-            metadata.paged_kv_indices,
-            metadata.paged_kv_last_page_len,
+            paged_kv_indptr,
+            paged_kv_indices,
+            paged_kv_last_page_len,
             entry.static_input_ids,
             entry.static_positions,
             static_metadata.slot_mapping,
@@ -394,7 +673,9 @@ class DecodeAclGraphRunner(BaseRunner):
             static_metadata.paged_kv_last_page_len,
             padded_batch_size,
         )
-        self._fill_host_metadata(entry, metadata, batch_size)
+        self._fill_host_metadata(
+            entry, kv_seq_lens_host_values, batch_size
+        )
 
         if input_embedding is not None:
             if input_embedding.shape[0] != batch_size:
@@ -421,11 +702,8 @@ class DecodeAclGraphRunner(BaseRunner):
         elif entry.static_input_embedding is not None:
             entry.static_input_embedding.zero_()
 
-        if (
-            metadata.block_table is not None
-            and static_metadata.block_table is not None
-        ):
-            src_bt = metadata.block_table.to(torch.int32)
+        if static_metadata.block_table is not None:
+            src_bt = block_table
             copy_cols = min(
                 src_bt.shape[1],
                 static_metadata.block_table.shape[1],
@@ -444,23 +722,30 @@ class DecodeAclGraphRunner(BaseRunner):
     def _fill_host_metadata(
         self,
         entry: _DecodeGraphEntry,
-        metadata: AttentionMetadata,
+        kv_seq_lens: list[int] | None,
         batch_size: int,
     ) -> None:
-        kv_seq_lens = metadata.kv_seq_lens_host
+        if getattr(self.attention_backend, "is_mla", False):
+            return
         if kv_seq_lens is None:
-            raise RuntimeError("decode ACL graph requires host KV lengths")
-        kv_seq_lens = kv_seq_lens.cpu()
-        if kv_seq_lens.numel() != batch_size:
+            raise RuntimeError(
+                "decode ACL graph requires scheduler-provided host KV lengths"
+            )
+        if len(kv_seq_lens) != batch_size:
             raise RuntimeError(
                 "decode ACL graph requires per-sequence host KV lengths"
             )
 
         padded_batch_size = entry.batch_size
         static_metadata = entry.static_metadata
-        static_metadata.kv_seq_lens_host[:batch_size].copy_(kv_seq_lens)
+        static_kv_seq_lens = static_metadata.kv_seq_lens_host_values
+        if static_kv_seq_lens is None:
+            raise RuntimeError("decode ACL graph host KV buffer is missing")
+        static_kv_seq_lens[:batch_size] = kv_seq_lens
         if padded_batch_size > batch_size:
-            static_metadata.kv_seq_lens_host[batch_size:].fill_(1)
+            static_kv_seq_lens[batch_size:] = [1] * (
+                padded_batch_size - batch_size
+            )
 
     def _capture(self, entry: _DecodeGraphEntry) -> None:
         context = ForwardContext(

--- a/xllm/python/model_executor/runners/decode_acl_graph.py
+++ b/xllm/python/model_executor/runners/decode_acl_graph.py
@@ -39,6 +39,7 @@ from xllm.python import kernels
 from xllm.python.attention.backend import AttentionBackend, AttentionMetadata
 from xllm.python.model_executor.forward_context import (
     AclGraphCaptureContext,
+    AclGraphExecutionState,
     AclGraphTask,
     ForwardContext,
     forward_context,
@@ -75,12 +76,20 @@ class _DecodeGraphEntry:
         "static_output",
         "static_input_ids",
         "static_positions",
+        "static_input_embedding",
         "static_metadata",
         "kv_seq_lens_delta",
-        "host_seq_lens",
-        "host_block_counts",
         "graph_tasks",
+        "execution_state",
     )
+
+
+_GraphKey = tuple[
+    int,
+    torch.dtype | None,
+    torch.device | None,
+    tuple[int, ...] | None,
+]
 
 
 class DecodeAclGraphRunner(BaseRunner):
@@ -97,7 +106,7 @@ class DecodeAclGraphRunner(BaseRunner):
         super().__init__(model, attention_backend, device)
         self.max_batch = max_batch
         self.max_model_len = max_model_len
-        self._graphs: dict[int, _DecodeGraphEntry] = {}
+        self._graphs: dict[_GraphKey, _DecodeGraphEntry] = {}
         self._paged_kv_indices_buffer: torch.Tensor | None = None
         self._max_blocks_per_sequence: int = 0
         self._stream: torch.npu.Stream | None = None
@@ -106,18 +115,35 @@ class DecodeAclGraphRunner(BaseRunner):
         self._warmed_up = False
 
     def can_execute(
-        self, input_ids: torch.Tensor, metadata: AttentionMetadata
+        self,
+        input_ids: torch.Tensor,
+        metadata: AttentionMetadata,
+        input_embedding: torch.Tensor | None = None,
     ) -> bool:
+        batch_size = input_ids.shape[0]
+        bucket_size = _decode_bucket(batch_size)
         return (
             not metadata.is_prefill
             and not metadata.is_chunked_prefill
-            and _decode_bucket(input_ids.shape[0]) <= self.max_batch
+            and bucket_size <= self.max_batch
         )
 
-    def warmup(self, device: torch.device, _dtype: torch.dtype) -> None:
+    def warmup(
+        self,
+        device: torch.device,
+        _dtype: torch.dtype,
+        input_embedding: torch.Tensor | None = None,
+    ) -> None:
         if self._warmed_up:
             return
         self._warmed_up = True
+
+        # MLA/SFA graph inputs include Lightning Indexer state and paged KV
+        # metadata.  Capturing these graphs with dummy warmup data would make
+        # the first real replay consume stale indexer/KV arguments.  Let the
+        # first real request lazily capture its bucket instead.
+        if getattr(self.attention_backend, "is_mla", False):
+            return
 
         buckets = [size for size in (1, 2, 4, 8) if size <= self.max_batch]
         buckets.extend(range(16, self.max_batch + 1, 16))
@@ -138,18 +164,27 @@ class DecodeAclGraphRunner(BaseRunner):
                 paged_kv_last_page_len=torch.ones(
                     batch_size, dtype=torch.int32, device=device
                 ),
-                kv_seq_lens_host=torch.arange(
-                    batch_size + 1, dtype=torch.int32, device="cpu"
-                ).mul_(2),
+                kv_seq_lens_host=torch.full(
+                    (batch_size,), 2, dtype=torch.int32, device="cpu"
+                ),
                 kv_cu_seq_lens=torch.arange(
                     batch_size + 1, dtype=torch.int32, device=device
                 ).mul_(2),
                 block_table=block_ids.unsqueeze(1),
             )
+            warmup_embedding = None
+            if input_embedding is not None:
+                warmup_embedding = torch.zeros(
+                    batch_size,
+                    input_embedding.shape[-1],
+                    dtype=input_embedding.dtype,
+                    device=device,
+                )
             self.execute(
                 torch.zeros(batch_size, dtype=torch.int32, device=device),
                 torch.zeros(batch_size, dtype=torch.int32, device=device),
                 metadata,
+                warmup_embedding,
             )
 
     def execute(
@@ -157,19 +192,21 @@ class DecodeAclGraphRunner(BaseRunner):
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         metadata: AttentionMetadata,
+        input_embedding: torch.Tensor | None = None,
     ) -> torch.Tensor:
         batch_size = input_ids.shape[0]
         padded_batch_size = _decode_bucket(batch_size)
         if padded_batch_size > self.max_batch:
             raise ValueError("decode batch exceeds ACL graph capacity")
 
-        entry = self._graphs.get(padded_batch_size)
+        graph_key = self._graph_key(padded_batch_size, input_embedding)
+        entry = self._graphs.get(graph_key)
         first_capture = entry is None
         if first_capture:
             entry = self._allocate_entry(
                 padded_batch_size, input_ids, positions, metadata
             )
-            self._graphs[padded_batch_size] = entry
+            self._graphs[graph_key] = entry
 
         if self._stream is None:
             self._stream = torch.npu.Stream(device=input_ids.device)
@@ -181,9 +218,19 @@ class DecodeAclGraphRunner(BaseRunner):
         assert self._update_stream is not None
         assert self._replay_done_event is not None
 
-        self._fill_entry(entry, input_ids, positions, metadata, batch_size)
+        self._fill_entry(
+            entry, input_ids, positions, metadata, batch_size, input_embedding
+        )
 
-        self.attention_backend.prepare(entry.static_metadata, graph_mode=True)
+        prepare_context = ForwardContext(
+            self.attention_backend,
+            self.device,
+            execution_state=entry.execution_state,
+        )
+        with forward_context(prepare_context):
+            self.attention_backend.prepare(
+                entry.static_metadata, graph_mode=True
+            )
 
         if first_capture:
             self._capture(entry)
@@ -206,6 +253,21 @@ class DecodeAclGraphRunner(BaseRunner):
 
         torch.npu.current_stream().wait_stream(self._stream)
         return output
+
+    @staticmethod
+    def _graph_key(
+        padded_batch_size: int,
+        input_embedding: torch.Tensor | None,
+    ) -> _GraphKey:
+        """Return the capture shape key, including the MTP input path."""
+        if input_embedding is None:
+            return padded_batch_size, None, None, None
+        return (
+            padded_batch_size,
+            input_embedding.dtype,
+            input_embedding.device,
+            tuple(input_embedding.shape[1:]),
+        )
 
     def _allocate_entry(
         self,
@@ -239,12 +301,14 @@ class DecodeAclGraphRunner(BaseRunner):
         entry.graph = None
         entry.static_output = None
         entry.graph_tasks = []
+        entry.execution_state = AclGraphExecutionState({})
         entry.static_input_ids = torch.zeros(
             padded_batch_size, dtype=input_ids.dtype, device=device
         )
         entry.static_positions = torch.zeros(
             padded_batch_size, dtype=torch.int32, device=device
         )
+        entry.static_input_embedding = None
         entry.static_metadata = _StaticAttentionMetadata(
             slot_mapping=torch.zeros(
                 padded_batch_size,
@@ -274,19 +338,16 @@ class DecodeAclGraphRunner(BaseRunner):
                 padded_batch_size, dtype=torch.int32, device="cpu"
             ),
             kv_seq_lens_host=torch.zeros(
-                padded_batch_size + 1, dtype=torch.int32, device="cpu"
+                padded_batch_size, dtype=torch.int32, device="cpu"
             ),
             block_table=static_block_table,
         )
         entry.kv_seq_lens_delta = torch.empty(
             padded_batch_size, dtype=torch.int32, device=device
         )
-        entry.host_seq_lens = torch.empty(
-            padded_batch_size, dtype=torch.int32, device="cpu"
-        )
-        entry.host_block_counts = torch.empty(
-            padded_batch_size, dtype=torch.int32, device="cpu"
-        )
+        # The graph metadata update writes per-sequence KV lengths into this
+        # buffer.  MLA/SFA consumes the same stable buffer as its key lengths.
+        entry.static_metadata.kv_seq_lens = entry.kv_seq_lens_delta
         return entry
 
     def _fill_entry(
@@ -296,19 +357,26 @@ class DecodeAclGraphRunner(BaseRunner):
         positions: torch.Tensor,
         metadata: AttentionMetadata,
         batch_size: int,
+        input_embedding: torch.Tensor | None,
     ) -> None:
         padded_batch_size = entry.batch_size
         static_metadata = entry.static_metadata
-        if metadata.kv_cu_seq_lens is None:
+        if metadata.kv_seq_lens is None and metadata.kv_cu_seq_lens is None:
             raise RuntimeError(
-                "decode ACL graph requires device cumulative KV lengths"
+                "decode ACL graph requires device KV lengths"
             )
+        cumulative_kv_seq_lens = metadata.kv_cu_seq_lens
+        if cumulative_kv_seq_lens is None:
+            raise RuntimeError(
+                "decode ACL graph requires C++ cumulative KV lengths"
+            )
+        cumulative_kv_seq_lens = cumulative_kv_seq_lens.to(torch.int32)
         graph_positions = positions.to(torch.int32).contiguous()
         kernels.update_decode_graph_metadata(
             input_ids,
             graph_positions,
             metadata.slot_mapping,
-            metadata.kv_cu_seq_lens,
+            cumulative_kv_seq_lens,
             metadata.paged_kv_indptr,
             metadata.paged_kv_indices,
             metadata.paged_kv_last_page_len,
@@ -323,6 +391,31 @@ class DecodeAclGraphRunner(BaseRunner):
             padded_batch_size,
         )
         self._fill_host_metadata(entry, metadata, batch_size)
+
+        if input_embedding is not None:
+            if input_embedding.shape[0] != batch_size:
+                raise ValueError(
+                    "ACL graph input_embedding token count must match input_ids"
+                )
+            if entry.static_input_embedding is None:
+                entry.static_input_embedding = torch.zeros(
+                    entry.batch_size,
+                    input_embedding.shape[-1],
+                    dtype=input_embedding.dtype,
+                    device=input_embedding.device,
+                )
+            elif (
+                entry.static_input_embedding.shape[1:]
+                != input_embedding.shape[1:]
+            ):
+                raise ValueError(
+                    "ACL graph input_embedding shape changed for a graph bucket"
+                )
+            entry.static_input_embedding[:batch_size].copy_(input_embedding)
+            if entry.batch_size > batch_size:
+                entry.static_input_embedding[batch_size:].zero_()
+        elif entry.static_input_embedding is not None:
+            entry.static_input_embedding.zero_()
 
         if (
             metadata.block_table is not None
@@ -339,97 +432,41 @@ class DecodeAclGraphRunner(BaseRunner):
             if padded_batch_size > batch_size:
                 static_metadata.block_table[batch_size:].zero_()
 
+        # Padded lanes must remain valid inputs for sparse MLA tiling.  Their
+        # token and slot mapping are dummy values, so one KV token is safe.
+        if padded_batch_size > batch_size:
+            entry.kv_seq_lens_delta[batch_size:].fill_(1)
+
     def _fill_host_metadata(
         self,
         entry: _DecodeGraphEntry,
         metadata: AttentionMetadata,
         batch_size: int,
     ) -> None:
-        cumulative_seq_lens = metadata.kv_seq_lens_host
-        if cumulative_seq_lens is None:
+        kv_seq_lens = metadata.kv_seq_lens_host
+        if kv_seq_lens is None:
             raise RuntimeError("decode ACL graph requires host KV lengths")
-        cumulative_seq_lens = cumulative_seq_lens.cpu()
-        if cumulative_seq_lens.numel() == batch_size:
-            cum = torch.zeros(
-                batch_size + 1,
-                dtype=cumulative_seq_lens.dtype,
-                device=cumulative_seq_lens.device,
-            )
-            cum[1:] = torch.cumsum(cumulative_seq_lens, dim=0)
-            cumulative_seq_lens = cum
-        if cumulative_seq_lens.numel() != batch_size + 1:
+        kv_seq_lens = kv_seq_lens.cpu()
+        if kv_seq_lens.numel() != batch_size:
             raise RuntimeError(
-                "decode ACL graph requires cumulative host KV lengths"
+                "decode ACL graph requires per-sequence host KV lengths"
             )
 
         padded_batch_size = entry.batch_size
         static_metadata = entry.static_metadata
-        torch.sub(
-            cumulative_seq_lens[1:],
-            cumulative_seq_lens[:-1],
-            out=entry.host_seq_lens[:batch_size],
-        )
+        static_metadata.kv_seq_lens_host[:batch_size].copy_(kv_seq_lens)
         if padded_batch_size > batch_size:
-            entry.host_seq_lens[batch_size:padded_batch_size].fill_(1)
-        torch.cumsum(
-            entry.host_seq_lens,
-            dim=0,
-            out=static_metadata.kv_seq_lens_host[1:],
-        )
-
-        page_size = self.attention_backend.page_size
-        if page_size == 1:
-            static_metadata.paged_kv_indptr_host[: batch_size + 1].copy_(
-                cumulative_seq_lens
-            )
-            static_metadata.paged_kv_last_page_len_host.fill_(1)
-        else:
-            torch.add(
-                entry.host_seq_lens,
-                page_size - 1,
-                out=entry.host_block_counts,
-            )
-            torch.div(
-                entry.host_block_counts,
-                page_size,
-                rounding_mode="floor",
-                out=entry.host_block_counts,
-            )
-            torch.cumsum(
-                entry.host_block_counts,
-                dim=0,
-                out=static_metadata.paged_kv_indptr_host[1:],
-            )
-            torch.sub(
-                entry.host_seq_lens,
-                1,
-                out=static_metadata.paged_kv_last_page_len_host,
-            )
-            torch.remainder(
-                static_metadata.paged_kv_last_page_len_host,
-                page_size,
-                out=static_metadata.paged_kv_last_page_len_host,
-            )
-            torch.add(
-                static_metadata.paged_kv_last_page_len_host,
-                1,
-                out=static_metadata.paged_kv_last_page_len_host,
-            )
-            if padded_batch_size > batch_size:
-                static_metadata.paged_kv_last_page_len_host[
-                    batch_size:padded_batch_size
-                ].fill_(1)
-
-        if page_size == 1 and padded_batch_size > batch_size:
-            static_metadata.paged_kv_indptr_host[
-                batch_size + 1 : padded_batch_size + 1
-            ].fill_(int(cumulative_seq_lens[-1]))
+            static_metadata.kv_seq_lens_host[batch_size:].fill_(1)
 
     def _capture(self, entry: _DecodeGraphEntry) -> None:
-        context = ForwardContext(self.attention_backend, self.device)
+        context = ForwardContext(
+            self.attention_backend,
+            self.device,
+            execution_state=entry.execution_state,
+        )
         with forward_context(context):
             for _ in range(_CAPTURE_WARMUP_STEPS):
-                self.model(entry.static_input_ids, entry.static_positions)
+                self._forward_static(entry)
         torch.npu.synchronize()
         entry.graph = torch.npu.NPUGraph()
         capture_context = AclGraphCaptureContext(self._stream, [])
@@ -437,13 +474,21 @@ class DecodeAclGraphRunner(BaseRunner):
             self.attention_backend,
             self.device,
             acl_graph=capture_context,
+            execution_state=entry.execution_state,
         )
         with forward_context(context):
             with torch.npu.graph(entry.graph, stream=self._stream):
-                entry.static_output = self.model(
-                    entry.static_input_ids, entry.static_positions
-                )
+                entry.static_output = self._forward_static(entry)
         entry.graph_tasks = capture_context.tasks
+
+    def _forward_static(self, entry: _DecodeGraphEntry) -> torch.Tensor:
+        if entry.static_input_embedding is None:
+            return self.model(entry.static_input_ids, entry.static_positions)
+        return self.model(
+            entry.static_input_ids,
+            entry.static_positions,
+            entry.static_input_embedding,
+        )
 
     @staticmethod
     def _update_graph_tasks(

--- a/xllm/python/model_executor/runners/decode_acl_graph.py
+++ b/xllm/python/model_executor/runners/decode_acl_graph.py
@@ -37,6 +37,10 @@ import torch.nn as nn
 
 from xllm.python import kernels
 from xllm.python.attention.backend import AttentionBackend, AttentionMetadata
+from xllm.python.attention.expanded_decode_metadata import (
+    ExpandedDecodeMetadata,
+    resolve_expanded_decode_metadata,
+)
 from xllm.python.model_executor.forward_context import (
     AclGraphCaptureContext,
     AclGraphExecutionState,
@@ -61,10 +65,12 @@ class _StaticAttentionMetadata:
     q_cu_seq_lens: torch.Tensor | None = None
     kv_cu_seq_lens: torch.Tensor | None = None
     kv_seq_lens_host: torch.Tensor | None = None
+    kv_seq_lens_host_values: list[int] | None = None
     paged_kv_indptr_host: torch.Tensor | None = None
     paged_kv_last_page_len_host: torch.Tensor | None = None
     block_table: torch.Tensor | None = None
     kv_seq_lens: torch.Tensor | None = None
+    expanded_decode_metadata: ExpandedDecodeMetadata | None = None
     is_prefill: bool = False
     is_chunked_prefill: bool = False
 
@@ -86,6 +92,7 @@ class _DecodeGraphEntry:
 
 _GraphKey = tuple[
     int,
+    bool,
     torch.dtype | None,
     torch.device | None,
     tuple[int, ...] | None,
@@ -120,12 +127,237 @@ class DecodeAclGraphRunner(BaseRunner):
         metadata: AttentionMetadata,
         input_embedding: torch.Tensor | None = None,
     ) -> bool:
-        batch_size = input_ids.shape[0]
+        if input_ids.dim() != 1:
+            return False
+        batch_size = input_ids.numel()
         bucket_size = _decode_bucket(batch_size)
+        is_expanded_spec_verify = (
+            resolve_expanded_decode_metadata(metadata) is not None
+        )
         return (
-            not metadata.is_prefill
-            and not metadata.is_chunked_prefill
+            (
+                (not metadata.is_prefill and not metadata.is_chunked_prefill)
+                or is_expanded_spec_verify
+            )
+            and self._has_compatible_decode_metadata(input_ids, metadata)
+            and (
+                input_embedding is None
+                or input_embedding.shape[0] == batch_size
+            )
             and bucket_size <= self.max_batch
+        )
+
+    def _decode_metadata(
+        self, metadata: AttentionMetadata
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        list[int] | None,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+    ]:
+        """Return per-row KV and paging metadata for decode graph replay."""
+        expanded = resolve_expanded_decode_metadata(
+            metadata, block_size=self.attention_backend.page_size
+        )
+        block_table = (
+            expanded.block_table if expanded is not None else metadata.block_table
+        )
+        kv_seq_lens = (
+            expanded.kv_seq_lens if expanded is not None else metadata.kv_seq_lens
+        )
+        kv_seq_lens_host_values = (
+            expanded.kv_seq_lens_host_values
+            if expanded is not None
+            else getattr(metadata, "kv_seq_lens_host_values", None)
+        )
+        if block_table is None or kv_seq_lens is None:
+            raise RuntimeError("decode graph requires block and KV metadata")
+        block_table = block_table.to(torch.int32)
+        kv_seq_lens = kv_seq_lens.to(torch.int32)
+        is_mla = getattr(self.attention_backend, "is_mla", False)
+        if kv_seq_lens_host_values is None and not is_mla:
+            raise RuntimeError(
+                "decode graph requires scheduler-provided host KV lengths"
+            )
+
+        paged_kv_indptr = (
+            expanded.paged_kv_indptr
+            if expanded is not None
+            else metadata.paged_kv_indptr
+        )
+        paged_kv_indices = (
+            expanded.paged_kv_indices
+            if expanded is not None
+            else metadata.paged_kv_indices
+        )
+        paged_kv_last_page_len = (
+            expanded.paged_kv_last_page_len
+            if expanded is not None
+            else metadata.paged_kv_last_page_len
+        )
+        if (
+            paged_kv_indptr is None
+            or paged_kv_indices is None
+            or paged_kv_last_page_len is None
+        ):
+            raise RuntimeError("decode graph requires paged KV metadata")
+        self._validate_decode_metadata_shapes(
+            block_table,
+            kv_seq_lens,
+            kv_seq_lens_host_values,
+            paged_kv_indptr,
+            paged_kv_indices,
+            paged_kv_last_page_len,
+        )
+        return (
+            block_table,
+            kv_seq_lens,
+            kv_seq_lens_host_values,
+            paged_kv_indptr,
+            paged_kv_indices,
+            paged_kv_last_page_len,
+        )
+
+    @staticmethod
+    def _validate_decode_metadata_shapes(
+        block_table: torch.Tensor,
+        kv_seq_lens: torch.Tensor,
+        kv_seq_lens_host_values: list[int] | None,
+        paged_kv_indptr: torch.Tensor,
+        paged_kv_indices: torch.Tensor,
+        paged_kv_last_page_len: torch.Tensor,
+    ) -> None:
+        if block_table.dim() != 2:
+            raise RuntimeError("decode block_table must be two-dimensional")
+        sequence_count = block_table.shape[0]
+        per_sequence_tensors = (
+            ("kv_seq_lens", kv_seq_lens),
+            ("paged_kv_last_page_len", paged_kv_last_page_len),
+        )
+        for name, tensor in per_sequence_tensors:
+            if tensor.dim() != 1 or tensor.numel() != sequence_count:
+                raise RuntimeError(
+                    f"decode {name} must contain one value per sequence"
+                )
+        if (
+            kv_seq_lens_host_values is not None
+            and len(kv_seq_lens_host_values) != sequence_count
+        ):
+            raise RuntimeError(
+                "decode kv_seq_lens_host_values must contain one value per "
+                "sequence"
+            )
+        if (
+            paged_kv_indptr.dim() != 1
+            or paged_kv_indptr.numel() != sequence_count + 1
+        ):
+            raise RuntimeError(
+                "decode paged_kv_indptr must contain one offset per sequence "
+                "plus the terminal offset"
+            )
+        if paged_kv_indices.dim() != 1 or paged_kv_indices.numel() == 0:
+            raise RuntimeError(
+                "decode paged_kv_indices must be a non-empty flat page list"
+            )
+
+    @staticmethod
+    def _validate_decode_token_layout(
+        input_ids: torch.Tensor,
+        positions: torch.Tensor | None,
+        slot_mapping: torch.Tensor,
+        sequence_count: int,
+    ) -> None:
+        if input_ids.dim() != 1 or input_ids.numel() != sequence_count:
+            raise RuntimeError(
+                "ACL graph decode input_ids must contain one token per sequence"
+            )
+        if slot_mapping.dim() != 1 or slot_mapping.numel() != sequence_count:
+            raise RuntimeError(
+                "ACL graph decode slot_mapping must contain one slot per token"
+            )
+        if positions is not None and (
+            positions.dim() != 1 or positions.numel() != sequence_count
+        ):
+            raise RuntimeError(
+                "ACL graph decode positions must contain one value per token"
+            )
+
+    def _has_compatible_decode_metadata(
+        self,
+        input_ids: torch.Tensor,
+        metadata: AttentionMetadata,
+    ) -> bool:
+        """Check the one-token-per-sequence contract of ACL decode graphs."""
+        try:
+            (
+                block_table,
+                _,
+                _,
+                _,
+                _,
+                _,
+            ) = self._decode_metadata(metadata)
+            self._validate_decode_token_layout(
+                input_ids,
+                None,
+                metadata.slot_mapping,
+                block_table.shape[0],
+            )
+        except (RuntimeError, ValueError):
+            return False
+        batch_size = input_ids.numel()
+        is_expanded = resolve_expanded_decode_metadata(metadata) is not None
+        if not is_expanded and metadata.kv_cu_seq_lens is not None:
+            if metadata.kv_cu_seq_lens.numel() not in (
+                batch_size,
+                batch_size + 1,
+            ):
+                return False
+        if metadata.q_cu_seq_lens is not None and not is_expanded:
+            if metadata.q_cu_seq_lens.numel() not in (
+                batch_size,
+                batch_size + 1,
+            ):
+                return False
+        return True
+
+    @staticmethod
+    def _cumulative_lengths(
+        sequence_lengths: torch.Tensor,
+        cumulative_lengths: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """Normalize NPU sequence ends to a cumulative tensor with a zero."""
+        batch_size = sequence_lengths.numel()
+        if cumulative_lengths is None:
+            return torch.cat(
+                (
+                    torch.zeros(
+                        1,
+                        dtype=torch.int32,
+                        device=sequence_lengths.device,
+                    ),
+                    torch.cumsum(sequence_lengths, dim=0),
+                )
+            )
+        cumulative_lengths = cumulative_lengths.to(torch.int32)
+        if cumulative_lengths.numel() == batch_size + 1:
+            return cumulative_lengths
+        if cumulative_lengths.numel() == batch_size:
+            return torch.cat(
+                (
+                    torch.zeros(
+                        1,
+                        dtype=torch.int32,
+                        device=cumulative_lengths.device,
+                    ),
+                    cumulative_lengths,
+                )
+            )
+        raise RuntimeError(
+            "cumulative sequence lengths must contain either one value per "
+            "sequence or a leading zero plus one value per sequence"
         )
 
     def warmup(
@@ -167,6 +399,7 @@ class DecodeAclGraphRunner(BaseRunner):
                 kv_seq_lens_host=torch.full(
                     (batch_size,), 2, dtype=torch.int32, device="cpu"
                 ),
+                kv_seq_lens_host_values=[2] * batch_size,
                 kv_cu_seq_lens=torch.arange(
                     batch_size + 1, dtype=torch.int32, device=device
                 ).mul_(2),
@@ -199,7 +432,10 @@ class DecodeAclGraphRunner(BaseRunner):
         if padded_batch_size > self.max_batch:
             raise ValueError("decode batch exceeds ACL graph capacity")
 
-        graph_key = self._graph_key(padded_batch_size, input_embedding)
+        is_expanded = resolve_expanded_decode_metadata(metadata) is not None
+        graph_key = self._graph_key(
+            padded_batch_size, is_expanded, input_embedding
+        )
         entry = self._graphs.get(graph_key)
         first_capture = entry is None
         if first_capture:
@@ -257,13 +493,15 @@ class DecodeAclGraphRunner(BaseRunner):
     @staticmethod
     def _graph_key(
         padded_batch_size: int,
+        is_expanded: bool,
         input_embedding: torch.Tensor | None,
     ) -> _GraphKey:
-        """Return the capture shape key, including the MTP input path."""
+        """Return the key for a shape- and metadata-specific graph."""
         if input_embedding is None:
-            return padded_batch_size, None, None, None
+            return padded_batch_size, is_expanded, None, None, None
         return (
             padded_batch_size,
+            is_expanded,
             input_embedding.dtype,
             input_embedding.device,
             tuple(input_embedding.shape[1:]),
@@ -277,6 +515,14 @@ class DecodeAclGraphRunner(BaseRunner):
         metadata: AttentionMetadata,
     ) -> _DecodeGraphEntry:
         device = input_ids.device
+        (
+            _,
+            _,
+            _,
+            paged_kv_indptr,
+            paged_kv_indices,
+            paged_kv_last_page_len,
+        ) = self._decode_metadata(metadata)
         if self._paged_kv_indices_buffer is None:
             page_size = self.attention_backend.page_size
             max_blocks_per_sequence = (
@@ -284,7 +530,7 @@ class DecodeAclGraphRunner(BaseRunner):
             ) // page_size
             self._paged_kv_indices_buffer = torch.zeros(
                 self.max_batch * max_blocks_per_sequence,
-                dtype=metadata.paged_kv_indices.dtype,
+                dtype=paged_kv_indices.dtype,
                 device=device,
             )
             self._max_blocks_per_sequence = max_blocks_per_sequence
@@ -317,13 +563,13 @@ class DecodeAclGraphRunner(BaseRunner):
             ),
             paged_kv_indptr=torch.zeros(
                 padded_batch_size + 1,
-                dtype=metadata.paged_kv_indptr.dtype,
+                dtype=paged_kv_indptr.dtype,
                 device=device,
             ),
             paged_kv_indices=self._paged_kv_indices_buffer,
             paged_kv_last_page_len=torch.zeros(
                 padded_batch_size,
-                dtype=metadata.paged_kv_last_page_len.dtype,
+                dtype=paged_kv_last_page_len.dtype,
                 device=device,
             ),
             kv_cu_seq_lens=torch.zeros(
@@ -337,17 +583,35 @@ class DecodeAclGraphRunner(BaseRunner):
             paged_kv_last_page_len_host=torch.ones(
                 padded_batch_size, dtype=torch.int32, device="cpu"
             ),
-            kv_seq_lens_host=torch.zeros(
-                padded_batch_size, dtype=torch.int32, device="cpu"
-            ),
+            kv_seq_lens_host_values=[1] * padded_batch_size,
             block_table=static_block_table,
         )
+        is_expanded = resolve_expanded_decode_metadata(metadata) is not None
         entry.kv_seq_lens_delta = torch.empty(
             padded_batch_size, dtype=torch.int32, device=device
         )
         # The graph metadata update writes per-sequence KV lengths into this
         # buffer.  MLA/SFA consumes the same stable buffer as its key lengths.
         entry.static_metadata.kv_seq_lens = entry.kv_seq_lens_delta
+        if is_expanded:
+            entry.static_metadata.expanded_decode_metadata = (
+                ExpandedDecodeMetadata(
+                    kv_seq_lens=entry.kv_seq_lens_delta,
+                    block_table=entry.static_metadata.block_table,
+                    paged_kv_indptr=entry.static_metadata.paged_kv_indptr,
+                    paged_kv_indices=entry.static_metadata.paged_kv_indices,
+                    paged_kv_last_page_len=(
+                        entry.static_metadata.paged_kv_last_page_len
+                    ),
+                    paged_attention_tiling_data=None,
+                    kv_seq_lens_host=None,
+                    kv_seq_lens_host_values=(
+                        None
+                        if getattr(self.attention_backend, "is_mla", False)
+                        else entry.static_metadata.kv_seq_lens_host_values
+                    ),
+                )
+            )
         return entry
 
     def _fill_entry(
@@ -361,25 +625,38 @@ class DecodeAclGraphRunner(BaseRunner):
     ) -> None:
         padded_batch_size = entry.batch_size
         static_metadata = entry.static_metadata
-        if metadata.kv_seq_lens is None and metadata.kv_cu_seq_lens is None:
+        (
+            block_table,
+            kv_seq_lens,
+            kv_seq_lens_host_values,
+            paged_kv_indptr,
+            paged_kv_indices,
+            paged_kv_last_page_len,
+        ) = self._decode_metadata(metadata)
+        if batch_size != block_table.shape[0]:
             raise RuntimeError(
-                "decode ACL graph requires device KV lengths"
+                "ACL graph decode batch size must match metadata sequences"
             )
-        cumulative_kv_seq_lens = metadata.kv_cu_seq_lens
-        if cumulative_kv_seq_lens is None:
-            raise RuntimeError(
-                "decode ACL graph requires C++ cumulative KV lengths"
-            )
-        cumulative_kv_seq_lens = cumulative_kv_seq_lens.to(torch.int32)
+        self._validate_decode_token_layout(
+            input_ids,
+            positions,
+            metadata.slot_mapping,
+            block_table.shape[0],
+        )
+        is_expanded = resolve_expanded_decode_metadata(metadata) is not None
+        cumulative_kv_seq_lens = self._cumulative_lengths(
+            kv_seq_lens,
+            None if is_expanded else metadata.kv_cu_seq_lens,
+        )
         graph_positions = positions.to(torch.int32).contiguous()
         kernels.update_decode_graph_metadata(
             input_ids,
             graph_positions,
             metadata.slot_mapping,
             cumulative_kv_seq_lens,
-            metadata.paged_kv_indptr,
-            metadata.paged_kv_indices,
-            metadata.paged_kv_last_page_len,
+            paged_kv_indptr,
+            paged_kv_indices,
+            paged_kv_last_page_len,
             entry.static_input_ids,
             entry.static_positions,
             static_metadata.slot_mapping,
@@ -390,7 +667,9 @@ class DecodeAclGraphRunner(BaseRunner):
             static_metadata.paged_kv_last_page_len,
             padded_batch_size,
         )
-        self._fill_host_metadata(entry, metadata, batch_size)
+        self._fill_host_metadata(
+            entry, kv_seq_lens_host_values, batch_size
+        )
 
         if input_embedding is not None:
             if input_embedding.shape[0] != batch_size:
@@ -417,11 +696,8 @@ class DecodeAclGraphRunner(BaseRunner):
         elif entry.static_input_embedding is not None:
             entry.static_input_embedding.zero_()
 
-        if (
-            metadata.block_table is not None
-            and static_metadata.block_table is not None
-        ):
-            src_bt = metadata.block_table.to(torch.int32)
+        if static_metadata.block_table is not None:
+            src_bt = block_table
             copy_cols = min(
                 src_bt.shape[1],
                 static_metadata.block_table.shape[1],
@@ -440,23 +716,30 @@ class DecodeAclGraphRunner(BaseRunner):
     def _fill_host_metadata(
         self,
         entry: _DecodeGraphEntry,
-        metadata: AttentionMetadata,
+        kv_seq_lens: list[int] | None,
         batch_size: int,
     ) -> None:
-        kv_seq_lens = metadata.kv_seq_lens_host
+        if getattr(self.attention_backend, "is_mla", False):
+            return
         if kv_seq_lens is None:
-            raise RuntimeError("decode ACL graph requires host KV lengths")
-        kv_seq_lens = kv_seq_lens.cpu()
-        if kv_seq_lens.numel() != batch_size:
+            raise RuntimeError(
+                "decode ACL graph requires scheduler-provided host KV lengths"
+            )
+        if len(kv_seq_lens) != batch_size:
             raise RuntimeError(
                 "decode ACL graph requires per-sequence host KV lengths"
             )
 
         padded_batch_size = entry.batch_size
         static_metadata = entry.static_metadata
-        static_metadata.kv_seq_lens_host[:batch_size].copy_(kv_seq_lens)
+        static_kv_seq_lens = static_metadata.kv_seq_lens_host_values
+        if static_kv_seq_lens is None:
+            raise RuntimeError("decode ACL graph host KV buffer is missing")
+        static_kv_seq_lens[:batch_size] = kv_seq_lens
         if padded_batch_size > batch_size:
-            static_metadata.kv_seq_lens_host[batch_size:].fill_(1)
+            static_kv_seq_lens[batch_size:] = [1] * (
+                padded_batch_size - batch_size
+            )
 
     def _capture(self, entry: _DecodeGraphEntry) -> None:
         context = ForwardContext(

--- a/xllm/python/model_executor/runners/decode_cuda_graph.py
+++ b/xllm/python/model_executor/runners/decode_cuda_graph.py
@@ -90,10 +90,14 @@ class DecodeCudaGraphRunner(BaseRunner):
         self._warmed_up = False
 
     def can_execute(
-        self, input_ids: torch.Tensor, metadata: AttentionMetadata
+        self,
+        input_ids: torch.Tensor,
+        metadata: AttentionMetadata,
+        input_embedding: torch.Tensor | None = None,
     ) -> bool:
         return (
-            not metadata.is_prefill
+            input_embedding is None
+            and not metadata.is_prefill
             and not metadata.is_chunked_prefill
             and _decode_bucket(input_ids.shape[0]) <= self.max_batch
         )
@@ -137,6 +141,7 @@ class DecodeCudaGraphRunner(BaseRunner):
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         metadata: AttentionMetadata,
+        input_embedding: torch.Tensor | None = None,
     ) -> torch.Tensor:
         batch_size = input_ids.shape[0]
         padded_batch_size = _decode_bucket(batch_size)

--- a/xllm/python/model_executor/runners/decode_cuda_graph.py
+++ b/xllm/python/model_executor/runners/decode_cuda_graph.py
@@ -102,7 +102,12 @@ class DecodeCudaGraphRunner(BaseRunner):
             and _decode_bucket(input_ids.shape[0]) <= self.max_batch
         )
 
-    def warmup(self, device: torch.device, _dtype: torch.dtype) -> None:
+    def warmup(
+        self,
+        device: torch.device,
+        _dtype: torch.dtype,
+        _input_embedding: torch.Tensor | None = None,
+    ) -> None:
         if self._warmed_up:
             return
         self._warmed_up = True

--- a/xllm/python/model_executor/runners/decode_cuda_graph.py
+++ b/xllm/python/model_executor/runners/decode_cuda_graph.py
@@ -109,11 +109,15 @@ class DecodeCudaGraphRunner(BaseRunner):
         self._warmed_up = False
 
     def can_execute(
-        self, input_ids: torch.Tensor, metadata: AttentionMetadata
+        self,
+        input_ids: torch.Tensor,
+        metadata: AttentionMetadata,
+        input_embedding: torch.Tensor | None = None,
     ) -> bool:
         graph_key = self._graph_key(input_ids, metadata)
         return (
-            not metadata.is_prefill
+            input_embedding is None
+            and not metadata.is_prefill
             and not metadata.is_chunked_prefill
             and graph_key is not None
             and graph_key in self._graphs
@@ -188,6 +192,7 @@ class DecodeCudaGraphRunner(BaseRunner):
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         metadata: AttentionMetadata,
+        input_embedding: torch.Tensor | None = None,
     ) -> torch.Tensor:
         batch_size = input_ids.shape[0]
         graph_key = self._graph_key(input_ids, metadata)

--- a/xllm/python/model_executor/runners/decode_cuda_graph.py
+++ b/xllm/python/model_executor/runners/decode_cuda_graph.py
@@ -123,7 +123,12 @@ class DecodeCudaGraphRunner(BaseRunner):
             and graph_key in self._graphs
         )
 
-    def warmup(self, device: torch.device, _dtype: torch.dtype) -> None:
+    def warmup(
+        self,
+        device: torch.device,
+        _dtype: torch.dtype,
+        _input_embedding: torch.Tensor | None = None,
+    ) -> None:
         if self._warmed_up:
             return
 

--- a/xllm/python/model_executor/runners/eager.py
+++ b/xllm/python/model_executor/runners/eager.py
@@ -31,13 +31,17 @@ class EagerRunner(BaseRunner):
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         metadata: AttentionMetadata,
+        input_embedding: torch.Tensor | None = None,
         layer_synchronizer: LayerSynchronizer | None = None,
     ) -> torch.Tensor:
         self.attention_backend.prepare(metadata)
         with forward_context(
             ForwardContext(
-                self.attention_backend, self.device,
+                self.attention_backend,
+                self.device,
                 layer_synchronizer=layer_synchronizer,
             )
         ):
-            return self.model(input_ids, positions)
+            if input_embedding is None:
+                return self.model(input_ids, positions)
+            return self.model(input_ids, positions, input_embedding)

--- a/xllm/python/model_executor/runners/eager.py
+++ b/xllm/python/model_executor/runners/eager.py
@@ -31,6 +31,7 @@ class EagerRunner(BaseRunner):
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         metadata: AttentionMetadata,
+        input_embedding: torch.Tensor | None = None,
         layer_synchronizer: LayerSynchronizer | None = None,
     ) -> torch.Tensor:
         self.attention_backend.prepare(metadata)
@@ -43,4 +44,6 @@ class EagerRunner(BaseRunner):
                 layer_synchronizer=layer_synchronizer,
             )
         ):
-            return self.model(input_ids, positions)
+            if input_embedding is None:
+                return self.model(input_ids, positions)
+            return self.model(input_ids, positions, input_embedding)

--- a/xllm/python/model_executor/runners/inductor.py
+++ b/xllm/python/model_executor/runners/inductor.py
@@ -35,13 +35,17 @@ class InductorRunner(BaseRunner):
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         metadata: AttentionMetadata,
+        input_embedding: torch.Tensor | None = None,
         layer_synchronizer: LayerSynchronizer | None = None,
     ) -> torch.Tensor:
         self.attention_backend.prepare(metadata)
         with forward_context(
             ForwardContext(
-                self.attention_backend, self.device,
+                self.attention_backend,
+                self.device,
                 layer_synchronizer=layer_synchronizer,
             )
         ):
-            return self.compiled_model(input_ids, positions)
+            if input_embedding is None:
+                return self.compiled_model(input_ids, positions)
+            return self.compiled_model(input_ids, positions, input_embedding)

--- a/xllm/python/model_executor/runners/inductor.py
+++ b/xllm/python/model_executor/runners/inductor.py
@@ -35,6 +35,7 @@ class InductorRunner(BaseRunner):
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         metadata: AttentionMetadata,
+        input_embedding: torch.Tensor | None = None,
         layer_synchronizer: LayerSynchronizer | None = None,
     ) -> torch.Tensor:
         self.attention_backend.prepare(metadata)
@@ -47,4 +48,6 @@ class InductorRunner(BaseRunner):
                 layer_synchronizer=layer_synchronizer,
             )
         ):
-            return self.compiled_model(input_ids, positions)
+            if input_embedding is None:
+                return self.compiled_model(input_ids, positions)
+            return self.compiled_model(input_ids, positions, input_embedding)

--- a/xllm/python/models/deepseek_v32.py
+++ b/xllm/python/models/deepseek_v32.py
@@ -961,7 +961,7 @@ class DeepseekV3Model(nn.Module):
 class DeepseekV3ForCausalLM(PyModelBase):
     """DeepSeek-V3.2 causal LM. Registered under ``model_type='deepseek_v32'``."""
 
-    def __init__(self, config: dict) -> None:
+    def __init__(self, config: dict, build_model: bool = True) -> None:
         super().__init__()
         self.cfg = DeepseekV3Config.from_dict(config)
         self.cfg.tp_size = int(config.get("tp_size", 1))
@@ -975,14 +975,21 @@ class DeepseekV3ForCausalLM(PyModelBase):
         self.device = device
         tp = self.cfg.tp_size
         assert self.cfg.vocab_size % tp == 0
-        self.model = DeepseekV3Model(self.cfg, dtype, device)
+        self.model: Optional[nn.Module] = None
+        self.lm_head: Optional[nn.Module] = None
+        if build_model:
+            self._build_model()
+
+    def _build_model(self) -> None:
+        tp = self.cfg.tp_size
+        self.model = DeepseekV3Model(self.cfg, self.dtype, self.device)
         self.lm_head = ColumnParallelLinear(
             self.cfg.hidden_size,
             self.cfg.vocab_size // tp,
             tp,
             gather_output=True,
-            dtype=dtype,
-            device=device,
+            dtype=self.dtype,
+            device=self.device,
         )
 
     def load_weights(
@@ -991,12 +998,18 @@ class DeepseekV3ForCausalLM(PyModelBase):
         tp_rank: int,
         tp_size: int,
         load_lm_head: bool = True,
+        load_embedding: bool = True,
     ) -> None:
         cfg = self.cfg
         loader = W8A8WeightLoader(self, state_dicts, cfg.tp_size, cfg.tp_rank)
 
-        loader.copy_in("model.embed_tokens.weight",
-                       loader.shard(loader.load_tensor("model.embed_tokens.weight"), dim=1))
+        if load_embedding:
+            loader.copy_in(
+                "model.embed_tokens.weight",
+                loader.shard(
+                    loader.load_tensor("model.embed_tokens.weight"), dim=1
+                ),
+            )
 
         for i in range(cfg.n_layers):
             p = f"model.layers.{i}."

--- a/xllm/python/models/deepseek_v32.py
+++ b/xllm/python/models/deepseek_v32.py
@@ -974,6 +974,7 @@ class DeepseekV3ForCausalLM(PyModelBase):
         state_dicts: list,
         tp_rank: int,
         tp_size: int,
+        load_lm_head: bool = True,
     ) -> None:
         cfg = self.cfg
         loader = W8A8WeightLoader(self, state_dicts, cfg.tp_size, cfg.tp_rank)
@@ -1050,5 +1051,8 @@ class DeepseekV3ForCausalLM(PyModelBase):
                 self.model.layers[i].mlp.process_weights_after_loading()
 
         loader.copy_in("model.norm.weight", loader.load_tensor("model.norm.weight"))
-        loader.copy_in("lm_head.weight",
-                       loader.shard(loader.load_tensor("lm_head.weight"), dim=0))
+        if load_lm_head:
+            loader.copy_in(
+                "lm_head.weight",
+                loader.shard(loader.load_tensor("lm_head.weight"), dim=0),
+            )

--- a/xllm/python/models/deepseek_v32.py
+++ b/xllm/python/models/deepseek_v32.py
@@ -36,7 +36,10 @@ from xllm.python.layers import (
     RotaryEmbedding,
     RowParallelLinear,
 )
-from xllm.python.model_executor.forward_context import get_forward_context
+from xllm.python.model_executor.forward_context import (
+    get_execution_buffer,
+    get_forward_context,
+)
 from xllm.python.models.base import PyModelBase
 
 
@@ -706,16 +709,29 @@ class DeepseekV3Indexer(nn.Module):
         q = torch.cat([q_pe, q_nope], dim=-1)
         k = torch.cat([k_pe, k_nope], dim=-1)
         if ctx.index_cache is not None and ctx.slot_mapping is not None:
-            k_view = ctx.index_cache.view(-1, ctx.index_cache.size(-1))
-            kernels.scatter_nd_update(
-                k_view, ctx.slot_mapping.reshape(-1, 1).clamp_min(0), k
-            )
-        topk = kernels.lightning_indexer(
+            ctx.update_index_cache(k)
+
+        key_head_num = ctx.index_cache.size(2) if ctx.index_cache.dim() >= 3 else 1
+        output_shape = (q.size(0), key_head_num, self.topk)
+        buffer_key = tuple(output_shape)
+        topk_buffer = get_execution_buffer(
+            ("LIGHTNING_INDEXER_INDICES",) + buffer_key,
+            lambda: torch.empty(
+                output_shape, dtype=torch.int32, device=q.device
+            ),
+        )
+        values_buffer = get_execution_buffer(
+            ("LIGHTNING_INDEXER_VALUES",) + buffer_key,
+            lambda: torch.empty(
+                output_shape, dtype=q.dtype, device=q.device
+            ),
+        )
+        topk = kernels.lightning_indexer_out(
             q, ctx.index_cache, weights,
             ctx.actual_seq_q, ctx.actual_seq_kv, ctx.block_table,
             "TND", "PA_BSND", self.topk, 3,
             9223372036854775807, 9223372036854775807,
-            False,
+            False, topk_buffer, values_buffer,
         )
         return topk
 

--- a/xllm/python/models/deepseek_v32_mtp.py
+++ b/xllm/python/models/deepseek_v32_mtp.py
@@ -1,0 +1,174 @@
+# Copyright 2026 The xLLM Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://github.com/jd-opensource/xllm/blob/main/LICENSE
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DeepSeek-V3.2 MTP model graph.
+
+The speculative worker and MTP scheduling remain in C++.  This module only
+describes the MTP model computation.  In particular, ``input_embedding`` is
+the hidden state produced by the target model and supplied by the caller for
+the next MTP step.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+import torch
+import torch.nn as nn
+
+from xllm.python.layers import ColumnParallelLinear, HiddenParallelEmbedding, RMSNorm
+from xllm.python.models.deepseek_v32 import (
+    DeepseekV3Config,
+    DeepseekV3DecoderLayer,
+    DeepseekV3ForCausalLM,
+)
+
+
+class DeepseekV32MtpModel(nn.Module):
+    """MTP body matching ``MtpModelImplBase`` and ``DeepseekV32MtpModel``."""
+
+    def __init__(
+        self, cfg: DeepseekV3Config, dtype: torch.dtype, device: torch.device
+    ) -> None:
+        super().__init__()
+        tp = cfg.tp_size
+        assert cfg.hidden_size % tp == 0
+
+        self.cfg = cfg
+        self.embed_tokens = HiddenParallelEmbedding(
+            cfg.vocab_size,
+            cfg.hidden_size // tp,
+            tp,
+            dtype=dtype,
+            device=device,
+        )
+        self.eh_proj = ColumnParallelLinear(
+            2 * cfg.hidden_size,
+            cfg.hidden_size // tp,
+            tp,
+            gather_output=True,
+            dtype=dtype,
+            device=device,
+        )
+        self.rot = ColumnParallelLinear(
+            cfg.hidden_size,
+            cfg.hidden_size // tp,
+            tp,
+            gather_output=True,
+            dtype=dtype,
+            device=device,
+        )
+        self.enorm = RMSNorm(cfg.hidden_size, cfg.rms_norm_eps, dtype, device)
+        self.hnorm = RMSNorm(cfg.hidden_size, cfg.rms_norm_eps, dtype, device)
+        self.layers = nn.ModuleList(
+            [
+                DeepseekV3DecoderLayer(cfg, i, dtype, device)
+                for i in range(cfg.n_layers)
+            ]
+        )
+        self.norm = RMSNorm(cfg.hidden_size, cfg.rms_norm_eps, dtype, device)
+        self.enable_rot = False
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        input_embedding: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        token_hidden = self.embed_tokens(input_ids)
+        if input_embedding is None:
+            input_embedding = token_hidden
+
+        rotated_embedding = (
+            self.rot(input_embedding) if self.enable_rot else input_embedding
+        )
+        h = self.eh_proj(
+            torch.cat((self.enorm(token_hidden), self.hnorm(rotated_embedding)), dim=-1)
+        )
+        positions = positions.to(torch.int64).contiguous()
+        residual: Optional[torch.Tensor] = None
+        for layer in self.layers:
+            h, residual = layer(h, residual, positions)
+        h, _ = self.norm(h, residual)
+        return h
+
+
+class _MtpStateDictView:
+    """Add aliases for the two MTP checkpoint naming conventions."""
+
+    def __init__(self, state_dict: object) -> None:
+        self._state_dict = state_dict
+
+    @staticmethod
+    def _aliases(name: str) -> Iterable[str]:
+        if name == "model.norm.weight":
+            yield "model.norm.weight"
+            yield "model.final_norm.weight"
+            yield "model.shared_head.norm.weight"
+            yield "shared_head.norm.weight"
+            return
+        yield name
+        if name.startswith("model."):
+            yield name[len("model.") :]
+        else:
+            yield "model." + name
+
+    def has(self, name: str) -> bool:
+        return any(self._state_dict.has(alias) for alias in self._aliases(name))
+
+    def get_tensor(self, name: str) -> torch.Tensor:
+        for alias in self._aliases(name):
+            if self._state_dict.has(alias):
+                return self._state_dict.get_tensor(alias)
+        raise KeyError(name)
+
+
+class DeepseekV32MtpForCausalLM(DeepseekV3ForCausalLM):
+    """DeepSeek-V3.2 MTP calculator; scheduling stays in the C++ worker."""
+
+    def __init__(self, config: dict) -> None:
+        super().__init__(config)
+        self.model = DeepseekV32MtpModel(self.cfg, self.dtype, self.device)
+
+    def load_weights(self, state_dicts: list, tp_rank: int, tp_size: int) -> None:
+        views = [_MtpStateDictView(state_dict) for state_dict in state_dicts]
+        super().load_weights(views, tp_rank, tp_size, load_lm_head=False)
+
+        def find(name: str):
+            for state_dict in views:
+                if state_dict.has(name):
+                    return state_dict
+            return None
+
+        def copy_if_present(module_name: str, *aliases: str) -> bool:
+            state_dict = find(module_name + ".weight")
+            if state_dict is None:
+                for alias in aliases:
+                    state_dict = find(alias + ".weight")
+                    if state_dict is not None:
+                        break
+            if state_dict is None:
+                return False
+            tensor = state_dict.get_tensor(module_name + ".weight")
+            parameter = self.get_parameter("model." + module_name + ".weight")
+            if tensor.shape != parameter.shape and tensor.dim() == 2:
+                part = tensor.shape[0] // self.cfg.tp_size
+                tensor = tensor.narrow(0, self.cfg.tp_rank * part, part)
+            parameter.data.copy_(tensor.to(dtype=parameter.dtype, device=parameter.device))
+            return True
+
+        copy_if_present("eh_proj")
+        copy_if_present("enorm")
+        copy_if_present("hnorm")
+        self.model.enable_rot = copy_if_present("rot")

--- a/xllm/python/models/deepseek_v32_mtp.py
+++ b/xllm/python/models/deepseek_v32_mtp.py
@@ -27,11 +27,12 @@ from typing import Iterable, Optional
 import torch
 import torch.nn as nn
 
-from xllm.python.layers import ColumnParallelLinear, HiddenParallelEmbedding, RMSNorm
+from xllm.python.layers import ColumnParallelLinear, RMSNorm
 from xllm.python.models.deepseek_v32 import (
     DeepseekV3Config,
     DeepseekV3DecoderLayer,
     DeepseekV3ForCausalLM,
+    DeepseekYarnRotaryEmbedding,
 )
 
 
@@ -46,13 +47,7 @@ class DeepseekV32MtpModel(nn.Module):
         assert cfg.hidden_size % tp == 0
 
         self.cfg = cfg
-        self.embed_tokens = HiddenParallelEmbedding(
-            cfg.vocab_size,
-            cfg.hidden_size // tp,
-            tp,
-            dtype=dtype,
-            device=device,
-        )
+        self.embed_tokens: Optional[nn.Module] = None
         self.eh_proj = ColumnParallelLinear(
             2 * cfg.hidden_size,
             cfg.hidden_size // tp,
@@ -78,6 +73,18 @@ class DeepseekV32MtpModel(nn.Module):
             ]
         )
         self.norm = RMSNorm(cfg.hidden_size, cfg.rms_norm_eps, dtype, device)
+        self.rotary = DeepseekYarnRotaryEmbedding(
+            cfg.qk_rope_head_dim,
+            cfg.original_max_position_embeddings,
+            cfg.rope_scaling_factor,
+            cfg.rope_theta,
+            cfg.rope_beta_fast,
+            cfg.rope_beta_slow,
+            cfg.rope_mscale,
+            cfg.rope_mscale_all_dim,
+            dtype=dtype,
+            device=device,
+        )
         self.enable_rot = False
 
     def forward(
@@ -86,6 +93,7 @@ class DeepseekV32MtpModel(nn.Module):
         positions: torch.Tensor,
         input_embedding: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        assert self.embed_tokens is not None
         token_hidden = self.embed_tokens(input_ids)
         if input_embedding is None:
             input_embedding = token_hidden
@@ -97,9 +105,10 @@ class DeepseekV32MtpModel(nn.Module):
             torch.cat((self.enorm(token_hidden), self.hnorm(rotated_embedding)), dim=-1)
         )
         positions = positions.to(torch.int64).contiguous()
+        cos_sin_cache = self.rotary.cos_sin_cache
         residual: Optional[torch.Tensor] = None
         for layer in self.layers:
-            h, residual = layer(h, residual, positions)
+            h, residual = layer(h, residual, positions, cos_sin_cache)
         h, _ = self.norm(h, residual)
         return h
 
@@ -138,12 +147,18 @@ class DeepseekV32MtpForCausalLM(DeepseekV3ForCausalLM):
     """DeepSeek-V3.2 MTP calculator; scheduling stays in the C++ worker."""
 
     def __init__(self, config: dict) -> None:
-        super().__init__(config)
+        super().__init__(config, build_model=False)
         self.model = DeepseekV32MtpModel(self.cfg, self.dtype, self.device)
 
     def load_weights(self, state_dicts: list, tp_rank: int, tp_size: int) -> None:
         views = [_MtpStateDictView(state_dict) for state_dict in state_dicts]
-        super().load_weights(views, tp_rank, tp_size, load_lm_head=False)
+        super().load_weights(
+            views,
+            tp_rank,
+            tp_size,
+            load_lm_head=False,
+            load_embedding=False,
+        )
 
         def find(name: str):
             for state_dict in views:
@@ -151,7 +166,9 @@ class DeepseekV32MtpForCausalLM(DeepseekV3ForCausalLM):
                     return state_dict
             return None
 
-        def copy_if_present(module_name: str, *aliases: str) -> bool:
+        def copy_if_present(
+            module_name: str, *aliases: str, required: bool = False
+        ) -> bool:
             state_dict = find(module_name + ".weight")
             if state_dict is None:
                 for alias in aliases:
@@ -159,6 +176,10 @@ class DeepseekV32MtpForCausalLM(DeepseekV3ForCausalLM):
                     if state_dict is not None:
                         break
             if state_dict is None:
+                if required:
+                    raise KeyError(
+                        f"missing required MTP weight: {module_name}.weight"
+                    )
                 return False
             tensor = state_dict.get_tensor(module_name + ".weight")
             parameter = self.get_parameter("model." + module_name + ".weight")
@@ -168,7 +189,7 @@ class DeepseekV32MtpForCausalLM(DeepseekV3ForCausalLM):
             parameter.data.copy_(tensor.to(dtype=parameter.dtype, device=parameter.device))
             return True
 
-        copy_if_present("eh_proj")
-        copy_if_present("enorm")
-        copy_if_present("hnorm")
+        copy_if_present("eh_proj", required=True)
+        copy_if_present("enorm", required=True)
+        copy_if_present("hnorm", required=True)
         self.model.enable_rot = copy_if_present("rot")

--- a/xllm/python/registry.py
+++ b/xllm/python/registry.py
@@ -89,5 +89,9 @@ def _register_builtin_models() -> None:
         "glm_moe_dsa",
     )
 
+    from xllm.python.models.deepseek_v32_mtp import DeepseekV32MtpForCausalLM
+
+    register_model("deepseek_v32_mtp")(DeepseekV32MtpForCausalLM)
+
 
 _register_builtin_models()

--- a/xllm/python/registry.py
+++ b/xllm/python/registry.py
@@ -89,9 +89,11 @@ def _register_builtin_models() -> None:
         "glm_moe_dsa",
     )
 
-    from xllm.python.models.deepseek_v32_mtp import DeepseekV32MtpForCausalLM
-
-    register_model("deepseek_v32_mtp")(DeepseekV32MtpForCausalLM)
+    _register_model_path(
+        "xllm.python.models.deepseek_v32_mtp",
+        "DeepseekV32MtpForCausalLM",
+        "deepseek_v32_mtp",
+    )
 
 
 _register_builtin_models()

--- a/xllm/python/registry.py
+++ b/xllm/python/registry.py
@@ -77,5 +77,9 @@ def _register_builtin_models() -> None:
         "glm_moe_dsa",
     )
 
+    from xllm.python.models.deepseek_v32_mtp import DeepseekV32MtpForCausalLM
+
+    register_model("deepseek_v32_mtp")(DeepseekV32MtpForCausalLM)
+
 
 _register_builtin_models()

--- a/xllm/python/registry.py
+++ b/xllm/python/registry.py
@@ -77,9 +77,11 @@ def _register_builtin_models() -> None:
         "glm_moe_dsa",
     )
 
-    from xllm.python.models.deepseek_v32_mtp import DeepseekV32MtpForCausalLM
-
-    register_model("deepseek_v32_mtp")(DeepseekV32MtpForCausalLM)
+    _register_model_path(
+        "xllm.python.models.deepseek_v32_mtp",
+        "DeepseekV32MtpForCausalLM",
+        "deepseek_v32_mtp",
+    )
 
 
 _register_builtin_models()


### PR DESCRIPTION
## Description

This PR adds DeepSeek-V3.2 Python MTP and NPU ACLGraph support.

 The main changes include:

  - Add the DeepSeek-V3.2 MTP Python model and registry entry.
  - Share target-model embeddings and LM head with the Python MTP draft model.
  - Support multi-token MTP metadata expansion for repair/current rows.

These changes enable Python-based DeepSeek-V3.2 MTP execution with NPU ACLGraph while avoiding metadata shape mismatches during multi-request and multi-token verification.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Performance Comparision (from server log)
DeepSeek-V3.2-w8a8-MTP, ~2K input + 1K output, 10 requests
| Metric | C++ | Python ACLGraph | Delta |
|:---|---:|---:|:---|
| TTFT avg (ms) | 823.30 | 814.30 | Python 1.1% faster |
| TPOT avg (ms/token) | 30.03 | 37.69 | C++ 20.3% faster |
| Latency avg (s) | 31.546 | 39.379 | C++ 19.9% faster |
| Decode throughput (tokens/s) | 33.36 | 26.56 | C++ 25.6% faster |
