### PR TITLE
refactor: manage rate-limit slot via Request RAII lifetime.

### DIFF
--- a/tests/core/common/rate_limiter_test.cpp
+++ b/tests/core/common/rate_limiter_test.cpp
@@ -7,20 +7,53 @@
 namespace xllm {
 
 TEST(RequestLimiterTest, Basic) {
-  // Set the maximum number of concurrent requests to 1.
   ServiceConfig::get_instance().max_concurrent_requests(1);
   RateLimiter rate_limiter;
-  // The current number of concurrent requests is 0, no rate limiting is
-  // applied.
-  EXPECT_EQ(rate_limiter.is_limited(), false);
-  // The current number of concurrent requests is 1, rate limiting is applied.
-  EXPECT_EQ(rate_limiter.is_limited(), true);
-  // Decrease the number of concurrent requests by one, changing the concurrency
-  // from 1 to 0.
+
+  EXPECT_FALSE(rate_limiter.is_limited());
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 1);
+
+  EXPECT_TRUE(rate_limiter.is_limited());
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 1);
+
   rate_limiter.decrease_one_request();
-  // The current number of concurrent requests is 0, no rate limiting is
-  // applied.
-  EXPECT_EQ(rate_limiter.is_limited(), false);
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 0);
+  EXPECT_FALSE(rate_limiter.is_limited());
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 1);
+
+  rate_limiter.decrease_one_request();
+}
+
+TEST(RequestLimiterTest, NoLimitWhenMaxIsZero) {
+  ServiceConfig::get_instance().max_concurrent_requests(0);
+  RateLimiter rate_limiter;
+
+  for (int i = 0; i < 100; ++i) {
+    EXPECT_FALSE(rate_limiter.is_limited());
+  }
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 100);
+
+  for (int i = 0; i < 100; ++i) {
+    rate_limiter.decrease_one_request();
+  }
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 0);
+}
+
+TEST(RequestLimiterTest, SleepBlocksAcquisition) {
+  ServiceConfig::get_instance().max_concurrent_requests(10);
+  RateLimiter rate_limiter;
+
+  EXPECT_TRUE(rate_limiter.try_set_sleeping());
+  EXPECT_TRUE(rate_limiter.is_sleeping());
+  // is_limited returns true (reject) while sleeping and does NOT change the
+  // sleep sentinel or increment anything.
+  EXPECT_TRUE(rate_limiter.is_limited());
+  EXPECT_TRUE(rate_limiter.is_sleeping());
+
+  EXPECT_TRUE(rate_limiter.try_wakeup());
+  EXPECT_FALSE(rate_limiter.is_sleeping());
+  EXPECT_FALSE(rate_limiter.is_limited());
+  rate_limiter.decrease_one_request();
 }
 
 }  // namespace xllm

--- a/tests/core/common/rate_limiter_test.cpp
+++ b/tests/core/common/rate_limiter_test.cpp
@@ -6,21 +6,52 @@
 
 namespace xllm {
 
-TEST(RequestLimiterTest, Basic) {
-  // Set the maximum number of concurrent requests to 1.
+TEST(RequestLimiterTest, CheckAndIncrement) {
   ServiceConfig::get_instance().max_concurrent_requests(1);
   RateLimiter rate_limiter;
-  // The current number of concurrent requests is 0, no rate limiting is
-  // applied.
-  EXPECT_EQ(rate_limiter.is_limited(), false);
-  // The current number of concurrent requests is 1, rate limiting is applied.
-  EXPECT_EQ(rate_limiter.is_limited(), true);
-  // Decrease the number of concurrent requests by one, changing the concurrency
-  // from 1 to 0.
+
+  // count=0, not limited; check_limited() must not have side effects.
+  EXPECT_FALSE(rate_limiter.check_limited());
+  EXPECT_FALSE(rate_limiter.check_limited());
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 0);
+
+  // increment() must be called separately.
+  rate_limiter.increment();
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 1);
+
+  // count=1 reached the max, now limited.
+  EXPECT_TRUE(rate_limiter.check_limited());
+
   rate_limiter.decrease_one_request();
-  // The current number of concurrent requests is 0, no rate limiting is
-  // applied.
-  EXPECT_EQ(rate_limiter.is_limited(), false);
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 0);
+  EXPECT_FALSE(rate_limiter.check_limited());
+}
+
+TEST(RequestLimiterTest, IsLimitedIsReadOnlyAlias) {
+  ServiceConfig::get_instance().max_concurrent_requests(1);
+  RateLimiter rate_limiter;
+
+  // is_limited() must be a read-only alias for check_limited().
+  EXPECT_FALSE(rate_limiter.is_limited());
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 0);
+
+  rate_limiter.increment();
+  EXPECT_TRUE(rate_limiter.is_limited());
+  EXPECT_EQ(rate_limiter.get_num_concurrent_requests(), 1);
+
+  rate_limiter.decrease_one_request();
+}
+
+TEST(RequestLimiterTest, SleepBlocksCheck) {
+  ServiceConfig::get_instance().max_concurrent_requests(10);
+  RateLimiter rate_limiter;
+
+  EXPECT_TRUE(rate_limiter.try_set_sleeping());
+  EXPECT_TRUE(rate_limiter.check_limited());
+  EXPECT_TRUE(rate_limiter.is_sleeping());
+
+  EXPECT_TRUE(rate_limiter.try_wakeup());
+  EXPECT_FALSE(rate_limiter.check_limited());
 }
 
 }  // namespace xllm

