### PR TITLE
bugfix: adjust MTP batch capacity for concurrency.

### DIFF
--- a/xllm/xllm.cpp
+++ b/xllm/xllm.cpp
@@ -24,6 +24,7 @@ namespace py = pybind11;
 #include <acl/acl.h>
 #endif
 
+#include <algorithm>
 #include <csignal>
 #include <filesystem>
 #include <memory>
@@ -318,6 +319,7 @@ void validate_config(const std::string& model_type) {
   LoadConfig& load_config = LoadConfig::get_instance();
   KVCacheConfig& kv_cache_config = KVCacheConfig::get_instance();
   SchedulerConfig& scheduler_config = SchedulerConfig::get_instance();
+  ServiceConfig& service_config = ServiceConfig::get_instance();
   ParallelConfig& parallel_config = ParallelConfig::get_instance();
   DisaggPDConfig& disagg_pd_config = DisaggPDConfig::get_instance();
   SpeculativeConfig& speculative_config = SpeculativeConfig::get_instance();
@@ -412,6 +414,38 @@ void validate_config(const std::string& model_type) {
     LOG(FATAL) << "enable_rolling_load is only supported on NPU.";
   }
 #endif
+
+  const int32_t scheduler_cap = scheduler_config.max_seqs_per_batch();
+  const int32_t service_cap = service_config.max_concurrent_requests();
+  if (scheduler_cap <= 0 && service_cap <= 0) {
+    LOG(FATAL) << "Both max_seqs_per_batch and max_concurrent_requests are 0; "
+                  "set at least one to a positive value.";
+  }
+
+  const int64_t decode_rows_per_request =
+      speculative_config.num_speculative_tokens() > 0
+          ? static_cast<int64_t>(speculative_config.num_speculative_tokens()) +
+                1
+          : 1;
+  int32_t effective_service_cap = service_cap;
+  int32_t effective_scheduler_cap = scheduler_cap;
+  if (effective_service_cap <= 0) {
+    effective_service_cap = static_cast<int32_t>(
+        std::max<int64_t>(scheduler_cap / decode_rows_per_request, 1));
+  }
+
+  const int64_t required_scheduler_cap =
+      static_cast<int64_t>(effective_service_cap) * decode_rows_per_request;
+  if (effective_scheduler_cap < required_scheduler_cap) {
+    LOG(WARNING) << "Increasing max_seqs_per_batch from "
+                 << effective_scheduler_cap << " to " << required_scheduler_cap
+                 << " to cover max_concurrent_requests="
+                 << effective_service_cap
+                 << " with decode_rows_per_request=" << decode_rows_per_request;
+    effective_scheduler_cap = static_cast<int32_t>(required_scheduler_cap);
+  }
+  scheduler_config.max_seqs_per_batch(effective_scheduler_cap);
+  service_config.max_concurrent_requests(effective_service_cap);
 
   model_config.normalize_cpp_chat_template(model_type);
 }


### PR DESCRIPTION
## Description

Adjust MTP startup capacity handling to keep scheduler batch capacity consistent with service admission concurrency.

When speculative decoding is enabled, one logical request can expand into `num_speculative_tokens + 1` decode rows during target validation. If `max_concurrent_requests` is configured higher than what `max_seqs_per_batch` can cover, the service may admit more requests than the runtime batch buffer capacity, which can make the runtime validate pass produce more decode rows than the batch capacity reserved by the scheduler, leading to buffer overflow in the batch-level validation storage.

This change raises `max_seqs_per_batch` during startup validation when needed:

`required_max_seqs_per_batch = max_concurrent_requests * (num_speculative_tokens + 1)`

If `max_concurrent_requests` is unset, it is derived from the scheduler capacity as before. A warning is emitted when `max_seqs_per_batch` is increased automatically.

## Related Issues

N/A

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

Validation performed:

- `pre-commit run clang-format --files xllm/xllm.cpp` passed.
- `git diff --check` passed.
- The PR branch contains only one changed file: `xllm/xllm.cpp`.

Runtime validation was previously performed on an NPU machine with Qwen3.5-2B and Qwen3.5-2B-mtp:

- Started xLLM with `--max_concurrent_requests=35`, `--max_seqs_per_batch=120`, and `--num_speculative_tokens=3`.
- Verified startup raised `max_seqs_per_batch` from `120` to `140`.
- Sent one chat completion request successfully.
- Sent 35 concurrent chat completion requests successfully.

Full `pre-commit run --all-files` and `python setup.py build test` were not rerun for this one-file change.