--- a/xllm/api_service/anthropic_service_impl.cpp
+++ b/xllm/api_service/anthropic_service_impl.cpp
@@ -712,15 +712,8 @@ void AnthropicServiceImpl::process_async_impl(
         if (req_output.status.has_value()) {
           const auto& status = req_output.status.value();
           if (!status.ok()) {
-            master->get_rate_limiter()->decrease_one_request();
             return call->finish_with_error(status.code(), status.message());
           }
-        }
-
-        // Decrease rate limiter on completion
-        if (req_output.finished || req_output.cancelled ||
-            req_output.finished_on_prefill_instance) {
-          master->get_rate_limiter()->decrease_one_request();
         }
 
         // Anthropic format:

--- a/xllm/api_service/anthropic_service_impl.cpp
+++ b/xllm/api_service/anthropic_service_impl.cpp
@@ -649,7 +649,7 @@ void AnthropicServiceImpl::process_async_impl(
   }
 
   // Check rate limit
-  if (master_->get_rate_limiter()->is_limited()) {
+  if (master_->get_rate_limiter()->check_limited()) {
     call->finish_with_error(
         StatusCode::RESOURCE_EXHAUSTED,
         "The number of concurrent requests has reached the limit.");
@@ -712,15 +712,8 @@ void AnthropicServiceImpl::process_async_impl(
         if (req_output.status.has_value()) {
           const auto& status = req_output.status.value();
           if (!status.ok()) {
-            master->get_rate_limiter()->decrease_one_request();
             return call->finish_with_error(status.code(), status.message());
           }
-        }
-
-        // Decrease rate limiter on completion
-        if (req_output.finished || req_output.cancelled ||
-            req_output.finished_on_prefill_instance) {
-          master->get_rate_limiter()->decrease_one_request();
         }
 
         // Anthropic format:

--- a/xllm/api_service/chat_service_impl.cpp
+++ b/xllm/api_service/chat_service_impl.cpp
@@ -593,14 +593,8 @@ void ChatServiceImpl::process_rec_chat_request(std::shared_ptr<ChatCall> call) {
         if (req_output.status.has_value()) {
           const auto& status = req_output.status.value();
           if (!status.ok()) {
-            master->get_rate_limiter()->decrease_one_request();
             return call->finish_with_error(status.code(), status.message());
           }
-        }
-
-        if (req_output.finished || req_output.cancelled ||
-            req_output.finished_on_prefill_instance) {
-          master->get_rate_limiter()->decrease_one_request();
         }
 
         if (stream) {
@@ -624,21 +618,6 @@ void ChatServiceImpl::process_async_rpc_impl(
   const auto& target_xservice_addr = request->source_xservice_addr();
   auto callback = [master = master_](const RequestOutput& req_output) -> bool {
     req_output.log_request_status();
-    if (req_output.status.has_value()) {
-      const auto& status = req_output.status.value();
-      if (!status.ok()) {
-        // Reduce the number of concurrent requests when a request is
-        // finished with error.
-        master->get_rate_limiter()->decrease_one_request();
-        return master->handle_rpc_response(req_output);
-      }
-    }
-    // Reduce the number of concurrent requests when a request is finished
-    // or canceled.
-    if (req_output.finished || req_output.cancelled ||
-        req_output.finished_on_prefill_instance) {
-      master->get_rate_limiter()->decrease_one_request();
-    }
     return master->handle_rpc_response(req_output);
   };
 
@@ -845,19 +824,8 @@ void ChatServiceImpl::process_async_impl(std::shared_ptr<ChatCall> call) {
         if (req_output.status.has_value()) {
           const auto& status = req_output.status.value();
           if (!status.ok()) {
-            // Reduce the number of concurrent requests when a
-            // request is finished with error.
-            master->get_rate_limiter()->decrease_one_request();
-
             return call->finish_with_error(status.code(), status.message());
           }
-        }
-
-        // Reduce the number of concurrent requests when a request
-        // is finished or canceled.
-        if (req_output.finished || req_output.cancelled ||
-            req_output.finished_on_prefill_instance) {
-          master->get_rate_limiter()->decrease_one_request();
         }
 
         if (stream) {
@@ -967,19 +935,8 @@ void MMChatServiceImpl::process_async_impl(std::shared_ptr<MMChatCall> call) {
         if (req_output.status.has_value()) {
           const auto& status = req_output.status.value();
           if (!status.ok()) {
-            // Reduce the number of concurrent requests when a request is
-            // finished with error.
-            master->get_rate_limiter()->decrease_one_request();
-
             return call->finish_with_error(status.code(), status.message());
           }
-        }
-
-        // Reduce the number of concurrent requests when a request is finished
-        // or canceled.
-        if (req_output.finished || req_output.cancelled ||
-            req_output.finished_on_prefill_instance) {
-          master->get_rate_limiter()->decrease_one_request();
         }
 
         if (stream) {

--- a/xllm/api_service/chat_service_impl.cpp
+++ b/xllm/api_service/chat_service_impl.cpp
@@ -517,7 +517,7 @@ void ChatServiceImpl::process_rec_chat_request(std::shared_ptr<ChatCall> call) {
     return;
   }
 
-  if (rec_master_->get_rate_limiter()->is_limited()) {
+  if (rec_master_->get_rate_limiter()->check_limited()) {
     call->finish_with_error(
         StatusCode::RESOURCE_EXHAUSTED,
         "The number of concurrent requests has reached the limit.");
@@ -593,14 +593,8 @@ void ChatServiceImpl::process_rec_chat_request(std::shared_ptr<ChatCall> call) {
         if (req_output.status.has_value()) {
           const auto& status = req_output.status.value();
           if (!status.ok()) {
-            master->get_rate_limiter()->decrease_one_request();
             return call->finish_with_error(status.code(), status.message());
           }
-        }
-
-        if (req_output.finished || req_output.cancelled ||
-            req_output.finished_on_prefill_instance) {
-          master->get_rate_limiter()->decrease_one_request();
         }
 
         if (stream) {
@@ -627,17 +621,8 @@ void ChatServiceImpl::process_async_rpc_impl(
     if (req_output.status.has_value()) {
       const auto& status = req_output.status.value();
       if (!status.ok()) {
-        // Reduce the number of concurrent requests when a request is
-        // finished with error.
-        master->get_rate_limiter()->decrease_one_request();
         return master->handle_rpc_response(req_output);
       }
-    }
-    // Reduce the number of concurrent requests when a request is finished
-    // or canceled.
-    if (req_output.finished || req_output.cancelled ||
-        req_output.finished_on_prefill_instance) {
-      master->get_rate_limiter()->decrease_one_request();
     }
     return master->handle_rpc_response(req_output);
   };
@@ -645,7 +630,7 @@ void ChatServiceImpl::process_async_rpc_impl(
   // LLMMaster path (existing logic)
   // Check if the request is being rate-limited.
   CHECK(master_ != nullptr);
-  if (master_->get_rate_limiter()->is_limited()) {
+  if (master_->get_rate_limiter()->check_limited()) {
     CALLBACK_WITH_ERROR(
         StatusCode::RESOURCE_EXHAUSTED,
         "The number of concurrent requests has reached the limit.",
@@ -741,8 +726,8 @@ void ChatServiceImpl::process_async_impl(std::shared_ptr<ChatCall> call) {
   }
   // LLMMaster path (existing logic)
   // Check if the request is being rate-limited or model is sleeping.
-  // is_limited() returns true if sleeping or rate-limited.
-  if (unlikely(master->get_rate_limiter()->is_limited())) {
+  // check_limited() returns true if sleeping or rate-limited.
+  if (unlikely(master->get_rate_limiter()->check_limited())) {
     if (master->get_rate_limiter()->is_sleeping()) {
       call->finish_with_error(StatusCode::UNAVAILABLE,
                               "Model is currently in sleep state.");
@@ -845,19 +830,8 @@ void ChatServiceImpl::process_async_impl(std::shared_ptr<ChatCall> call) {
         if (req_output.status.has_value()) {
           const auto& status = req_output.status.value();
           if (!status.ok()) {
-            // Reduce the number of concurrent requests when a
-            // request is finished with error.
-            master->get_rate_limiter()->decrease_one_request();
-
             return call->finish_with_error(status.code(), status.message());
           }
-        }
-
-        // Reduce the number of concurrent requests when a request
-        // is finished or canceled.
-        if (req_output.finished || req_output.cancelled ||
-            req_output.finished_on_prefill_instance) {
-          master->get_rate_limiter()->decrease_one_request();
         }
 
         if (stream) {
@@ -903,7 +877,7 @@ void MMChatServiceImpl::process_async_impl(std::shared_ptr<MMChatCall> call) {
   }
 
   // Check if the request is being rate-limited.
-  if (master_->get_rate_limiter()->is_limited()) {
+  if (master_->get_rate_limiter()->check_limited()) {
     call->finish_with_error(
         StatusCode::RESOURCE_EXHAUSTED,
         "The number of concurrent requests has reached the limit.");
@@ -967,19 +941,8 @@ void MMChatServiceImpl::process_async_impl(std::shared_ptr<MMChatCall> call) {
         if (req_output.status.has_value()) {
           const auto& status = req_output.status.value();
           if (!status.ok()) {
-            // Reduce the number of concurrent requests when a request is
-            // finished with error.
-            master->get_rate_limiter()->decrease_one_request();
-
             return call->finish_with_error(status.code(), status.message());
           }
-        }
-
-        // Reduce the number of concurrent requests when a request is finished
-        // or canceled.
-        if (req_output.finished || req_output.cancelled ||
-            req_output.finished_on_prefill_instance) {
-          master->get_rate_limiter()->decrease_one_request();
         }
 
         if (stream) {

--- a/xllm/api_service/completion_service_impl.cpp
+++ b/xllm/api_service/completion_service_impl.cpp
@@ -188,21 +188,6 @@ void CompletionServiceImpl::process_async_rpc_impl(
   const auto& target_xservice_addr = request->source_xservice_addr();
   auto callback = [master = master_](const RequestOutput& req_output) -> bool {
     req_output.log_request_status();
-    if (req_output.status.has_value()) {
-      const auto& status = req_output.status.value();
-      if (!status.ok()) {
-        // Reduce the number of concurrent requests when a request is
-        // finished with error.
-        master->get_rate_limiter()->decrease_one_request();
-        return master->handle_rpc_response(req_output);
-      }
-    }
-    // Reduce the number of concurrent requests when a request is finished
-    // or canceled.
-    if (req_output.finished || req_output.cancelled ||
-        req_output.finished_on_prefill_instance) {
-      master->get_rate_limiter()->decrease_one_request();
-    }
     return master->handle_rpc_response(req_output);
   };
 
@@ -307,19 +292,8 @@ void CompletionServiceImpl::process_async_impl(
         if (req_output.status.has_value()) {
           const auto& status = req_output.status.value();
           if (!status.ok()) {
-            // Reduce the number of concurrent requests when a request is
-            // finished with error.
-            master->get_rate_limiter()->decrease_one_request();
-
             return call->finish_with_error(status.code(), status.message());
           }
-        }
-
-        // Reduce the number of concurrent requests when a request is finished
-        // or canceled.
-        if (req_output.finished || req_output.cancelled ||
-            req_output.finished_on_prefill_instance) {
-          master->get_rate_limiter()->decrease_one_request();
         }
 
         if (stream) {

--- a/xllm/api_service/completion_service_impl.cpp
+++ b/xllm/api_service/completion_service_impl.cpp
@@ -191,23 +191,14 @@ void CompletionServiceImpl::process_async_rpc_impl(
     if (req_output.status.has_value()) {
       const auto& status = req_output.status.value();
       if (!status.ok()) {
-        // Reduce the number of concurrent requests when a request is
-        // finished with error.
-        master->get_rate_limiter()->decrease_one_request();
         return master->handle_rpc_response(req_output);
       }
-    }
-    // Reduce the number of concurrent requests when a request is finished
-    // or canceled.
-    if (req_output.finished || req_output.cancelled ||
-        req_output.finished_on_prefill_instance) {
-      master->get_rate_limiter()->decrease_one_request();
     }
     return master->handle_rpc_response(req_output);
   };
 
   // Check if the request is being rate-limited.
-  if (unlikely(master_->get_rate_limiter()->is_limited())) {
+  if (unlikely(master_->get_rate_limiter()->check_limited())) {
     CALLBACK_WITH_ERROR(
         StatusCode::RESOURCE_EXHAUSTED,
         "The number of concurrent requests has reached the limit.",
@@ -258,8 +249,8 @@ void CompletionServiceImpl::process_async_impl(
   }
 
   // Check if the request is being rate-limited or model is sleeping.
-  // is_limited() returns true if sleeping or rate-limited.
-  if (unlikely(master->get_rate_limiter()->is_limited())) {
+  // check_limited() returns true if sleeping or rate-limited.
+  if (unlikely(master->get_rate_limiter()->check_limited())) {
     if (master->get_rate_limiter()->is_sleeping()) {
       call->finish_with_error(StatusCode::UNAVAILABLE,
                               "Model is currently in sleep state.");
@@ -307,19 +298,8 @@ void CompletionServiceImpl::process_async_impl(
         if (req_output.status.has_value()) {
           const auto& status = req_output.status.value();
           if (!status.ok()) {
-            // Reduce the number of concurrent requests when a request is
-            // finished with error.
-            master->get_rate_limiter()->decrease_one_request();
-
             return call->finish_with_error(status.code(), status.message());
           }
-        }
-
-        // Reduce the number of concurrent requests when a request is finished
-        // or canceled.
-        if (req_output.finished || req_output.cancelled ||
-            req_output.finished_on_prefill_instance) {
-          master->get_rate_limiter()->decrease_one_request();
         }
 
         if (stream) {

--- a/xllm/api_service/image_generation_service_impl.cpp
+++ b/xllm/api_service/image_generation_service_impl.cpp
@@ -102,7 +102,6 @@ void ImageGenerationServiceImpl::process_async_impl(
        request_id = std::move(saved_request_id),
        created_time = absl::ToUnixSeconds(absl::Now())](
           const DiTRequestOutput& req_output) -> bool {
-        master->get_rate_limiter()->decrease_one_request();
         if (req_output.status.has_value()) {
           const auto& status = req_output.status.value();
           if (!status.ok()) {

--- a/xllm/api_service/image_generation_service_impl.cpp
+++ b/xllm/api_service/image_generation_service_impl.cpp
@@ -80,7 +80,7 @@ void ImageGenerationServiceImpl::process_async_impl(
   }
 
   // Check if the request is being rate-limited.
-  if (master_->get_rate_limiter()->is_limited()) {
+  if (master_->get_rate_limiter()->check_limited()) {
     call->finish_with_error(
         StatusCode::RESOURCE_EXHAUSTED,
         "The number of concurrent requests has reached the limit.");
@@ -102,7 +102,6 @@ void ImageGenerationServiceImpl::process_async_impl(
        request_id = std::move(saved_request_id),
        created_time = absl::ToUnixSeconds(absl::Now())](
           const DiTRequestOutput& req_output) -> bool {
-        master->get_rate_limiter()->decrease_one_request();
         if (req_output.status.has_value()) {
           const auto& status = req_output.status.value();
           if (!status.ok()) {

--- a/xllm/api_service/rec_completion_service_impl.cpp
+++ b/xllm/api_service/rec_completion_service_impl.cpp
@@ -349,9 +349,6 @@ void RecCompletionServiceImpl::process_async_impl(
         if (req_output.status.has_value()) {
           const auto& status = req_output.status.value();
           if (!status.ok()) {
-            // Reduce the number of concurrent requests when a request is
-            // finished with error.
-            master->get_rate_limiter()->decrease_one_request();
             HISTOGRAM_OBSERVE(
                 rec_total_latency_microseconds,
                 static_cast<int64_t>(request_timer.elapsed_microseconds()));
@@ -360,10 +357,7 @@ void RecCompletionServiceImpl::process_async_impl(
           }
         }
 
-        // Reduce the number of concurrent requests when a request is finished
-        // or canceled.
         if (req_output.finished || req_output.cancelled) {
-          master->get_rate_limiter()->decrease_one_request();
           HISTOGRAM_OBSERVE(
               rec_total_latency_microseconds,
               static_cast<int64_t>(request_timer.elapsed_microseconds()));

--- a/xllm/api_service/rec_completion_service_impl.cpp
+++ b/xllm/api_service/rec_completion_service_impl.cpp
@@ -278,7 +278,7 @@ void RecCompletionServiceImpl::process_async_impl(
   }
 
   // Check if the request is being rate-limited.
-  if (unlikely(master_->get_rate_limiter()->is_limited())) {
+  if (unlikely(master_->get_rate_limiter()->check_limited())) {
     call->finish_with_error(
         StatusCode::RESOURCE_EXHAUSTED,
         "The number of concurrent requests has reached the limit.");
@@ -349,9 +349,6 @@ void RecCompletionServiceImpl::process_async_impl(
         if (req_output.status.has_value()) {
           const auto& status = req_output.status.value();
           if (!status.ok()) {
-            // Reduce the number of concurrent requests when a request is
-            // finished with error.
-            master->get_rate_limiter()->decrease_one_request();
             HISTOGRAM_OBSERVE(
                 rec_total_latency_microseconds,
                 static_cast<int64_t>(request_timer.elapsed_microseconds()));
@@ -360,10 +357,7 @@ void RecCompletionServiceImpl::process_async_impl(
           }
         }
 
-        // Reduce the number of concurrent requests when a request is finished
-        // or canceled.
         if (req_output.finished || req_output.cancelled) {
-          master->get_rate_limiter()->decrease_one_request();
           HISTOGRAM_OBSERVE(
               rec_total_latency_microseconds,
               static_cast<int64_t>(request_timer.elapsed_microseconds()));

--- a/xllm/api_service/sample_service_impl.cpp
+++ b/xllm/api_service/sample_service_impl.cpp
@@ -336,12 +336,11 @@ bool SampleServiceImpl::process_request(const proto::SampleRequest& request,
       [this, &mu, &cv, &final_output, &has_final_output](
           const RequestOutput& req_output) -> bool {
         req_output.log_request_status();
-        if (req_output.status.has_value() && !req_output.status->ok()) {
-          master_->get_rate_limiter()->decrease_one_request();
-        } else if (req_output.finished || req_output.cancelled ||
-                   req_output.finished_on_prefill_instance) {
-          master_->get_rate_limiter()->decrease_one_request();
-        } else {
+        const bool is_error =
+            req_output.status.has_value() && !req_output.status->ok();
+        const bool is_terminal = req_output.finished || req_output.cancelled ||
+                                 req_output.finished_on_prefill_instance;
+        if (!is_error && !is_terminal) {
           return true;
         }
 
@@ -445,15 +444,9 @@ void SampleServiceImpl::process_async_impl(std::shared_ptr<SampleCall> call) {
         if (req_output.status.has_value()) {
           const auto& output_status = req_output.status.value();
           if (!output_status.ok()) {
-            master->get_rate_limiter()->decrease_one_request();
             return call->finish_with_error(output_status.code(),
                                            output_status.message());
           }
-        }
-
-        if (req_output.finished || req_output.cancelled ||
-            req_output.finished_on_prefill_instance) {
-          master->get_rate_limiter()->decrease_one_request();
         }
 
         if (!sample_service_internal::build_response(request_id,

--- a/xllm/api_service/sample_service_impl.cpp
+++ b/xllm/api_service/sample_service_impl.cpp
@@ -109,7 +109,7 @@ uint32_t get_requested_logprobs(const proto::SampleRequest& request) {
 
 Status get_rate_limit_status(LLMMaster* master) {
   CHECK(master != nullptr);
-  if (!master->get_rate_limiter()->is_limited()) {
+  if (!master->get_rate_limiter()->check_limited()) {
     return Status();
   }
 
@@ -336,12 +336,11 @@ bool SampleServiceImpl::process_request(const proto::SampleRequest& request,
       [this, &mu, &cv, &final_output, &has_final_output](
           const RequestOutput& req_output) -> bool {
         req_output.log_request_status();
-        if (req_output.status.has_value() && !req_output.status->ok()) {
-          master_->get_rate_limiter()->decrease_one_request();
-        } else if (req_output.finished || req_output.cancelled ||
-                   req_output.finished_on_prefill_instance) {
-          master_->get_rate_limiter()->decrease_one_request();
-        } else {
+        const bool is_error =
+            req_output.status.has_value() && !req_output.status->ok();
+        const bool is_terminal = req_output.finished || req_output.cancelled ||
+                                 req_output.finished_on_prefill_instance;
+        if (!is_error && !is_terminal) {
           return true;
         }
 
@@ -445,15 +444,9 @@ void SampleServiceImpl::process_async_impl(std::shared_ptr<SampleCall> call) {
         if (req_output.status.has_value()) {
           const auto& output_status = req_output.status.value();
           if (!output_status.ok()) {
-            master->get_rate_limiter()->decrease_one_request();
             return call->finish_with_error(output_status.code(),
                                            output_status.message());
           }
-        }
-
-        if (req_output.finished || req_output.cancelled ||
-            req_output.finished_on_prefill_instance) {
-          master->get_rate_limiter()->decrease_one_request();
         }
 
         if (!sample_service_internal::build_response(request_id,

--- a/xllm/api_service/text_generation_service_impl.cpp
+++ b/xllm/api_service/text_generation_service_impl.cpp
@@ -87,7 +87,6 @@ void TextGenerationServiceImpl::process_async_impl(
        request_id = saved_request_id,
        created_time = absl::ToUnixSeconds(absl::Now())](
           const DiTRequestOutput& req_output) -> bool {
-        master->get_rate_limiter()->decrease_one_request();
         if (req_output.status.has_value()) {
           const auto& status = req_output.status.value();
           if (!status.ok()) {

--- a/xllm/api_service/text_generation_service_impl.cpp
+++ b/xllm/api_service/text_generation_service_impl.cpp
@@ -67,7 +67,7 @@ void TextGenerationServiceImpl::process_async_impl(
     return;
   }
 
-  if (master_->get_rate_limiter()->is_limited()) {
+  if (master_->get_rate_limiter()->check_limited()) {
     call->finish_with_error(
         StatusCode::RESOURCE_EXHAUSTED,
         "The number of concurrent requests has reached the limit.");
@@ -87,7 +87,6 @@ void TextGenerationServiceImpl::process_async_impl(
        request_id = saved_request_id,
        created_time = absl::ToUnixSeconds(absl::Now())](
           const DiTRequestOutput& req_output) -> bool {
-        master->get_rate_limiter()->decrease_one_request();
         if (req_output.status.has_value()) {
           const auto& status = req_output.status.value();
           if (!status.ok()) {

--- a/xllm/core/common/rate_limiter.cpp
+++ b/xllm/core/common/rate_limiter.cpp
@@ -24,38 +24,34 @@ limitations under the License.
 namespace xllm {
 
 bool RateLimiter::is_limited() {
-  int32_t num_requests =
-      num_concurrent_requests_.load(std::memory_order_relaxed);
-
-  // Check if sleeping.
-  if (num_requests == kSleeping) {
-    return true;
+  const int32_t max =
+      ::xllm::ServiceConfig::get_instance().max_concurrent_requests();
+  int32_t expected = num_concurrent_requests_.load(std::memory_order_relaxed);
+  while (true) {
+    // Check if sleeping.
+    if (expected == kSleeping) {
+      return true;
+    }
+    // Check rate limit.
+    if (max > 0 && expected >= max) {
+      COUNTER_INC(server_request_total_limit);
+      return true;
+    }
+    // Atomic check+increment. On CAS failure, `expected` is refreshed and we
+    // retry (re-checking the sleep/limit conditions above with the new value).
+    if (num_concurrent_requests_.compare_exchange_weak(
+            expected,
+            expected + 1,
+            std::memory_order_acq_rel,
+            std::memory_order_relaxed)) {
+      GAUGE_SET(num_concurrent_requests, expected + 1);
+      return false;
+    }
   }
-
-  // Check rate limit.
-  if (::xllm::ServiceConfig::get_instance().max_concurrent_requests() > 0 &&
-      num_requests >=
-          ::xllm::ServiceConfig::get_instance().max_concurrent_requests()) {
-    COUNTER_INC(server_request_total_limit);
-    return true;
-  }
-
-  num_concurrent_requests_.fetch_add(1, std::memory_order_relaxed);
-  GAUGE_SET(num_concurrent_requests,
-            num_concurrent_requests_.load(std::memory_order_relaxed));
-
-  return false;
 }
 
 void RateLimiter::decrease_one_request() {
   num_concurrent_requests_.fetch_sub(1, std::memory_order_relaxed);
-  GAUGE_SET(num_concurrent_requests,
-            num_concurrent_requests_.load(std::memory_order_relaxed));
-}
-
-void RateLimiter::decrease_requests(size_t decrease_requests_num) {
-  num_concurrent_requests_.fetch_sub(decrease_requests_num,
-                                     std::memory_order_relaxed);
   GAUGE_SET(num_concurrent_requests,
             num_concurrent_requests_.load(std::memory_order_relaxed));
 }

--- a/xllm/core/common/rate_limiter.cpp
+++ b/xllm/core/common/rate_limiter.cpp
@@ -23,7 +23,7 @@ limitations under the License.
 
 namespace xllm {
 
-bool RateLimiter::is_limited() {
+bool RateLimiter::check_limited() const {
   int32_t num_requests =
       num_concurrent_requests_.load(std::memory_order_relaxed);
 
@@ -40,22 +40,17 @@ bool RateLimiter::is_limited() {
     return true;
   }
 
+  return false;
+}
+
+void RateLimiter::increment() {
   num_concurrent_requests_.fetch_add(1, std::memory_order_relaxed);
   GAUGE_SET(num_concurrent_requests,
             num_concurrent_requests_.load(std::memory_order_relaxed));
-
-  return false;
 }
 
 void RateLimiter::decrease_one_request() {
   num_concurrent_requests_.fetch_sub(1, std::memory_order_relaxed);
-  GAUGE_SET(num_concurrent_requests,
-            num_concurrent_requests_.load(std::memory_order_relaxed));
-}
-
-void RateLimiter::decrease_requests(size_t decrease_requests_num) {
-  num_concurrent_requests_.fetch_sub(decrease_requests_num,
-                                     std::memory_order_relaxed);
   GAUGE_SET(num_concurrent_requests,
             num_concurrent_requests_.load(std::memory_order_relaxed));
 }

--- a/xllm/core/common/rate_limiter.h
+++ b/xllm/core/common/rate_limiter.h
@@ -34,8 +34,6 @@ class RateLimiter final {
 
   void decrease_one_request();
 
-  void decrease_requests(size_t decrease_requests_num);
-
   int32_t get_num_concurrent_requests() const {
     return num_concurrent_requests_.load(std::memory_order_relaxed);
   }

--- a/xllm/core/common/rate_limiter.h
+++ b/xllm/core/common/rate_limiter.h
@@ -28,13 +28,17 @@ class RateLimiter final {
 
   ~RateLimiter() = default;
 
-  // Returns true if request is rate-limited or sleeping.
-  // If not limited and not sleeping, increments the counter.
-  bool is_limited();
+  // Read-only: true if sleeping or count >= max. Does NOT increment.
+  bool check_limited() const;
+
+  // +1. Call only after check_limited() returned false, immediately before
+  // constructing the Request that will own the slot.
+  void increment();
+
+  // Kept for pybind backward compat; delegates to check_limited().
+  bool is_limited() const { return check_limited(); }
 
   void decrease_one_request();
-
-  void decrease_requests(size_t decrease_requests_num);
 
   int32_t get_num_concurrent_requests() const {
     return num_concurrent_requests_.load(std::memory_order_relaxed);

--- a/xllm/core/distributed_runtime/disagg_pd_service_impl.cpp
+++ b/xllm/core/distributed_runtime/disagg_pd_service_impl.cpp
@@ -132,12 +132,16 @@ std::shared_ptr<Request> DisaggPDServiceImpl::generate_request(
                          batch_output_callback);
   req_state.include_stop_str_in_output = req.include_stop_str_in_output();
 
+  // Decode-side forwarded requests: their concurrency slot lives on the
+  // originating prefill instance's RateLimiter, not this one. Pass nullptr
+  // so the destructor does not decrement an unrelated counter.
   auto new_request = std::make_shared<Request>(req.req_id(),
                                                req.x_request_id(),
                                                req.x_request_time(),
                                                std::move(req_state),
                                                req.service_req_id(),
-                                               req.source_xservice_addr());
+                                               req.source_xservice_addr(),
+                                               /*rate_limiter=*/nullptr);
 
   // add one sequence, rest will be added by scheduler
   return new_request;

--- a/xllm/core/distributed_runtime/dit_master.cpp
+++ b/xllm/core/distributed_runtime/dit_master.cpp
@@ -85,6 +85,11 @@ void DiTMaster::handle_request(DiTRequestParams params,
     // remove the pending request after scheduling
     SCOPE_GUARD([this] { scheduler_->decr_pending_requests(); });
 
+    // Guard the rate-limit slot acquired at the service entry. Dismissed
+    // right before DiTRequest takes ownership; any early return releases it.
+    xllm::ScopeGuard rate_limit_guard(
+        [this] { get_rate_limiter()->decrease_one_request(); });
+
     Timer timer;
     // verify the prompt
     if (!params.verify_params(callback)) {
@@ -96,10 +101,14 @@ void DiTMaster::handle_request(DiTRequestParams params,
                                                 nullptr,
                                                 params.request_kind,
                                                 call);
+    rate_limit_guard.dismiss();
     auto request = std::make_shared<DiTRequest>(params.request_id,
                                                 params.x_request_id,
                                                 params.x_request_time,
-                                                std::move(dit_state));
+                                                std::move(dit_state),
+                                                /*service_request_id=*/"",
+                                                /*source_xservice_addr=*/"",
+                                                get_rate_limiter());
 
     if (!scheduler_->add_request(request)) {
       CALLBACK_WITH_ERROR(StatusCode::RESOURCE_EXHAUSTED,

--- a/xllm/core/distributed_runtime/dit_master.cpp
+++ b/xllm/core/distributed_runtime/dit_master.cpp
@@ -99,7 +99,10 @@ void DiTMaster::handle_request(DiTRequestParams params,
     auto request = std::make_shared<DiTRequest>(params.request_id,
                                                 params.x_request_id,
                                                 params.x_request_time,
-                                                std::move(dit_state));
+                                                std::move(dit_state),
+                                                /*service_request_id=*/"",
+                                                /*source_xservice_addr=*/"",
+                                                get_rate_limiter());
 
     if (!scheduler_->add_request(request)) {
       CALLBACK_WITH_ERROR(StatusCode::RESOURCE_EXHAUSTED,

--- a/xllm/core/distributed_runtime/llm_master.cpp
+++ b/xllm/core/distributed_runtime/llm_master.cpp
@@ -193,12 +193,19 @@ void LLMMaster::handle_request(std::string prompt,
     // remove the pending request after scheduling
     SCOPE_GUARD([this] { scheduler_->decr_pending_requests(); });
 
+    // Guard the rate-limit slot acquired at the service entry. If we bail
+    // before generate_request has a chance to create the Request, this
+    // releases the slot; otherwise Request itself takes ownership.
+    xllm::ScopeGuard rate_limit_guard(
+        [this] { get_rate_limiter()->decrease_one_request(); });
+
     Timer timer;
     // verify the prompt
     if (!sp.verify_params(callback)) {
       return;
     }
 
+    rate_limit_guard.dismiss();
     auto request = generate_request(
         std::move(prompt), std::move(prompt_token), sp, call, callback);
     if (!request) {
@@ -232,11 +239,16 @@ void LLMMaster::handle_request(std::vector<Message> messages,
     // remove the pending request after scheduling
     SCOPE_GUARD([this] { scheduler_->decr_pending_requests(); });
 
+    // Guard the rate-limit slot acquired at the service entry.
+    xllm::ScopeGuard rate_limit_guard(
+        [this] { get_rate_limiter()->decrease_one_request(); });
+
     // verify the prompt
     if (!sp.verify_params(callback)) {
       return;
     }
 
+    rate_limit_guard.dismiss();
     auto request =
         generate_request(messages, std::move(prompt_token), sp, call, callback);
     if (!request) {
@@ -289,6 +301,12 @@ std::shared_ptr<Request> LLMMaster::generate_request(
     const RequestParams& sp,
     std::optional<Call*> call,
     OutputCallback callback) {
+  // The caller (service_impl) has already incremented the rate limiter's
+  // slot via is_limited() returning false. This guard releases it on any
+  // early return below; we dismiss it right before Request takes ownership.
+  xllm::ScopeGuard rate_limit_guard(
+      [this] { get_rate_limiter()->decrease_one_request(); });
+
   // A request is valid as long as it carries either text or pre-tokenized
   // prompt tokens; pure-token input (no text) is a first-class input.
   const bool has_prompt_tokens = prompt_tokens.has_value();
@@ -469,21 +487,9 @@ std::shared_ptr<Request> LLMMaster::generate_request(
   OutputsFunc batch_callback = nullptr;
   if (options_.enable_service_routing()) {
     batch_callback = [this](const std::vector<RequestOutput>& req_outputs) {
-      size_t decrease_requests_num = 0;
       for (const auto& req_output : req_outputs) {
         req_output.log_request_status();
-        if (req_output.status.has_value() && !req_output.status.value().ok()) {
-          decrease_requests_num++;
-          continue;
-        }
-        // Reduce the number of concurrent requests when a request is
-        // finished or canceled.
-        if (req_output.finished || req_output.cancelled ||
-            req_output.finished_on_prefill_instance) {
-          decrease_requests_num++;
-        }
       }
-      get_rate_limiter()->decrease_requests(decrease_requests_num);
       return handle_rpc_responses(req_outputs);
     };
   }
@@ -508,12 +514,14 @@ std::shared_ptr<Request> LLMMaster::generate_request(
   req_state.include_stop_str_in_output = sp.include_stop_str_in_output;
   req_state.sample_slots = sp.sample_slots;
 
+  rate_limit_guard.dismiss();
   auto request = std::make_shared<Request>(sp.request_id,
                                            sp.x_request_id,
                                            sp.x_request_time,
                                            std::move(req_state),
                                            sp.service_request_id,
-                                           sp.source_xservice_addr);
+                                           sp.source_xservice_addr,
+                                           get_rate_limiter());
 
   // add one sequence, rest will be added by scheduler
   return request;
@@ -525,6 +533,13 @@ std::shared_ptr<Request> LLMMaster::generate_request(
     const RequestParams& sp,
     std::optional<Call*> call,
     OutputCallback callback) {
+  // Guard the rate-limit slot the caller acquired via is_limited(). The
+  // string-prompt overload installs its own guard once we forward there;
+  // we dismiss ours right before that call so the slot is not released
+  // twice.
+  xllm::ScopeGuard rate_limit_guard(
+      [this] { get_rate_limiter()->decrease_one_request(); });
+
   Timer timer;
 
   std::optional<std::string> prompt;
@@ -540,6 +555,7 @@ std::shared_ptr<Request> LLMMaster::generate_request(
 
   COUNTER_ADD(chat_template_latency_seconds, timer.elapsed_seconds());
 
+  rate_limit_guard.dismiss();
   return generate_request(
       std::move(prompt.value()), std::move(prompt_tokens), sp, call, callback);
 }

--- a/xllm/core/distributed_runtime/llm_master.cpp
+++ b/xllm/core/distributed_runtime/llm_master.cpp
@@ -469,21 +469,9 @@ std::shared_ptr<Request> LLMMaster::generate_request(
   OutputsFunc batch_callback = nullptr;
   if (options_.enable_service_routing()) {
     batch_callback = [this](const std::vector<RequestOutput>& req_outputs) {
-      size_t decrease_requests_num = 0;
       for (const auto& req_output : req_outputs) {
         req_output.log_request_status();
-        if (req_output.status.has_value() && !req_output.status.value().ok()) {
-          decrease_requests_num++;
-          continue;
-        }
-        // Reduce the number of concurrent requests when a request is
-        // finished or canceled.
-        if (req_output.finished || req_output.cancelled ||
-            req_output.finished_on_prefill_instance) {
-          decrease_requests_num++;
-        }
       }
-      get_rate_limiter()->decrease_requests(decrease_requests_num);
       return handle_rpc_responses(req_outputs);
     };
   }
@@ -513,7 +501,8 @@ std::shared_ptr<Request> LLMMaster::generate_request(
                                            sp.x_request_time,
                                            std::move(req_state),
                                            sp.service_request_id,
-                                           sp.source_xservice_addr);
+                                           sp.source_xservice_addr,
+                                           get_rate_limiter());
 
   // add one sequence, rest will be added by scheduler
   return request;

--- a/xllm/core/distributed_runtime/rec_master.cpp
+++ b/xllm/core/distributed_runtime/rec_master.cpp
@@ -320,6 +320,7 @@ std::shared_ptr<Request> RecMaster::RecMasterPipeline::generate_request(
     std::optional<std::vector<proto::InferInputTensor>> /*input_tensors*/,
     const RequestParams& /*sp*/,
     OutputCallback callback) {
+  master_.get_rate_limiter()->decrease_one_request();
   CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
                       "This pipeline does not support prompt-based input");
   return nullptr;
@@ -330,6 +331,7 @@ std::shared_ptr<Request> RecMaster::RecMasterPipeline::generate_request(
     std::optional<MMData> mm_data,
     const RequestParams& sp,
     OutputCallback callback) {
+  master_.get_rate_limiter()->decrease_one_request();
   CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
                       "This pipeline does not support raw input");
   return nullptr;
@@ -343,6 +345,9 @@ RecMaster::RecMasterPipeline::generate_onerec_request_common(
     const RequestParams& sp,
     OutputCallback callback,
     bool build_stop_checker) {
+  xllm::ScopeGuard rate_limit_guard(
+      [this] { master_.get_rate_limiter()->decrease_one_request(); });
+
   Timer timer;
   std::vector<int32_t> local_prompt_tokens;
   MMData processed_mm_data;
@@ -358,6 +363,7 @@ RecMaster::RecMasterPipeline::generate_onerec_request_common(
 
   COUNTER_ADD(tokenization_latency_seconds, timer.elapsed_seconds());
 
+  rate_limit_guard.dismiss();
   return master_.build_request_common(std::move(prompt),
                                       std::move(local_prompt_tokens),
                                       std::move(processed_mm_data),
@@ -378,6 +384,11 @@ std::shared_ptr<Request> RecMaster::LlmRecMasterPipeline::generate_request(
     std::optional<std::vector<proto::InferInputTensor>> /*input_tensors*/,
     const RequestParams& sp,
     OutputCallback callback) {
+  // Guard the rate-limit slot acquired at the service entry. Dismissed
+  // before we forward to build_request_common (which installs its own guard).
+  xllm::ScopeGuard rate_limit_guard(
+      [this] { master_.get_rate_limiter()->decrease_one_request(); });
+
   Timer timer;
   std::vector<int32_t> local_prompt_tokens;
   MMData processed_mm_data;
@@ -412,6 +423,7 @@ std::shared_ptr<Request> RecMaster::LlmRecMasterPipeline::generate_request(
 
   COUNTER_ADD(tokenization_latency_seconds, timer.elapsed_seconds());
 
+  rate_limit_guard.dismiss();
   return master_.build_request_common(std::move(prompt),
                                       std::move(local_prompt_tokens),
                                       std::move(processed_mm_data),
@@ -433,6 +445,9 @@ RecMaster::LlmRecWithMmDataMasterPipeline::generate_request(
     std::optional<MMData> mm_data,
     const RequestParams& sp,
     OutputCallback callback) {
+  xllm::ScopeGuard rate_limit_guard(
+      [this] { master_.get_rate_limiter()->decrease_one_request(); });
+
   std::vector<int32_t> local_prompt_tokens;
   MMData processed_mm_data;
 
@@ -447,6 +462,7 @@ RecMaster::LlmRecWithMmDataMasterPipeline::generate_request(
     return nullptr;
   }
 
+  rate_limit_guard.dismiss();
   return master_.build_request_common(std::string(""),
                                       std::move(local_prompt_tokens),
                                       std::move(processed_mm_data),
@@ -752,6 +768,11 @@ std::shared_ptr<Request> RecMaster::build_request_common(
     const RequestParams& sp,
     OutputCallback callback,
     bool build_stop_checker) {
+  // Guard the rate-limit slot acquired at the service entry. Dismissed
+  // right before Request takes ownership.
+  xllm::ScopeGuard rate_limit_guard(
+      [this] { get_rate_limiter()->decrease_one_request(); });
+
   int32_t max_context_len = model_args_.max_position_embeddings();
   if (!options_.enable_chunked_prefill()) {
     int32_t max_tokens_per_req = options_.max_tokens_per_batch();
@@ -859,12 +880,14 @@ std::shared_ptr<Request> RecMaster::build_request_common(
   req_state.include_stop_str_in_output = sp.include_stop_str_in_output;
   req_state.rec_type = rec_type_;
   req_state.bos_token_id = model_args_.bos_token_id();
+  rate_limit_guard.dismiss();
   auto request = std::make_shared<Request>(sp.request_id,
                                            sp.x_request_id,
                                            sp.x_request_time,
                                            std::move(req_state),
                                            sp.service_request_id,
-                                           sp.source_xservice_addr);
+                                           sp.source_xservice_addr,
+                                           get_rate_limiter());
   return request;
 }
 

--- a/xllm/core/distributed_runtime/rec_master.cpp
+++ b/xllm/core/distributed_runtime/rec_master.cpp
@@ -864,7 +864,8 @@ std::shared_ptr<Request> RecMaster::build_request_common(
                                            sp.x_request_time,
                                            std::move(req_state),
                                            sp.service_request_id,
-                                           sp.source_xservice_addr);
+                                           sp.source_xservice_addr,
+                                           get_rate_limiter());
   return request;
 }
 

--- a/xllm/core/distributed_runtime/vlm_master.cpp
+++ b/xllm/core/distributed_runtime/vlm_master.cpp
@@ -147,12 +147,17 @@ void VLMMaster::handle_request(std::string prompt,
     // remove the pending request after scheduling
     SCOPE_GUARD([this] { scheduler_->decr_pending_requests(); });
 
+    // Guard the rate-limit slot acquired at the service entry.
+    xllm::ScopeGuard rate_limit_guard(
+        [this] { get_rate_limiter()->decrease_one_request(); });
+
     Timer timer;
     // verify the prompt
     if (!sp.verify_params(callback)) {
       return;
     }
 
+    rate_limit_guard.dismiss();
     auto request = generate_request(std::move(prompt),
                                     std::move(mm_data),
                                     std::move(sp),
@@ -189,11 +194,16 @@ void VLMMaster::handle_request(std::vector<Message> messages,
     // remove the pending request after scheduling
     SCOPE_GUARD([this] { scheduler_->decr_pending_requests(); });
 
+    // Guard the rate-limit slot acquired at the service entry.
+    xllm::ScopeGuard rate_limit_guard(
+        [this] { get_rate_limiter()->decrease_one_request(); });
+
     // verify the prompt
     if (!sp.verify_params(callback)) {
       return;
     }
 
+    rate_limit_guard.dismiss();
     auto request = generate_request(std::move(messages),
                                     std::move(sp),
                                     std::move(payload),
@@ -307,6 +317,11 @@ std::shared_ptr<Request> VLMMaster::generate_request(std::string prompt,
                                                      MMData mm_data,
                                                      RequestParams sp,
                                                      OutputCallback callback) {
+  // Guard the rate-limit slot acquired at the service entry. build_request
+  // installs its own guard, so we dismiss ours before forwarding.
+  xllm::ScopeGuard rate_limit_guard(
+      [this] { get_rate_limiter()->decrease_one_request(); });
+
   if (prompt.empty() && mm_data.empty()) {
     LOG(ERROR) << "Prompt and multimodal data cannot be both empty.";
     CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
@@ -321,6 +336,7 @@ std::shared_ptr<Request> VLMMaster::generate_request(std::string prompt,
     return nullptr;
   }
 
+  rate_limit_guard.dismiss();
   return build_request(std::move(prompt),
                        std::move(prompt_tokens),
                        std::move(mm_data),
@@ -334,6 +350,12 @@ std::shared_ptr<Request> VLMMaster::build_request(
     MMData mm_data,
     RequestParams sp,
     OutputCallback callback) {
+  // Guard the rate-limit slot acquired at the service entry. Any early
+  // return below releases it; success path dismisses right before Request
+  // takes ownership.
+  xllm::ScopeGuard rate_limit_guard(
+      [this] { get_rate_limiter()->decrease_one_request(); });
+
   const int32_t max_context_len = model_args_.max_position_embeddings();
   int32_t prompt_token_limit = max_context_len;
   if (!options_.enable_chunked_prefill()) {
@@ -423,12 +445,14 @@ std::shared_ptr<Request> VLMMaster::build_request(
                          callback,
                          nullptr);
   req_state.include_stop_str_in_output = sp.include_stop_str_in_output;
+  rate_limit_guard.dismiss();
   auto request = std::make_shared<Request>(sp.request_id,
                                            sp.x_request_id,
                                            sp.x_request_time,
                                            std::move(req_state),
                                            sp.service_request_id,
-                                           sp.source_xservice_addr);
+                                           sp.source_xservice_addr,
+                                           get_rate_limiter());
 
   // add one sequence, rest will be added by scheduler
   return request;
@@ -439,6 +463,12 @@ std::shared_ptr<Request> VLMMaster::generate_request(
     RequestParams sp,
     std::string payload,
     OutputCallback callback) {
+  // Guard the rate-limit slot acquired at the service entry. The next hop
+  // (generate_request(prompt, ...)) installs its own guard, so we dismiss
+  // ours before forwarding.
+  xllm::ScopeGuard rate_limit_guard(
+      [this] { get_rate_limiter()->decrease_one_request(); });
+
   static MMInputTransfer mm_input_transfer;
 
   MMInput mm_inputs(std::move(payload));
@@ -469,6 +499,7 @@ std::shared_ptr<Request> VLMMaster::generate_request(
   }
   COUNTER_ADD(chat_template_latency_seconds, timer.elapsed_seconds());
 
+  rate_limit_guard.dismiss();
   return generate_request(std::move(prompt.value()),
                           std::move(mm_data),
                           std::move(sp),

--- a/xllm/core/distributed_runtime/vlm_master.cpp
+++ b/xllm/core/distributed_runtime/vlm_master.cpp
@@ -428,7 +428,8 @@ std::shared_ptr<Request> VLMMaster::build_request(
                                            sp.x_request_time,
                                            std::move(req_state),
                                            sp.service_request_id,
-                                           sp.source_xservice_addr);
+                                           sp.source_xservice_addr,
+                                           get_rate_limiter());
 
   // add one sequence, rest will be added by scheduler
   return request;

--- a/xllm/core/framework/request/CMakeLists.txt
+++ b/xllm/core/framework/request/CMakeLists.txt
@@ -30,6 +30,7 @@ cc_library(
     finish_reason.cpp
     incremental_decoder.cpp
     request.cpp
+    request_base.cpp
     dit_request.cpp
     request_output.cpp
     dit_request_output.cpp

--- a/xllm/core/framework/request/dit_request.cpp
+++ b/xllm/core/framework/request/dit_request.cpp
@@ -97,12 +97,14 @@ DiTRequest::DiTRequest(const std::string& request_id,
                        const std::string& x_request_time,
                        const DiTRequestState& state,
                        const std::string& service_request_id,
-                       const std::string& source_xservice_addr)
+                       const std::string& source_xservice_addr,
+                       RateLimiter* rate_limiter)
     : RequestBase(request_id,
                   x_request_id,
                   x_request_time,
                   service_request_id,
-                  source_xservice_addr),
+                  source_xservice_addr,
+                  rate_limiter),
       state_(state) {}
 
 bool DiTRequest::finished() const { return true; }

--- a/xllm/core/framework/request/dit_request.cpp
+++ b/xllm/core/framework/request/dit_request.cpp
@@ -27,6 +27,7 @@ limitations under the License.
 #include <vector>
 
 #include "api_service/call.h"
+#include "common/rate_limiter.h"
 #include "core/framework/multimodal/mm_codec.h"
 
 namespace xllm {
@@ -97,13 +98,28 @@ DiTRequest::DiTRequest(const std::string& request_id,
                        const std::string& x_request_time,
                        const DiTRequestState& state,
                        const std::string& service_request_id,
-                       const std::string& source_xservice_addr)
+                       const std::string& source_xservice_addr,
+                       RateLimiter* rate_limiter)
     : RequestBase(request_id,
                   x_request_id,
                   x_request_time,
                   service_request_id,
                   source_xservice_addr),
-      state_(state) {}
+      state_(state),
+      rate_limiter_(rate_limiter) {
+  if (rate_limiter_ != nullptr) {
+    rate_limiter_->increment();
+  }
+}
+
+DiTRequest::~DiTRequest() { release_rate_limit_slot(); }
+
+void DiTRequest::release_rate_limit_slot() {
+  if (rate_limiter_ != nullptr) {
+    rate_limiter_->decrease_one_request();
+    rate_limiter_ = nullptr;
+  }
+}
 
 bool DiTRequest::finished() const { return true; }
 

--- a/xllm/core/framework/request/dit_request.h
+++ b/xllm/core/framework/request/dit_request.h
@@ -38,7 +38,8 @@ class DiTRequest : public RequestBase {
              const std::string& x_request_time,
              const DiTRequestState& state,
              const std::string& service_request_id = "",
-             const std::string& source_xservice_addr = "");
+             const std::string& source_xservice_addr = "",
+             RateLimiter* rate_limiter = nullptr);
 
   bool finished() const;
 

--- a/xllm/core/framework/request/dit_request.h
+++ b/xllm/core/framework/request/dit_request.h
@@ -31,6 +31,8 @@ limitations under the License.
 
 namespace xllm {
 
+class RateLimiter;
+
 class DiTRequest : public RequestBase {
  public:
   DiTRequest(const std::string& request_id,
@@ -38,7 +40,17 @@ class DiTRequest : public RequestBase {
              const std::string& x_request_time,
              const DiTRequestState& state,
              const std::string& service_request_id = "",
-             const std::string& source_xservice_addr = "");
+             const std::string& source_xservice_addr = "",
+             RateLimiter* rate_limiter = nullptr);
+
+  ~DiTRequest();
+
+  DiTRequest(const DiTRequest&) = delete;
+  DiTRequest& operator=(const DiTRequest&) = delete;
+  DiTRequest(DiTRequest&&) = delete;
+  DiTRequest& operator=(DiTRequest&&) = delete;
+
+  void release_rate_limit_slot();
 
   bool finished() const;
 
@@ -55,6 +67,7 @@ class DiTRequest : public RequestBase {
  private:
   DiTRequestState state_;
   DiTForwardOutput output_;
+  RateLimiter* rate_limiter_ = nullptr;
 };
 
 }  // namespace xllm

--- a/xllm/core/framework/request/request.cpp
+++ b/xllm/core/framework/request/request.cpp
@@ -37,12 +37,14 @@ Request::Request(const std::string& request_id,
                  const std::string& x_request_time,
                  const RequestState& state,
                  const std::string& service_request_id,
-                 const std::string& source_xservice_addr)
+                 const std::string& source_xservice_addr,
+                 RateLimiter* rate_limiter)
     : RequestBase(request_id,
                   x_request_id,
                   x_request_time,
                   service_request_id,
-                  source_xservice_addr),
+                  source_xservice_addr,
+                  rate_limiter),
       state_(std::move(state)) {
   create_sequences_group();
 }

--- a/xllm/core/framework/request/request.cpp
+++ b/xllm/core/framework/request/request.cpp
@@ -27,6 +27,7 @@ limitations under the License.
 #include <vector>
 
 #include "api_service/call.h"
+#include "common/rate_limiter.h"
 #include "sequence.h"
 #include "util/timer.h"
 
@@ -37,14 +38,31 @@ Request::Request(const std::string& request_id,
                  const std::string& x_request_time,
                  const RequestState& state,
                  const std::string& service_request_id,
-                 const std::string& source_xservice_addr)
+                 const std::string& source_xservice_addr,
+                 RateLimiter* rate_limiter)
     : RequestBase(request_id,
                   x_request_id,
                   x_request_time,
                   service_request_id,
                   source_xservice_addr),
-      state_(std::move(state)) {
+      state_(std::move(state)),
+      rate_limiter_(rate_limiter) {
   create_sequences_group();
+  // Acquire the rate-limit slot last, so any exception thrown above skips it
+  // and no counter leaks. Callers must ensure the RateLimiter has spare
+  // capacity via check_limited() before constructing.
+  if (rate_limiter_ != nullptr) {
+    rate_limiter_->increment();
+  }
+}
+
+Request::~Request() { release_rate_limit_slot(); }
+
+void Request::release_rate_limit_slot() {
+  if (rate_limiter_ != nullptr) {
+    rate_limiter_->decrease_one_request();
+    rate_limiter_ = nullptr;
+  }
 }
 
 void Request::create_sequences_group() {

--- a/xllm/core/framework/request/request.h
+++ b/xllm/core/framework/request/request.h
@@ -42,7 +42,8 @@ class Request : public RequestBase {
           const std::string& x_request_time,
           const RequestState& state,
           const std::string& service_request_id = "",
-          const std::string& source_xservice_addr = "");
+          const std::string& source_xservice_addr = "",
+          RateLimiter* rate_limiter = nullptr);
 
   bool finished() const;
 

--- a/xllm/core/framework/request/request.h
+++ b/xllm/core/framework/request/request.h
@@ -33,6 +33,8 @@ limitations under the License.
 
 namespace xllm {
 
+class RateLimiter;
+
 enum class Urgency { STARVED = 2, URGENT = 1, NORMAL = 0 };
 
 class Request : public RequestBase {
@@ -42,7 +44,20 @@ class Request : public RequestBase {
           const std::string& x_request_time,
           const RequestState& state,
           const std::string& service_request_id = "",
-          const std::string& source_xservice_addr = "");
+          const std::string& source_xservice_addr = "",
+          RateLimiter* rate_limiter = nullptr);
+
+  ~Request();
+
+  Request(const Request&) = delete;
+  Request& operator=(const Request&) = delete;
+  Request(Request&&) = delete;
+  Request& operator=(Request&&) = delete;
+
+  // Release the rate-limit slot before destruction. Used when a request
+  // leaves the local instance's concurrency budget early (e.g. finished on
+  // prefill instance under disaggregated PD serving). Idempotent.
+  void release_rate_limit_slot();
 
   bool finished() const;
 
@@ -181,6 +196,11 @@ class Request : public RequestBase {
   bool starved_ = false;
 
   size_t num_prefix_cache_tokens_ = 0;
+
+  // Non-owning; nullptr for profile/warmup requests that don't count against
+  // the concurrency budget. Set to nullptr by release_rate_limit_slot() once
+  // the slot has been released.
+  RateLimiter* rate_limiter_ = nullptr;
 
   void create_sequences_group();
 };

--- a/xllm/core/framework/request/request_base.cpp
+++ b/xllm/core/framework/request/request_base.cpp
@@ -1,0 +1,48 @@
+/* Copyright 2025-2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "request_base.h"
+
+#include "common/rate_limiter.h"
+
+namespace xllm {
+
+RequestBase::RequestBase(const std::string& request_id,
+                         const std::string& x_request_id,
+                         const std::string& x_request_time,
+                         const std::string& service_request_id,
+                         const std::string& source_xservice_addr,
+                         RateLimiter* rate_limiter)
+    : created_time_(absl::Now()),
+      request_id_(request_id),
+      service_request_id_(service_request_id),
+      source_xservice_addr_(source_xservice_addr),
+      x_request_id_(x_request_id),
+      x_request_time_(x_request_time),
+      rate_limiter_(rate_limiter) {
+  // The caller (a service_impl entry) already incremented the counter via
+  // RateLimiter::is_limited() returning false. This constructor takes over
+  // ownership of that slot; the destructor releases it. Pass nullptr for
+  // requests that don't count against the concurrency budget (profile /
+  // warmup requests, PD-decode-side forwarded requests).
+}
+
+RequestBase::~RequestBase() {
+  if (rate_limiter_ != nullptr) {
+    rate_limiter_->decrease_one_request();
+  }
+}
+
+}  // namespace xllm

--- a/xllm/core/framework/request/request_base.h
+++ b/xllm/core/framework/request/request_base.h
@@ -31,19 +31,23 @@ limitations under the License.
 
 namespace xllm {
 
+class RateLimiter;
+
 class RequestBase {
  public:
   RequestBase(const std::string& request_id,
               const std::string& x_request_id,
               const std::string& x_request_time,
               const std::string& service_request_id = "",
-              const std::string& source_xservice_addr = "")
-      : request_id_(request_id),
-        x_request_id_(x_request_id),
-        x_request_time_(x_request_time),
-        service_request_id_(service_request_id),
-        source_xservice_addr_(source_xservice_addr),
-        created_time_(absl::Now()) {}
+              const std::string& source_xservice_addr = "",
+              RateLimiter* rate_limiter = nullptr);
+
+  virtual ~RequestBase();
+
+  RequestBase(const RequestBase&) = delete;
+  RequestBase& operator=(const RequestBase&) = delete;
+  RequestBase(RequestBase&&) = delete;
+  RequestBase& operator=(RequestBase&&) = delete;
 
   absl::Time created_time() const { return created_time_; }
 
@@ -79,6 +83,13 @@ class RequestBase {
 
   // x-request-time header value from client
   std::string x_request_time_;
+
+  // Non-owning; nullptr for profile/warmup requests and PD-decode-side
+  // forwarded requests that don't count against the concurrency budget. The
+  // slot is owned by whoever constructed the Request (either a scoped
+  // ScopeGuard on the failure path, or the Request itself on success). The
+  // destructor decrements exactly once when non-null.
+  RateLimiter* rate_limiter_ = nullptr;
 };
 
 }  // namespace xllm


### PR DESCRIPTION
## Summary

Bind the rate-limit slot's lifetime to the `Request` object via RAII, and make `RateLimiter::is_limited()` a single atomic CAS-loop instead of a `load` followed by `fetch_add`.

- Removes ~20 scattered manual `decrease_one_request()` calls across `api_service/` and `llm_master`'s batch callback.
- Fixes leak paths where an early return inside `generate_request` incremented the counter but never triggered a callback.
- Enforces `max_concurrent_requests` strictly: no more transient bursts above the limit under high concurrency.

## Motivation

Two bugs in the previous accounting:

1. **Non-atomic check + increment.** `is_limited()` did `load()` then `fetch_add(1)` as separate ops. With N concurrent callers all reading the same near-limit value, all of them could pass the check and all of them would `fetch_add`, pushing the counter past `max`. An e2e run with `max_concurrent_requests=50` and a burst of 100 saw `num_concurrent_requests` peak at **98** while the reject counter stayed at **0**.

2. **Manual -1 scattered across callbacks.** Every terminal branch (`error`, `finished`, `cancelled`, `finished_on_prefill_instance`) in every callback had its own `decrease_one_request()` line — ~20 sites. Early returns inside `generate_request` (empty prompt, encode failure, oov token, prompt-too-long, chat-template failure, invalid stop-token — 25 sites total) never reach a callback and leaked the slot.

## Approach

### 1. Atomic `is_limited()` (rate_limiter.cpp)

CAS-loop: check sleeping / >= max / attempt `expected → expected + 1` atomically; retry on lost race. API, return value, and semantics unchanged — every existing `if (is_limited()) reject` call site keeps working without modification.

```cpp
bool RateLimiter::is_limited() {
  int32_t expected = num_.load(relaxed);
  while (true) {
    if (expected == kSleeping) return true;
    if (max > 0 && expected >= max) { COUNTER_INC(...); return true; }
    if (num_.compare_exchange_weak(expected, expected + 1, acq_rel, relaxed)) {
      GAUGE_SET(...);
      return false;
    }
  }
}
```

### 2. Slot ownership follows the Request object

`RequestBase` gains a non-owning `RateLimiter*` field. The virtual destructor releases the slot exactly once; copy and move are `= delete` so a slot cannot be silently duplicated or leaked by a future edit. `Request` and `DiTRequest` just forward the pointer through their constructors.

### 3. `ScopeGuard` covers the acquire → construct gap

Between the `is_limited()` call at the service entry and `make_shared<Request>` deep inside `generate_request`, an `xllm::ScopeGuard` (the existing utility in `util/scope_guard.h`) holds the slot. Every early return releases it automatically via RAII; a `.dismiss()` right before `make_shared` transfers ownership to the newly-constructed `Request`.

This covers all 25 early-return paths across `llm_master.cpp`, `vlm_master.cpp`, `rec_master.cpp`, `dit_master.cpp` — plus `verify_params` paths in `handle_request` — without adding manual `-1` calls at each site.

### 4. Non-user-facing constructions opt out

`ProfileManager` (warmup requests) and `DisaggPDServiceImpl::generate_request` (decode-side forwarded requests) construct `Request` without passing a `RateLimiter*`. The default `nullptr` means the destructor is a no-op for them. Preserves existing behavior — profile requests never counted against user concurrency, and decode-side requests already had their slot accounted for on the prefill instance.

### 5. Callback cleanup

Every manual `decrease_one_request()` / `decrease_requests(size_t)` call in `api_service/*` and `llm_master`'s `batch_callback` is removed. `decrease_requests(size_t)` itself has no callers left and is removed from the header. `finished_on_prefill_instance` is now equivalent to `finished`: the `Request` is terminal, its `shared_ptr` goes out of scope, and the destructor releases the slot — behavior is equivalent to the previous immediate manual decrement (in both cases the slot is released within milliseconds of the marker being set).

## Test plan

- [x] `python setup.py build` — clean build, 342/342 targets.
- [x] `python setup.py test` — 1119/1119 passed.
- [x] `RequestLimiterTest.*` (rewritten): `Basic`, `NoLimitWhenMaxIsZero`, `SleepBlocksAcquisition` — all pass. Covers the atomic `is_limited()` semantics and the sleep state.
- [x] **Non-PD e2e**: 100 concurrent requests (test_per_raw.py, `--max-concurrency 100`) against a server with `max_concurrent_requests=50`.
  - `num_concurrent_requests` peaks at exactly **50** (measured 46 in a 2-second sample window — since the burst-and-drain lifecycle fits in <2 s the true peak can only be 50).
  - `server_request_total_limit` = **50** (exactly half rejected).
  - Gauge drains to **0** after the burst.
- [x] **PD-disaggregated e2e**: 1 prefill instance (`max_concurrent_requests=50`) + 1 decode instance + 1 xllm_service front door; 100 concurrent requests through the service.
  - Prefill `num_concurrent_requests` peaks at **50** (measured 50 in the sample), drains to 0.
  - Prefill `server_request_total_limit` = **19** (matches client-side Failed = 19 = 100 − 81 Successful).
  - Decode `num_concurrent_requests` stays 0 (decode-side Request doesn't own a slot, by design).
  - Fewer rejections in the PD case is expected: prefill slots turn over faster because a Request releases its slot as soon as it hands off to decode.

## Compared to the pre-fix behavior

Same e2e (100 concurrent, `max=50`) before this PR: gauge peaked at 98, reject counter stayed at 0. After this PR: gauge peaks at 50, reject counter matches client-side rejections exactly.
