### PR TITLE
perf: optimize GLM MTP scheduler overlap.

### DIFF
--- a/tests/core/framework/batch/batch_test.cpp
+++ b/tests/core/framework/batch/batch_test.cpp
@@ -1122,6 +1122,7 @@ TEST(BatchTest, ForwardInputPackedRoundTripPreservesTransportFields) {
   ForwardInput input =
       builder.build_forward_input(/*num_decoding_tokens=*/1,
                                   /*min_decoding_batch_size=*/0);
+  input.input_params.parallel.dp_global_batch_generations = {3, 7};
   input.input_params.embedding.mtp_bootstrap_row_idxes = {0};
   input.input_params.embedding.mtp_bootstrap_embeddings =
       torch::tensor({{3.0f, 4.0f}});
@@ -1151,6 +1152,8 @@ TEST(BatchTest, ForwardInputPackedRoundTripPreservesTransportFields) {
   EXPECT_EQ(mapping.remote_ids, (std::vector<uint64_t>{100}));
   EXPECT_EQ(round_trip.input_params.embedding.mtp_bootstrap_row_idxes,
             std::vector<int32_t>{0});
+  EXPECT_EQ(round_trip.input_params.parallel.dp_global_batch_generations,
+            (std::vector<uint64_t>{3, 7}));
   ASSERT_TRUE(
       round_trip.input_params.embedding.mtp_bootstrap_embeddings.defined());
   EXPECT_TRUE(torch::equal(

--- a/tests/core/framework/parallel_state/npu_dp_ep_padding_test.cpp
+++ b/tests/core/framework/parallel_state/npu_dp_ep_padding_test.cpp
@@ -128,4 +128,55 @@ TEST(DpEpPaddingTest, BuildAttnUnpaddingWithTrailingEmptyDpGroup) {
                            torch::tensor({0, 1}, torch::kInt32)));
 }
 
+TEST(DpEpPaddingCacheTest, ReusesBAndTwoBLayouts) {
+  DpEpPaddingCache cache(/*capacity=*/2);
+  DpEpPaddingData b_data;
+  b_data.attn_padding_idx(torch::tensor({1}, torch::kInt32));
+  DpEpPaddingData two_b_data;
+  two_b_data.attn_padding_idx(torch::tensor({2}, torch::kInt32));
+
+  cache.insert({4}, {}, b_data);
+  cache.insert({8}, {8}, two_b_data);
+
+  const DpEpPaddingData* cached_b = cache.find({4}, {4});
+  const DpEpPaddingData* cached_two_b = cache.find({8}, {});
+  ASSERT_NE(cached_b, nullptr);
+  ASSERT_NE(cached_two_b, nullptr);
+  EXPECT_EQ(cached_b->attn_padding_idx().item<int32_t>(), 1);
+  EXPECT_EQ(cached_two_b->attn_padding_idx().item<int32_t>(), 2);
+}
+
+TEST(DpEpPaddingCacheTest, DistinguishesDataParallelTokenDistributions) {
+  DpEpPaddingCache cache(/*capacity=*/2);
+  DpEpPaddingData b_data;
+  b_data.attn_padding_idx(torch::tensor({1}, torch::kInt32));
+  DpEpPaddingData two_b_data;
+  two_b_data.attn_padding_idx(torch::tensor({2}, torch::kInt32));
+
+  cache.insert({1, 2}, {1, 2}, b_data);
+  cache.insert({2, 4}, {2, 4}, two_b_data);
+
+  const DpEpPaddingData* cached_b = cache.find({1, 2}, {1, 2});
+  const DpEpPaddingData* cached_two_b = cache.find({2, 4}, {2, 4});
+  ASSERT_NE(cached_b, nullptr);
+  ASSERT_NE(cached_two_b, nullptr);
+  EXPECT_EQ(cached_b->attn_padding_idx().item<int32_t>(), 1);
+  EXPECT_EQ(cached_two_b->attn_padding_idx().item<int32_t>(), 2);
+  EXPECT_EQ(cache.find({2, 1}, {2, 1}), nullptr);
+  EXPECT_EQ(cache.find({1, 2}, {2, 1}), nullptr);
+}
+
+TEST(DpEpPaddingCacheTest, EvictsOldLayoutAtCapacity) {
+  DpEpPaddingCache cache(/*capacity=*/2);
+  DpEpPaddingData data;
+
+  cache.insert({4}, {}, data);
+  cache.insert({8}, {}, data);
+  cache.insert({6}, {}, data);
+
+  EXPECT_EQ(cache.find({4}, {}), nullptr);
+  EXPECT_NE(cache.find({8}, {}), nullptr);
+  EXPECT_NE(cache.find({6}, {}), nullptr);
+}
+
 }  // namespace xllm

--- a/tests/core/runtime/mtp_async_state_test.cpp
+++ b/tests/core/runtime/mtp_async_state_test.cpp
@@ -34,6 +34,7 @@ TEST(MtpAsyncStateTest, ClassifiesClosedTargetSpecVerifyPolicy) {
       {"qwen3_next", TargetSpecVerifyMode::GENERIC},
       {"qwen3_5_mtp", TargetSpecVerifyMode::GENERIC},
       {"qwen3_5_moe_mtp", TargetSpecVerifyMode::GENERIC},
+      {"glm_moe_dsa", TargetSpecVerifyMode::GENERIC},
       {"mimo_mtp", TargetSpecVerifyMode::GENERIC},
       {"unknown_model", TargetSpecVerifyMode::GENERIC},
   };
@@ -50,9 +51,58 @@ TEST(MtpAsyncStateTest, ClassifiesSupportedCombinedDraftExecutionPaths) {
   EXPECT_EQ(classify_combined_draft_execution_path("qwen3_5_moe_mtp"),
             CombinedDraftExecutionPath::QWEN3_5_PAGED_ATTENTION);
   EXPECT_EQ(classify_combined_draft_execution_path("glm_moe_dsa_mtp"),
-            CombinedDraftExecutionPath::UNSUPPORTED);
+            CombinedDraftExecutionPath::GLM_MOE_DSA_SPARSE_ATTENTION);
   EXPECT_EQ(classify_combined_draft_execution_path("mimo_mtp"),
             CombinedDraftExecutionPath::UNSUPPORTED);
+}
+
+TEST(MtpAsyncStateTest, RestrictsCombinedDraftToValidatedConfigurations) {
+  EXPECT_TRUE(supports_combined_draft_configuration(
+      CombinedDraftExecutionPath::QWEN3_5_PAGED_ATTENTION,
+      "TORCH",
+      /*dp_size=*/1));
+  EXPECT_FALSE(supports_combined_draft_configuration(
+      CombinedDraftExecutionPath::QWEN3_5_PAGED_ATTENTION,
+      "ATB",
+      /*dp_size=*/1));
+  EXPECT_FALSE(supports_combined_draft_configuration(
+      CombinedDraftExecutionPath::QWEN3_5_PAGED_ATTENTION,
+      "TORCH",
+      /*dp_size=*/2));
+  EXPECT_TRUE(supports_combined_draft_configuration(
+      CombinedDraftExecutionPath::GLM_MOE_DSA_SPARSE_ATTENTION,
+      "ATB",
+      /*dp_size=*/1));
+  EXPECT_TRUE(supports_combined_draft_configuration(
+      CombinedDraftExecutionPath::GLM_MOE_DSA_SPARSE_ATTENTION,
+      "ATB",
+      /*dp_size=*/2));
+  EXPECT_FALSE(supports_combined_draft_configuration(
+      CombinedDraftExecutionPath::GLM_MOE_DSA_SPARSE_ATTENTION,
+      "TORCH",
+      /*dp_size=*/1));
+  EXPECT_FALSE(supports_combined_draft_configuration(
+      CombinedDraftExecutionPath::UNSUPPORTED, "ATB", /*dp_size=*/1));
+}
+
+TEST(MtpAsyncStateTest, ExtractsTargetBaseKvLengthsFromVerifyLayouts) {
+  const torch::Tensor chunked_kv_seq_lens =
+      torch::tensor({104, 204}, torch::kInt);
+  const torch::Tensor decode_kv_seq_lens =
+      torch::tensor({101, 102, 103, 104, 201, 202, 203, 204}, torch::kInt);
+
+  EXPECT_TRUE(torch::equal(
+      extract_target_base_kv_seq_lens(chunked_kv_seq_lens,
+                                      /*batch_size=*/2,
+                                      /*num_validate_tokens=*/4,
+                                      /*use_chunked_prefill=*/true),
+      torch::tensor({101, 201}, torch::kInt)));
+  EXPECT_TRUE(torch::equal(
+      extract_target_base_kv_seq_lens(decode_kv_seq_lens,
+                                      /*batch_size=*/2,
+                                      /*num_validate_tokens=*/4,
+                                      /*use_chunked_prefill=*/false),
+      torch::tensor({101, 201}, torch::kInt)));
 }
 
 TEST(MtpAsyncStateTest, ComputesSharedSpecVerifyBlockTableCapacity) {
@@ -122,6 +172,24 @@ TEST(MtpAsyncStateTest, BuildsMixedAcceptanceStateWithoutHostRoundTrip) {
                            torch::tensor({105, 203, 302}, torch::kLong)));
 }
 
+TEST(MtpAsyncStateTest, BuildsTargetMetadataWithoutEmbeddingGather) {
+  const torch::Tensor accepted_tokens = torch::tensor(
+      {{10, 11, 12, 13}, {20, 21, -1, -1}, {30, -1, -1, -1}}, torch::kLong);
+  const torch::Tensor base_positions = torch::tensor({100, 200, 300});
+  const torch::Tensor base_kv_seq_lens = torch::tensor({101, 201, 301});
+
+  const AcceptedTokenMetadata metadata = build_accepted_token_metadata(
+      accepted_tokens, base_positions, base_kv_seq_lens);
+
+  EXPECT_TRUE(torch::equal(metadata.accepted_lengths,
+                           torch::tensor({4, 2, 1}, torch::kLong)));
+  EXPECT_TRUE(torch::equal(metadata.last_tokens, torch::tensor({13, 21, 30})));
+  EXPECT_TRUE(torch::equal(metadata.base_positions,
+                           torch::tensor({104, 202, 301}, torch::kLong)));
+  EXPECT_TRUE(torch::equal(metadata.base_kv_seq_lens,
+                           torch::tensor({105, 203, 302}, torch::kLong)));
+}
+
 TEST(MtpAsyncStateTest, BuildsRowMetadataForChunkedAndDecodeLayouts) {
   AcceptedState state;
   state.base_positions = torch::tensor({104, 202, 301}, torch::kLong);
@@ -156,6 +224,24 @@ TEST(MtpAsyncStateTest, MapsPositionsAcrossCacheBlockBoundaries) {
   EXPECT_TRUE(torch::equal(
       map_positions_to_cache_slots(block_tables, positions, /*block_size=*/4),
       torch::tensor({43, 44, 87, 88}, torch::kInt)));
+}
+
+TEST(MtpAsyncStateTest, BuildsLaterDraftMetadataFromAcceptedDeviceBase) {
+  AcceptedState state;
+  state.base_positions = torch::tensor({3, 7}, torch::kLong);
+  state.base_kv_seq_lens = torch::tensor({4, 8}, torch::kInt);
+  const torch::Tensor offsets = torch::tensor({2}, torch::kLong);
+  const torch::Tensor positions = make_row_positions(state, offsets);
+  const torch::Tensor block_tables =
+      torch::tensor({{10, 11, 12}, {20, 21, 22}}, torch::kInt);
+
+  EXPECT_TRUE(torch::equal(positions, torch::tensor({{5}, {9}}, torch::kLong)));
+  EXPECT_TRUE(torch::equal(
+      make_kv_seq_lens(state, offsets, /*use_chunked_prefill=*/false),
+      torch::tensor({6, 10}, torch::kLong)));
+  EXPECT_TRUE(torch::equal(
+      map_positions_to_cache_slots(block_tables, positions, /*block_size=*/4),
+      torch::tensor({45, 89}, torch::kInt)));
 }
 
 }  // namespace

--- a/tests/core/runtime/mtp_async_state_test.cpp
+++ b/tests/core/runtime/mtp_async_state_test.cpp
@@ -33,6 +33,7 @@ TEST(MtpAsyncStateTest, ClassifiesClosedTargetSpecVerifyPolicy) {
       {"qwen3_next", TargetSpecVerifyMode::GENERIC},
       {"qwen3_5_mtp", TargetSpecVerifyMode::GENERIC},
       {"qwen3_5_moe_mtp", TargetSpecVerifyMode::GENERIC},
+      {"glm_moe_dsa", TargetSpecVerifyMode::GENERIC},
       {"mimo_mtp", TargetSpecVerifyMode::GENERIC},
       {"unknown_model", TargetSpecVerifyMode::GENERIC},
   };
@@ -49,9 +50,58 @@ TEST(MtpAsyncStateTest, ClassifiesSupportedCombinedDraftExecutionPaths) {
   EXPECT_EQ(classify_combined_draft_execution_path("qwen3_5_moe_mtp"),
             CombinedDraftExecutionPath::QWEN3_5_PAGED_ATTENTION);
   EXPECT_EQ(classify_combined_draft_execution_path("glm_moe_dsa_mtp"),
-            CombinedDraftExecutionPath::UNSUPPORTED);
+            CombinedDraftExecutionPath::GLM_MOE_DSA_SPARSE_ATTENTION);
   EXPECT_EQ(classify_combined_draft_execution_path("mimo_mtp"),
             CombinedDraftExecutionPath::UNSUPPORTED);
+}
+
+TEST(MtpAsyncStateTest, RestrictsCombinedDraftToValidatedConfigurations) {
+  EXPECT_TRUE(supports_combined_draft_configuration(
+      CombinedDraftExecutionPath::QWEN3_5_PAGED_ATTENTION,
+      "TORCH",
+      /*dp_size=*/1));
+  EXPECT_FALSE(supports_combined_draft_configuration(
+      CombinedDraftExecutionPath::QWEN3_5_PAGED_ATTENTION,
+      "ATB",
+      /*dp_size=*/1));
+  EXPECT_FALSE(supports_combined_draft_configuration(
+      CombinedDraftExecutionPath::QWEN3_5_PAGED_ATTENTION,
+      "TORCH",
+      /*dp_size=*/2));
+  EXPECT_TRUE(supports_combined_draft_configuration(
+      CombinedDraftExecutionPath::GLM_MOE_DSA_SPARSE_ATTENTION,
+      "ATB",
+      /*dp_size=*/1));
+  EXPECT_TRUE(supports_combined_draft_configuration(
+      CombinedDraftExecutionPath::GLM_MOE_DSA_SPARSE_ATTENTION,
+      "ATB",
+      /*dp_size=*/2));
+  EXPECT_FALSE(supports_combined_draft_configuration(
+      CombinedDraftExecutionPath::GLM_MOE_DSA_SPARSE_ATTENTION,
+      "TORCH",
+      /*dp_size=*/1));
+  EXPECT_FALSE(supports_combined_draft_configuration(
+      CombinedDraftExecutionPath::UNSUPPORTED, "ATB", /*dp_size=*/1));
+}
+
+TEST(MtpAsyncStateTest, ExtractsTargetBaseKvLengthsFromVerifyLayouts) {
+  const torch::Tensor chunked_kv_seq_lens =
+      torch::tensor({104, 204}, torch::kInt);
+  const torch::Tensor decode_kv_seq_lens =
+      torch::tensor({101, 102, 103, 104, 201, 202, 203, 204}, torch::kInt);
+
+  EXPECT_TRUE(torch::equal(
+      extract_target_base_kv_seq_lens(chunked_kv_seq_lens,
+                                      /*batch_size=*/2,
+                                      /*num_validate_tokens=*/4,
+                                      /*use_chunked_prefill=*/true),
+      torch::tensor({101, 201}, torch::kInt)));
+  EXPECT_TRUE(torch::equal(
+      extract_target_base_kv_seq_lens(decode_kv_seq_lens,
+                                      /*batch_size=*/2,
+                                      /*num_validate_tokens=*/4,
+                                      /*use_chunked_prefill=*/false),
+      torch::tensor({101, 201}, torch::kInt)));
 }
 
 TEST(MtpAsyncStateTest, ComputesSharedSpecVerifyBlockTableCapacity) {
@@ -121,6 +171,24 @@ TEST(MtpAsyncStateTest, BuildsMixedAcceptanceStateWithoutHostRoundTrip) {
                            torch::tensor({105, 203, 302}, torch::kLong)));
 }
 
+TEST(MtpAsyncStateTest, BuildsTargetMetadataWithoutEmbeddingGather) {
+  const torch::Tensor accepted_tokens = torch::tensor(
+      {{10, 11, 12, 13}, {20, 21, -1, -1}, {30, -1, -1, -1}}, torch::kLong);
+  const torch::Tensor base_positions = torch::tensor({100, 200, 300});
+  const torch::Tensor base_kv_seq_lens = torch::tensor({101, 201, 301});
+
+  const AcceptedTokenMetadata metadata = build_accepted_token_metadata(
+      accepted_tokens, base_positions, base_kv_seq_lens);
+
+  EXPECT_TRUE(torch::equal(metadata.accepted_lengths,
+                           torch::tensor({4, 2, 1}, torch::kLong)));
+  EXPECT_TRUE(torch::equal(metadata.last_tokens, torch::tensor({13, 21, 30})));
+  EXPECT_TRUE(torch::equal(metadata.base_positions,
+                           torch::tensor({104, 202, 301}, torch::kLong)));
+  EXPECT_TRUE(torch::equal(metadata.base_kv_seq_lens,
+                           torch::tensor({105, 203, 302}, torch::kLong)));
+}
+
 TEST(MtpAsyncStateTest, BuildsRowMetadataForChunkedAndDecodeLayouts) {
   AcceptedState state;
   state.base_positions = torch::tensor({104, 202, 301}, torch::kLong);
@@ -155,6 +223,24 @@ TEST(MtpAsyncStateTest, MapsPositionsAcrossCacheBlockBoundaries) {
   EXPECT_TRUE(torch::equal(
       map_positions_to_cache_slots(block_tables, positions, /*block_size=*/4),
       torch::tensor({43, 44, 87, 88}, torch::kInt)));
+}
+
+TEST(MtpAsyncStateTest, BuildsLaterDraftMetadataFromAcceptedDeviceBase) {
+  AcceptedState state;
+  state.base_positions = torch::tensor({3, 7}, torch::kLong);
+  state.base_kv_seq_lens = torch::tensor({4, 8}, torch::kInt);
+  const torch::Tensor offsets = torch::tensor({2}, torch::kLong);
+  const torch::Tensor positions = make_row_positions(state, offsets);
+  const torch::Tensor block_tables =
+      torch::tensor({{10, 11, 12}, {20, 21, 22}}, torch::kInt);
+
+  EXPECT_TRUE(torch::equal(positions, torch::tensor({{5}, {9}}, torch::kLong)));
+  EXPECT_TRUE(torch::equal(
+      make_kv_seq_lens(state, offsets, /*use_chunked_prefill=*/false),
+      torch::tensor({6, 10}, torch::kLong)));
+  EXPECT_TRUE(torch::equal(
+      map_positions_to_cache_slots(block_tables, positions, /*block_size=*/4),
+      torch::tensor({45, 89}, torch::kInt)));
 }
 
 }  // namespace

--- a/xllm/core/distributed_runtime/llm_engine.cpp
+++ b/xllm/core/distributed_runtime/llm_engine.cpp
@@ -98,6 +98,9 @@ LLMEngine::LLMEngine(const runtime::Options& options,
 
   dp_size_ = options_.dp_size();
   cp_size_ = options_.cp_size();
+  dp_batch_embedding_ids_.resize(dp_size_);
+  dp_batch_request_ids_.resize(dp_size_);
+  dp_batch_generations_.resize(dp_size_, 0);
   worker_clients_num_ = worker_clients_.size();
   dp_local_size_ = worker_clients_num_ / dp_size_;
   const bool use_model_sharding =
@@ -1362,6 +1365,15 @@ std::vector<ForwardInput> LLMEngine::prepare_inputs(std::vector<Batch>& batch) {
     dp_is_decode[dp_rank] =
         current_batch_forward_type.is_decode() &&
         batched_inputs[dp_rank].input_params.meta.q_max_seq_len == 1;
+
+    const ModelEmbeddingInput& embedding =
+        batched_inputs[dp_rank].input_params.embedding;
+    if (dp_batch_embedding_ids_[dp_rank] != embedding.embedding_ids ||
+        dp_batch_request_ids_[dp_rank] != embedding.request_ids) {
+      dp_batch_embedding_ids_[dp_rank] = embedding.embedding_ids;
+      dp_batch_request_ids_[dp_rank] = embedding.request_ids;
+      ++dp_batch_generations_[dp_rank];
+    }
   }
 
   // eplb related
@@ -1392,6 +1404,8 @@ std::vector<ForwardInput> LLMEngine::prepare_inputs(std::vector<Batch>& batch) {
         dp_global_token_nums;
     batched_inputs[dp_rank].input_params.parallel.raw_dp_global_token_nums =
         dp_global_token_nums;
+    batched_inputs[dp_rank].input_params.parallel.dp_global_batch_generations =
+        dp_batch_generations_;
     batched_inputs[dp_rank].input_params.parallel.dp_global_kv_max_seq_lens =
         dp_global_kv_max_seq_lens;
     batched_inputs[dp_rank].input_params.parallel.dp_is_decode = dp_is_decode;

--- a/xllm/core/distributed_runtime/llm_engine.h
+++ b/xllm/core/distributed_runtime/llm_engine.h
@@ -23,6 +23,7 @@ limitations under the License.
 #include <cstdint>
 #include <deque>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "common/macros.h"
@@ -200,6 +201,9 @@ class LLMEngine : public Engine {
   // Effective TP width (MLU=dp_local; NPU=dp_local/cp).
   uint32_t dp_local_tp_size_;
   uint32_t dp_local_size_;
+  std::vector<std::vector<int32_t>> dp_batch_embedding_ids_;
+  std::vector<std::vector<std::string>> dp_batch_request_ids_;
+  std::vector<uint64_t> dp_batch_generations_;
 
   // For multi-node serving
   // engine brpc server, all workers connect to engine_server_,

--- a/xllm/core/framework/model/model_input_params.h
+++ b/xllm/core/framework/model/model_input_params.h
@@ -855,6 +855,10 @@ struct ParallelInput {
   // Attention/FFN paths may need the padded counts, while lm_head output
   // compaction must skip true empty DP ranks.
   std::vector<int32_t> raw_dp_global_token_nums;
+  // Per-DP-shard generation derived from the local batch identity. Every shard
+  // receives the full vector so speculative prelaunch reuse decisions remain
+  // collective-order consistent when any shard changes its batch.
+  std::vector<uint64_t> dp_global_batch_generations;
   // max kv seq len of all dp shards. Graph key generation uses this so empty
   // DP decode ranks pick the same graph as ranks with real decode tokens.
   std::vector<int32_t> dp_global_kv_max_seq_lens;
@@ -880,6 +884,7 @@ struct ParallelInput {
     ParallelInput out;
     out.dp_global_token_nums = dp_global_token_nums;
     out.raw_dp_global_token_nums = raw_dp_global_token_nums;
+    out.dp_global_batch_generations = dp_global_batch_generations;
     out.dp_global_kv_max_seq_lens = dp_global_kv_max_seq_lens;
     out.dp_is_decode = dp_is_decode;
     out.dp_ep_padding_data = dp_ep_padding_data;

--- a/xllm/core/framework/parallel_state/npu_dp_ep_padding.cpp
+++ b/xllm/core/framework/parallel_state/npu_dp_ep_padding.cpp
@@ -24,6 +24,48 @@ limitations under the License.
 
 namespace xllm {
 
+DpEpPaddingCache::DpEpPaddingCache(size_t capacity) : capacity_(capacity) {
+  CHECK_GT(capacity_, 0);
+  entries_.reserve(capacity_);
+}
+
+const DpEpPaddingData* DpEpPaddingCache::find(
+    const std::vector<int32_t>& token_size_per_dp_group,
+    const std::vector<int32_t>& raw_token_size_per_dp_group) const {
+  const std::vector<int32_t>& normalized_raw_token_sizes =
+      raw_token_size_per_dp_group.empty() ? token_size_per_dp_group
+                                          : raw_token_size_per_dp_group;
+  for (const Entry& entry : entries_) {
+    if (entry.token_size_per_dp_group == token_size_per_dp_group &&
+        entry.raw_token_size_per_dp_group == normalized_raw_token_sizes) {
+      return &entry.data;
+    }
+  }
+  return nullptr;
+}
+
+void DpEpPaddingCache::insert(
+    const std::vector<int32_t>& token_size_per_dp_group,
+    const std::vector<int32_t>& raw_token_size_per_dp_group,
+    const DpEpPaddingData& data) {
+  const std::vector<int32_t>& normalized_raw_token_sizes =
+      raw_token_size_per_dp_group.empty() ? token_size_per_dp_group
+                                          : raw_token_size_per_dp_group;
+  for (Entry& entry : entries_) {
+    if (entry.token_size_per_dp_group == token_size_per_dp_group &&
+        entry.raw_token_size_per_dp_group == normalized_raw_token_sizes) {
+      entry.data = data;
+      return;
+    }
+  }
+
+  if (entries_.size() == capacity_) {
+    entries_.erase(entries_.begin());
+  }
+  entries_.emplace_back(
+      Entry{token_size_per_dp_group, normalized_raw_token_sizes, data});
+}
+
 void DpEpPaddingData::set_placeholder(const torch::Tensor& placeholder) {
   attn_padding_idx_ = placeholder;
   attn_unpadding_idx_ = placeholder;

--- a/xllm/core/framework/parallel_state/npu_dp_ep_padding.h
+++ b/xllm/core/framework/parallel_state/npu_dp_ep_padding.h
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <torch/torch.h>
 
+#include <cstddef>
 #include <vector>
 
 #include "common/macros.h"
@@ -50,6 +51,31 @@ struct DpEpPaddingData {
   PROPERTY(torch::Tensor, expert_array);
 
   PROPERTY(torch::Tensor, post_lmhead_gather_indices);
+};
+
+// A small exact-key cache for stable B/2B draft decode layouts. Prefill
+// metadata must always be rebuilt and is intentionally not represented here.
+class DpEpPaddingCache final {
+ public:
+  explicit DpEpPaddingCache(size_t capacity);
+
+  const DpEpPaddingData* find(
+      const std::vector<int32_t>& token_size_per_dp_group,
+      const std::vector<int32_t>& raw_token_size_per_dp_group) const;
+
+  void insert(const std::vector<int32_t>& token_size_per_dp_group,
+              const std::vector<int32_t>& raw_token_size_per_dp_group,
+              const DpEpPaddingData& data);
+
+ private:
+  struct Entry {
+    std::vector<int32_t> token_size_per_dp_group;
+    std::vector<int32_t> raw_token_size_per_dp_group;
+    DpEpPaddingData data;
+  };
+
+  size_t capacity_ = 0;
+  std::vector<Entry> entries_;
 };
 
 class DpEpPadding {

--- a/xllm/core/layers/npu/npu_deepseek_v32_decoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_deepseek_v32_decoder_layer_impl.cpp
@@ -1167,6 +1167,11 @@ void NpuDeepseekV32DecoderLayerImpl::build_node_variant_pack(
   const CpAttentionMeta& cp_attention_meta =
       input_params.parallel.cp_plan.attention_meta();
   const bool use_cp_ep_padding = (cp_size_ > 1 && is_prefill);
+  const bool uses_dsa_attention =
+      (is_prefill ? prefill_param_ : decode_param_).index_n_heads > 0;
+  // DSA passes sequence lengths to LightningIndexer/SparseFlashAttention as
+  // device aclTensors. Only dense MLA converts these inputs from hostData into
+  // aclIntArray metadata.
 
   if (dp_size_ <= 1 && ep_size_ <= 1 || cp_size_ > 1) {
     dp_ep_padding.set_placeholder(tensor_placeholder_);
@@ -1202,14 +1207,18 @@ void NpuDeepseekV32DecoderLayerImpl::build_node_variant_pack(
            nullptr)) {
     node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 11) =
         atb_speed::Utils::AtTensor2Tensor(int_tensor_placeholder_);
-    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 11).hostData =
-        const_cast<int32_t*>(placeholder_vec_.data());
+    if (!uses_dsa_attention) {
+      node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 11).hostData =
+          const_cast<int32_t*>(placeholder_vec_.data());
+    }
   } else {
     node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 11) =
         atb_speed::Utils::AtTensor2Tensor(
             input_params.attention.device.kv_seq_lens);
-    node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 11).hostData =
-        const_cast<int32_t*>(input_params.attention.host.kv_seq_lens.data());
+    if (!uses_dsa_attention) {
+      node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 11).hostData =
+          const_cast<int32_t*>(input_params.attention.host.kv_seq_lens.data());
+    }
   }
 
   node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 12) =
@@ -1242,14 +1251,18 @@ void NpuDeepseekV32DecoderLayerImpl::build_node_variant_pack(
              nullptr)) {
       node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 17) =
           atb_speed::Utils::AtTensor2Tensor(int_tensor_placeholder_);
-      node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 17).hostData =
-          const_cast<int32_t*>(placeholder_vec_.data());
+      if (!uses_dsa_attention) {
+        node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 17).hostData =
+            const_cast<int32_t*>(placeholder_vec_.data());
+      }
     } else {
       node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 17) =
           atb_speed::Utils::AtTensor2Tensor(
               input_params.attention.device.q_seq_lens);
-      node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 17).hostData =
-          const_cast<int32_t*>(input_params.attention.host.q_seq_lens.data());
+      if (!uses_dsa_attention) {
+        node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 17).hostData =
+            const_cast<int32_t*>(input_params.attention.host.q_seq_lens.data());
+      }
     }
   } else {
     node.variantPack.inTensors.at(WEIGHT_COUNT_PER_LAYER + 17) =

--- a/xllm/core/runtime/forward_params.h
+++ b/xllm/core/runtime/forward_params.h
@@ -533,6 +533,7 @@ struct ForwardInput {
     inputs.skip_sampling_for_logits_only = skip_sampling_for_logits_only;
     inputs.kv_slot_layout = kv_slot_layout;
     inputs.metadata_ready_event = metadata_ready_event;
+    inputs.retained_device_tensors = retained_device_tensors;
   }
 
   void set_host_views(ForwardInput& inputs) const {
@@ -614,6 +615,10 @@ struct ForwardInput {
   // stream. These are local runtime handles and are intentionally not included
   // in proto or shared-memory transport.
   StreamEventPtr metadata_ready_event;
+
+  // Keep cross-stream metadata sources alive through no-sync execution. These
+  // handles are local runtime state and are not serialized.
+  std::vector<torch::Tensor> retained_device_tensors;
 };
 
 // output after forward execution

--- a/xllm/core/runtime/forward_shared_memory_manager.cpp
+++ b/xllm/core/runtime/forward_shared_memory_manager.cpp
@@ -2363,6 +2363,7 @@ inline void deserialize_forward_input_payload(
   read_tensor(context, input_params.embedding.input_embedding, stream);
   read_vector(context, input_params.parallel.dp_global_token_nums);
   read_vector(context, input_params.parallel.raw_dp_global_token_nums);
+  read_vector(context, input_params.parallel.dp_global_batch_generations);
   read_vector(context, input_params.parallel.dp_global_kv_max_seq_lens);
   read_vector(context, input_params.parallel.dp_is_decode);
   read_vector(context, input_params.embedding.embedding_ids);
@@ -2727,6 +2728,8 @@ inline void serialize_forward_input_sections(
   write_vector(context.descriptor, input_params.parallel.dp_global_token_nums);
   write_vector(context.descriptor,
                input_params.parallel.raw_dp_global_token_nums);
+  write_vector(context.descriptor,
+               input_params.parallel.dp_global_batch_generations);
   write_vector(context.descriptor,
                input_params.parallel.dp_global_kv_max_seq_lens);
   write_vector(context.descriptor, input_params.parallel.dp_is_decode);

--- a/xllm/core/runtime/mtp_async_input_builder.cpp
+++ b/xllm/core/runtime/mtp_async_input_builder.cpp
@@ -192,4 +192,94 @@ void prepare_next_draft_from_accepted_state(
 #endif
 }
 
+void prepare_later_draft_from_device_base(
+    ForwardInput& draft_input,
+    const ForwardInput& block_table_source,
+    const torch::Tensor& base_positions,
+    const torch::Tensor& base_kv_seq_lens,
+    int32_t position_offset,
+    int32_t block_size) {
+  CHECK(base_positions.defined());
+  CHECK(base_kv_seq_lens.defined());
+  CHECK_EQ(base_positions.dim(), 1);
+  CHECK_EQ(base_kv_seq_lens.dim(), 1);
+  CHECK_EQ(base_positions.numel(), base_kv_seq_lens.numel());
+  CHECK_GT(position_offset, 0);
+
+  torch::Tensor row_positions =
+      (base_positions + position_offset).unsqueeze(/*dim=*/1);
+  draft_input.positions =
+      row_positions.flatten().to(draft_input.positions.options());
+  draft_input.input_params.attention.device.new_cache_slots =
+      build_device_cache_slots(block_table_source, row_positions, block_size);
+  draft_input.input_params.attention.device.kv_seq_lens =
+      (base_kv_seq_lens + position_offset)
+          .to(draft_input.input_params.attention.device.kv_seq_lens.options());
+}
+
+void prepare_target_verify_from_accepted_state(
+    ForwardInput& validate_input,
+    const torch::Tensor& accepted_tokens,
+    const torch::Tensor& base_positions,
+    const torch::Tensor& base_kv_seq_lens,
+    int32_t block_size) {
+  CHECK(validate_input.token_ids.defined());
+  CHECK(validate_input.positions.defined());
+  CHECK_EQ(accepted_tokens.dim(), 2);
+  const int64_t batch_size = accepted_tokens.size(0);
+  const int64_t validate_width = accepted_tokens.size(1);
+  CHECK_EQ(validate_input.token_ids.numel(), batch_size * validate_width);
+  CHECK_EQ(validate_input.positions.numel(), batch_size * validate_width);
+
+  AcceptedTokenMetadata metadata = build_accepted_token_metadata(
+      accepted_tokens, base_positions, base_kv_seq_lens);
+  torch::Tensor template_position_rows =
+      validate_input.positions.view({batch_size, validate_width});
+  torch::Tensor position_delta =
+      metadata.base_positions -
+      template_position_rows.select(/*dim=*/1, /*index=*/0).to(torch::kLong);
+  torch::Tensor position_rows =
+      template_position_rows.to(torch::kLong) + position_delta.unsqueeze(1);
+  validate_input.positions =
+      position_rows.flatten().to(validate_input.positions.options());
+  if (validate_input.input_params.multi_block_tables.empty()) {
+    const torch::Tensor& expanded_block_tables =
+        validate_input.input_params.attention.device.block_tables;
+    CHECK(expanded_block_tables.defined());
+    CHECK_EQ(expanded_block_tables.dim(), 2);
+    CHECK_EQ(expanded_block_tables.size(0), batch_size * validate_width);
+    torch::Tensor sequence_block_tables =
+        expanded_block_tables
+            .view({batch_size, validate_width, expanded_block_tables.size(1)})
+            .select(/*dim=*/1, /*index=*/0);
+    validate_input.input_params.attention.device.new_cache_slots =
+        map_positions_to_cache_slots(
+            sequence_block_tables, position_rows, block_size);
+  } else {
+    validate_input.input_params.attention.device.new_cache_slots =
+        torch::zeros_like(position_rows,
+                          position_rows.options().dtype(torch::kInt))
+            .flatten();
+  }
+
+  torch::Tensor template_kv_rows =
+      validate_input.input_params.attention.device.kv_seq_lens.view(
+          {batch_size, validate_width});
+  torch::Tensor kv_delta =
+      metadata.base_kv_seq_lens -
+      template_kv_rows.select(/*dim=*/1, /*index=*/0).to(torch::kLong);
+  validate_input.input_params.attention.device.kv_seq_lens =
+      (template_kv_rows.to(torch::kLong) + kv_delta.unsqueeze(1))
+          .flatten()
+          .to(validate_input.input_params.attention.device.kv_seq_lens
+                  .options());
+
+  torch::Tensor token_rows =
+      validate_input.token_ids.view({batch_size, validate_width});
+  token_rows.select(/*dim=*/1, /*index=*/0)
+      .copy_(metadata.last_tokens.to(validate_input.token_ids.options()),
+             /*non_blocking=*/true);
+  validate_input.device_tensors_ready = true;
+}
+
 }  // namespace xllm::mtp_async

--- a/xllm/core/runtime/mtp_async_input_builder.cpp
+++ b/xllm/core/runtime/mtp_async_input_builder.cpp
@@ -141,4 +141,94 @@ void prepare_next_draft_from_accepted_state(
           .flatten(/*start_dim=*/0, /*end_dim=*/1);
 }
 
+void prepare_later_draft_from_device_base(
+    ForwardInput& draft_input,
+    const ForwardInput& block_table_source,
+    const torch::Tensor& base_positions,
+    const torch::Tensor& base_kv_seq_lens,
+    int32_t position_offset,
+    int32_t block_size) {
+  CHECK(base_positions.defined());
+  CHECK(base_kv_seq_lens.defined());
+  CHECK_EQ(base_positions.dim(), 1);
+  CHECK_EQ(base_kv_seq_lens.dim(), 1);
+  CHECK_EQ(base_positions.numel(), base_kv_seq_lens.numel());
+  CHECK_GT(position_offset, 0);
+
+  torch::Tensor row_positions =
+      (base_positions + position_offset).unsqueeze(/*dim=*/1);
+  draft_input.positions =
+      row_positions.flatten().to(draft_input.positions.options());
+  draft_input.input_params.attention.device.new_cache_slots =
+      build_device_cache_slots(block_table_source, row_positions, block_size);
+  draft_input.input_params.attention.device.kv_seq_lens =
+      (base_kv_seq_lens + position_offset)
+          .to(draft_input.input_params.attention.device.kv_seq_lens.options());
+}
+
+void prepare_target_verify_from_accepted_state(
+    ForwardInput& validate_input,
+    const torch::Tensor& accepted_tokens,
+    const torch::Tensor& base_positions,
+    const torch::Tensor& base_kv_seq_lens,
+    int32_t block_size) {
+  CHECK(validate_input.token_ids.defined());
+  CHECK(validate_input.positions.defined());
+  CHECK_EQ(accepted_tokens.dim(), 2);
+  const int64_t batch_size = accepted_tokens.size(0);
+  const int64_t validate_width = accepted_tokens.size(1);
+  CHECK_EQ(validate_input.token_ids.numel(), batch_size * validate_width);
+  CHECK_EQ(validate_input.positions.numel(), batch_size * validate_width);
+
+  AcceptedTokenMetadata metadata = build_accepted_token_metadata(
+      accepted_tokens, base_positions, base_kv_seq_lens);
+  torch::Tensor template_position_rows =
+      validate_input.positions.view({batch_size, validate_width});
+  torch::Tensor position_delta =
+      metadata.base_positions -
+      template_position_rows.select(/*dim=*/1, /*index=*/0).to(torch::kLong);
+  torch::Tensor position_rows =
+      template_position_rows.to(torch::kLong) + position_delta.unsqueeze(1);
+  validate_input.positions =
+      position_rows.flatten().to(validate_input.positions.options());
+  if (validate_input.input_params.multi_block_tables.empty()) {
+    const torch::Tensor& expanded_block_tables =
+        validate_input.input_params.attention.device.block_tables;
+    CHECK(expanded_block_tables.defined());
+    CHECK_EQ(expanded_block_tables.dim(), 2);
+    CHECK_EQ(expanded_block_tables.size(0), batch_size * validate_width);
+    torch::Tensor sequence_block_tables =
+        expanded_block_tables
+            .view({batch_size, validate_width, expanded_block_tables.size(1)})
+            .select(/*dim=*/1, /*index=*/0);
+    validate_input.input_params.attention.device.new_cache_slots =
+        map_positions_to_cache_slots(
+            sequence_block_tables, position_rows, block_size);
+  } else {
+    validate_input.input_params.attention.device.new_cache_slots =
+        torch::zeros_like(position_rows,
+                          position_rows.options().dtype(torch::kInt))
+            .flatten();
+  }
+
+  torch::Tensor template_kv_rows =
+      validate_input.input_params.attention.device.kv_seq_lens.view(
+          {batch_size, validate_width});
+  torch::Tensor kv_delta =
+      metadata.base_kv_seq_lens -
+      template_kv_rows.select(/*dim=*/1, /*index=*/0).to(torch::kLong);
+  validate_input.input_params.attention.device.kv_seq_lens =
+      (template_kv_rows.to(torch::kLong) + kv_delta.unsqueeze(1))
+          .flatten()
+          .to(validate_input.input_params.attention.device.kv_seq_lens
+                  .options());
+
+  torch::Tensor token_rows =
+      validate_input.token_ids.view({batch_size, validate_width});
+  token_rows.select(/*dim=*/1, /*index=*/0)
+      .copy_(metadata.last_tokens.to(validate_input.token_ids.options()),
+             /*non_blocking=*/true);
+  validate_input.device_tensors_ready = true;
+}
+
 }  // namespace xllm::mtp_async

--- a/xllm/core/runtime/mtp_async_input_builder.h
+++ b/xllm/core/runtime/mtp_async_input_builder.h
@@ -39,5 +39,26 @@ void prepare_next_draft_from_accepted_state(
     bool use_chunked_prefill,
     int32_t block_size);
 
+// Builds one-row-per-sequence metadata for a later draft step from the
+// accepted device base used by draft-0. The caller must order this work after
+// draft-0 metadata correction on the same stream.
+void prepare_later_draft_from_device_base(
+    ForwardInput& draft_input,
+    const ForwardInput& block_table_source,
+    const torch::Tensor& base_positions,
+    const torch::Tensor& base_kv_seq_lens,
+    int32_t position_offset,
+    int32_t block_size);
+
+// Corrects an already prepared fixed-shape target verification template from
+// the previous target's accepted device state. Draft token columns remain
+// placeholders and are filled after their producing draft forwards.
+void prepare_target_verify_from_accepted_state(
+    ForwardInput& validate_input,
+    const torch::Tensor& accepted_tokens,
+    const torch::Tensor& base_positions,
+    const torch::Tensor& base_kv_seq_lens,
+    int32_t block_size);
+
 }  // namespace mtp_async
 }  // namespace xllm

--- a/xllm/core/runtime/mtp_async_state.cpp
+++ b/xllm/core/runtime/mtp_async_state.cpp
@@ -68,7 +68,25 @@ CombinedDraftExecutionPath classify_combined_draft_execution_path(
   if (model_type == "qwen3_5_mtp" || model_type == "qwen3_5_moe_mtp") {
     return CombinedDraftExecutionPath::QWEN3_5_PAGED_ATTENTION;
   }
+  if (model_type == "glm_moe_dsa_mtp") {
+    return CombinedDraftExecutionPath::GLM_MOE_DSA_SPARSE_ATTENTION;
+  }
   return CombinedDraftExecutionPath::UNSUPPORTED;
+}
+
+bool supports_combined_draft_configuration(
+    CombinedDraftExecutionPath execution_path,
+    std::string_view npu_backend,
+    int32_t dp_size) {
+  switch (execution_path) {
+    case CombinedDraftExecutionPath::QWEN3_5_PAGED_ATTENTION:
+      return npu_backend == "TORCH" && dp_size <= 1;
+    case CombinedDraftExecutionPath::GLM_MOE_DSA_SPARSE_ATTENTION:
+      return npu_backend == "ATB";
+    case CombinedDraftExecutionPath::UNSUPPORTED:
+      return false;
+  }
+  return false;
 }
 
 torch::Tensor materialize_speculative_verify_tokens(
@@ -94,31 +112,55 @@ torch::Tensor materialize_speculative_verify_tokens(
   return verify_tokens;
 }
 
+torch::Tensor extract_target_base_kv_seq_lens(
+    const torch::Tensor& validate_kv_seq_lens,
+    int64_t batch_size,
+    int64_t num_validate_tokens,
+    bool use_chunked_prefill) {
+  CHECK(validate_kv_seq_lens.defined());
+  CHECK_GT(batch_size, 0);
+  CHECK_GT(num_validate_tokens, 0);
+  torch::Tensor flattened = validate_kv_seq_lens.flatten();
+  if (use_chunked_prefill) {
+    CHECK_GE(flattened.numel(), batch_size);
+    return flattened.slice(/*dim=*/0, /*start=*/0, /*end=*/batch_size) -
+           (num_validate_tokens - 1);
+  }
+
+  const int64_t expanded_rows = batch_size * num_validate_tokens;
+  CHECK_GE(flattened.numel(), expanded_rows);
+  return flattened.slice(/*dim=*/0, /*start=*/0, /*end=*/expanded_rows)
+      .view({batch_size, num_validate_tokens})
+      .select(/*dim=*/1, /*index=*/0)
+      .contiguous();
+}
+
 AcceptedState build_accepted_state(const torch::Tensor& accepted_tokens,
                                    const torch::Tensor& accepted_embeddings,
                                    const torch::Tensor& embedding_placeholder,
                                    const torch::Tensor& base_positions,
                                    const torch::Tensor& base_kv_seq_lens) {
-  CHECK_EQ(accepted_tokens.dim(), 2);
+  AcceptedTokenMetadata token_metadata = build_accepted_token_metadata(
+      accepted_tokens, base_positions, base_kv_seq_lens);
   CHECK_EQ(accepted_embeddings.dim(), 3);
   const int64_t batch_size = accepted_tokens.size(0);
   CHECK_EQ(accepted_embeddings.size(0), batch_size);
-  CHECK_GE(base_positions.numel(), batch_size);
-  CHECK_GE(base_kv_seq_lens.numel(), batch_size);
 
   AcceptedState state;
-  state.accepted_lengths =
-      accepted_tokens.ge(0).sum(/*dim=*/1).to(torch::kLong);
+  state.accepted_lengths = token_metadata.accepted_lengths;
   state.all_draft_accepted =
       state.accepted_lengths.eq(accepted_tokens.size(/*dim=*/1));
-  torch::Tensor last_indices = (state.accepted_lengths - 1).clamp_min(0);
+  state.last_tokens = token_metadata.last_tokens;
+  state.base_positions = token_metadata.base_positions;
+  state.base_kv_seq_lens = token_metadata.base_kv_seq_lens;
+
   torch::Tensor previous_indices = (state.accepted_lengths - 2).clamp_min(0);
-  state.last_tokens = gather_sequence_rows(accepted_tokens, last_indices);
   torch::Tensor gathered_previous_tokens =
       gather_sequence_rows(accepted_tokens, previous_indices);
   torch::Tensor has_previous = state.accepted_lengths.gt(1);
   state.previous_tokens =
       torch::where(has_previous, gathered_previous_tokens, state.last_tokens);
+  torch::Tensor last_indices = (state.accepted_lengths - 1).clamp_min(0);
   state.last_embeddings =
       gather_sequence_rows(accepted_embeddings, last_indices);
   torch::Tensor gathered_previous_embeddings =
@@ -132,13 +174,31 @@ AcceptedState build_accepted_state(const torch::Tensor& accepted_tokens,
                                            gathered_previous_embeddings,
                                            placeholder);
 
-  state.base_positions =
-      base_positions.flatten().slice(0, 0, batch_size).to(torch::kLong) +
-      state.accepted_lengths;
-  state.base_kv_seq_lens =
-      base_kv_seq_lens.flatten().slice(0, 0, batch_size).to(torch::kLong) +
-      state.accepted_lengths;
   return state;
+}
+
+AcceptedTokenMetadata build_accepted_token_metadata(
+    const torch::Tensor& accepted_tokens,
+    const torch::Tensor& base_positions,
+    const torch::Tensor& base_kv_seq_lens) {
+  CHECK_EQ(accepted_tokens.dim(), 2);
+  const int64_t batch_size = accepted_tokens.size(0);
+  CHECK_GT(accepted_tokens.size(1), 0);
+  CHECK_GE(base_positions.numel(), batch_size);
+  CHECK_GE(base_kv_seq_lens.numel(), batch_size);
+
+  AcceptedTokenMetadata metadata;
+  metadata.accepted_lengths =
+      accepted_tokens.ge(0).sum(/*dim=*/1).to(torch::kLong);
+  torch::Tensor last_indices = (metadata.accepted_lengths - 1).clamp_min(0);
+  metadata.last_tokens = gather_sequence_rows(accepted_tokens, last_indices);
+  metadata.base_positions =
+      base_positions.flatten().slice(0, 0, batch_size).to(torch::kLong) +
+      metadata.accepted_lengths;
+  metadata.base_kv_seq_lens =
+      base_kv_seq_lens.flatten().slice(0, 0, batch_size).to(torch::kLong) +
+      metadata.accepted_lengths;
+  return metadata;
 }
 
 torch::Tensor make_row_positions(const AcceptedState& state,

--- a/xllm/core/runtime/mtp_async_state.cpp
+++ b/xllm/core/runtime/mtp_async_state.cpp
@@ -64,7 +64,25 @@ CombinedDraftExecutionPath classify_combined_draft_execution_path(
   if (model_type == "qwen3_5_mtp" || model_type == "qwen3_5_moe_mtp") {
     return CombinedDraftExecutionPath::QWEN3_5_PAGED_ATTENTION;
   }
+  if (model_type == "glm_moe_dsa_mtp") {
+    return CombinedDraftExecutionPath::GLM_MOE_DSA_SPARSE_ATTENTION;
+  }
   return CombinedDraftExecutionPath::UNSUPPORTED;
+}
+
+bool supports_combined_draft_configuration(
+    CombinedDraftExecutionPath execution_path,
+    std::string_view npu_backend,
+    int32_t dp_size) {
+  switch (execution_path) {
+    case CombinedDraftExecutionPath::QWEN3_5_PAGED_ATTENTION:
+      return npu_backend == "TORCH" && dp_size <= 1;
+    case CombinedDraftExecutionPath::GLM_MOE_DSA_SPARSE_ATTENTION:
+      return npu_backend == "ATB";
+    case CombinedDraftExecutionPath::UNSUPPORTED:
+      return false;
+  }
+  return false;
 }
 
 torch::Tensor materialize_speculative_verify_tokens(
@@ -90,31 +108,55 @@ torch::Tensor materialize_speculative_verify_tokens(
   return verify_tokens;
 }
 
+torch::Tensor extract_target_base_kv_seq_lens(
+    const torch::Tensor& validate_kv_seq_lens,
+    int64_t batch_size,
+    int64_t num_validate_tokens,
+    bool use_chunked_prefill) {
+  CHECK(validate_kv_seq_lens.defined());
+  CHECK_GT(batch_size, 0);
+  CHECK_GT(num_validate_tokens, 0);
+  torch::Tensor flattened = validate_kv_seq_lens.flatten();
+  if (use_chunked_prefill) {
+    CHECK_GE(flattened.numel(), batch_size);
+    return flattened.slice(/*dim=*/0, /*start=*/0, /*end=*/batch_size) -
+           (num_validate_tokens - 1);
+  }
+
+  const int64_t expanded_rows = batch_size * num_validate_tokens;
+  CHECK_GE(flattened.numel(), expanded_rows);
+  return flattened.slice(/*dim=*/0, /*start=*/0, /*end=*/expanded_rows)
+      .view({batch_size, num_validate_tokens})
+      .select(/*dim=*/1, /*index=*/0)
+      .contiguous();
+}
+
 AcceptedState build_accepted_state(const torch::Tensor& accepted_tokens,
                                    const torch::Tensor& accepted_embeddings,
                                    const torch::Tensor& embedding_placeholder,
                                    const torch::Tensor& base_positions,
                                    const torch::Tensor& base_kv_seq_lens) {
-  CHECK_EQ(accepted_tokens.dim(), 2);
+  AcceptedTokenMetadata token_metadata = build_accepted_token_metadata(
+      accepted_tokens, base_positions, base_kv_seq_lens);
   CHECK_EQ(accepted_embeddings.dim(), 3);
   const int64_t batch_size = accepted_tokens.size(0);
   CHECK_EQ(accepted_embeddings.size(0), batch_size);
-  CHECK_GE(base_positions.numel(), batch_size);
-  CHECK_GE(base_kv_seq_lens.numel(), batch_size);
 
   AcceptedState state;
-  state.accepted_lengths =
-      accepted_tokens.ge(0).sum(/*dim=*/1).to(torch::kLong);
+  state.accepted_lengths = token_metadata.accepted_lengths;
   state.all_draft_accepted =
       state.accepted_lengths.eq(accepted_tokens.size(/*dim=*/1));
-  torch::Tensor last_indices = (state.accepted_lengths - 1).clamp_min(0);
+  state.last_tokens = token_metadata.last_tokens;
+  state.base_positions = token_metadata.base_positions;
+  state.base_kv_seq_lens = token_metadata.base_kv_seq_lens;
+
   torch::Tensor previous_indices = (state.accepted_lengths - 2).clamp_min(0);
-  state.last_tokens = gather_sequence_rows(accepted_tokens, last_indices);
   torch::Tensor gathered_previous_tokens =
       gather_sequence_rows(accepted_tokens, previous_indices);
   torch::Tensor has_previous = state.accepted_lengths.gt(1);
   state.previous_tokens =
       torch::where(has_previous, gathered_previous_tokens, state.last_tokens);
+  torch::Tensor last_indices = (state.accepted_lengths - 1).clamp_min(0);
   state.last_embeddings =
       gather_sequence_rows(accepted_embeddings, last_indices);
   torch::Tensor gathered_previous_embeddings =
@@ -128,13 +170,31 @@ AcceptedState build_accepted_state(const torch::Tensor& accepted_tokens,
                                            gathered_previous_embeddings,
                                            placeholder);
 
-  state.base_positions =
-      base_positions.flatten().slice(0, 0, batch_size).to(torch::kLong) +
-      state.accepted_lengths;
-  state.base_kv_seq_lens =
-      base_kv_seq_lens.flatten().slice(0, 0, batch_size).to(torch::kLong) +
-      state.accepted_lengths;
   return state;
+}
+
+AcceptedTokenMetadata build_accepted_token_metadata(
+    const torch::Tensor& accepted_tokens,
+    const torch::Tensor& base_positions,
+    const torch::Tensor& base_kv_seq_lens) {
+  CHECK_EQ(accepted_tokens.dim(), 2);
+  const int64_t batch_size = accepted_tokens.size(0);
+  CHECK_GT(accepted_tokens.size(1), 0);
+  CHECK_GE(base_positions.numel(), batch_size);
+  CHECK_GE(base_kv_seq_lens.numel(), batch_size);
+
+  AcceptedTokenMetadata metadata;
+  metadata.accepted_lengths =
+      accepted_tokens.ge(0).sum(/*dim=*/1).to(torch::kLong);
+  torch::Tensor last_indices = (metadata.accepted_lengths - 1).clamp_min(0);
+  metadata.last_tokens = gather_sequence_rows(accepted_tokens, last_indices);
+  metadata.base_positions =
+      base_positions.flatten().slice(0, 0, batch_size).to(torch::kLong) +
+      metadata.accepted_lengths;
+  metadata.base_kv_seq_lens =
+      base_kv_seq_lens.flatten().slice(0, 0, batch_size).to(torch::kLong) +
+      metadata.accepted_lengths;
+  return metadata;
 }
 
 torch::Tensor make_row_positions(const AcceptedState& state,

--- a/xllm/core/runtime/mtp_async_state.h
+++ b/xllm/core/runtime/mtp_async_state.h
@@ -43,10 +43,16 @@ int64_t speculative_verify_block_table_capacity(int64_t max_position_embeddings,
 enum class CombinedDraftExecutionPath {
   UNSUPPORTED,
   QWEN3_5_PAGED_ATTENTION,
+  GLM_MOE_DSA_SPARSE_ATTENTION,
 };
 
 CombinedDraftExecutionPath classify_combined_draft_execution_path(
     std::string_view model_type);
+
+bool supports_combined_draft_configuration(
+    CombinedDraftExecutionPath execution_path,
+    std::string_view npu_backend,
+    int32_t dp_size);
 
 // Materialize proposer-owned token columns into the row-major target verify
 // input. Graph replay normally performs this copy internally; eager fallback
@@ -54,6 +60,15 @@ CombinedDraftExecutionPath classify_combined_draft_execution_path(
 torch::Tensor materialize_speculative_verify_tokens(
     const torch::Tensor& verify_tokens,
     const std::vector<torch::Tensor>& draft_token_sources);
+
+// Recover the KV length at the first target-verify token. Chunked-prefill
+// stores one post-verify length per sequence, while decode stores one length
+// per expanded verification row.
+torch::Tensor extract_target_base_kv_seq_lens(
+    const torch::Tensor& validate_kv_seq_lens,
+    int64_t batch_size,
+    int64_t num_validate_tokens,
+    bool use_chunked_prefill);
 
 // Device-resident state derived from target verification. base_positions and
 // base_kv_seq_lens point at the logical position immediately after the accepted
@@ -68,6 +83,18 @@ struct AcceptedState {
   torch::Tensor base_positions;
   torch::Tensor base_kv_seq_lens;
 };
+
+struct AcceptedTokenMetadata {
+  torch::Tensor accepted_lengths;
+  torch::Tensor last_tokens;
+  torch::Tensor base_positions;
+  torch::Tensor base_kv_seq_lens;
+};
+
+AcceptedTokenMetadata build_accepted_token_metadata(
+    const torch::Tensor& accepted_tokens,
+    const torch::Tensor& base_positions,
+    const torch::Tensor& base_kv_seq_lens);
 
 AcceptedState build_accepted_state(const torch::Tensor& accepted_tokens,
                                    const torch::Tensor& accepted_embeddings,

--- a/xllm/core/runtime/mtp_async_state.h
+++ b/xllm/core/runtime/mtp_async_state.h
@@ -42,10 +42,16 @@ int64_t speculative_verify_block_table_capacity(int64_t max_position_embeddings,
 enum class CombinedDraftExecutionPath {
   UNSUPPORTED,
   QWEN3_5_PAGED_ATTENTION,
+  GLM_MOE_DSA_SPARSE_ATTENTION,
 };
 
 CombinedDraftExecutionPath classify_combined_draft_execution_path(
     std::string_view model_type);
+
+bool supports_combined_draft_configuration(
+    CombinedDraftExecutionPath execution_path,
+    std::string_view npu_backend,
+    int32_t dp_size);
 
 // Materialize proposer-owned token columns into the row-major target verify
 // input. Graph replay normally performs this copy internally; eager fallback
@@ -53,6 +59,15 @@ CombinedDraftExecutionPath classify_combined_draft_execution_path(
 torch::Tensor materialize_speculative_verify_tokens(
     const torch::Tensor& verify_tokens,
     const std::vector<torch::Tensor>& draft_token_sources);
+
+// Recover the KV length at the first target-verify token. Chunked-prefill
+// stores one post-verify length per sequence, while decode stores one length
+// per expanded verification row.
+torch::Tensor extract_target_base_kv_seq_lens(
+    const torch::Tensor& validate_kv_seq_lens,
+    int64_t batch_size,
+    int64_t num_validate_tokens,
+    bool use_chunked_prefill);
 
 // Device-resident state derived from target verification. base_positions and
 // base_kv_seq_lens point at the logical position immediately after the accepted
@@ -67,6 +82,18 @@ struct AcceptedState {
   torch::Tensor base_positions;
   torch::Tensor base_kv_seq_lens;
 };
+
+struct AcceptedTokenMetadata {
+  torch::Tensor accepted_lengths;
+  torch::Tensor last_tokens;
+  torch::Tensor base_positions;
+  torch::Tensor base_kv_seq_lens;
+};
+
+AcceptedTokenMetadata build_accepted_token_metadata(
+    const torch::Tensor& accepted_tokens,
+    const torch::Tensor& base_positions,
+    const torch::Tensor& base_kv_seq_lens);
 
 AcceptedState build_accepted_state(const torch::Tensor& accepted_tokens,
                                    const torch::Tensor& accepted_embeddings,

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -528,11 +528,6 @@ KVCacheShape MTPDraftKVCacheShape(const KVCacheShape& target_shape,
   return KVCacheShape(draft_capacity, draft_model_args, /*world_size=*/1);
 }
 
-bool is_qwen3_5_draft_model_type(const std::string& model_type) {
-  return mtp_async::classify_combined_draft_execution_path(model_type) ==
-         mtp_async::CombinedDraftExecutionPath::QWEN3_5_PAGED_ATTENTION;
-}
-
 }  // namespace
 
 MTPWorkerImpl::MTPWorkerImpl(const ParallelArgs& parallel_args,
@@ -584,10 +579,13 @@ bool MTPWorkerImpl::init_model(const std::string& model_weights_path,
 
   if (draft_impl_ != nullptr &&
       draft_impl_->get_status() == WorkerImpl::Status::LOADED) {
+    combined_draft_execution_path_ =
+        mtp_async::classify_combined_draft_execution_path(
+            draft_impl_->context_.get_model_args().model_type());
     const bool draft_owns_shared_weights =
         options_.enable_mtp_draft_body_tp1() &&
-        is_qwen3_5_draft_model_type(
-            draft_impl_->context_.get_model_args().model_type());
+        combined_draft_execution_path_ ==
+            mtp_async::CombinedDraftExecutionPath::QWEN3_5_PAGED_ATTENTION;
     // Qwen3.5 draft checkpoints contain complete embedding and LMHead weights.
     // Other MTP drafts retain their existing target-weight sharing contract;
     // only their transformer body is replicated with TP1 parallel arguments.
@@ -855,7 +853,7 @@ void MTPWorkerImpl::prepare_work_before_execute(const ForwardInput& input,
   SpeculativeWorkerImpl::prepare_work_before_execute(input, processed_input);
 }
 
-bool MTPWorkerImpl::owns_npu_cp_plan_build() const { return false; }
+bool MTPWorkerImpl::owns_npu_parallel_input_prepare() const { return false; }
 
 std::optional<ForwardOutput> MTPWorkerImpl::step_empty(
     const ForwardInput& input) {
@@ -1178,7 +1176,8 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
   if (use_prelaunched_first_draft) {
     // The first draft was fully prepared and submitted by the preceding
     // run_validate(). Host metadata is corrected below after the accepted-token
-    // update; it is only needed for draft steps 1..N-1 and target verification.
+    // update; continuous DSA drafts use device correction, while target
+    // verification still consumes the exact Host metadata.
   } else if (use_device_target_context) {
     c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
 
@@ -1254,6 +1253,61 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
     metadata_template = input;
     prepare_draft_extend_inputs(input, last_states, current_draft_input);
   }
+
+  const bool use_continuous_dsa_drafts =
+      (use_device_target_context || use_prelaunched_first_draft) &&
+      combined_draft_execution_path_ ==
+          mtp_async::CombinedDraftExecutionPath::GLM_MOE_DSA_SPARSE_ATTENTION;
+  std::vector<ForwardInput> later_draft_inputs;
+  torch::Tensor accepted_base_positions;
+  torch::Tensor accepted_base_kv_seq_lens;
+  if (use_continuous_dsa_drafts) {
+    later_draft_inputs.resize(num_speculative_tokens);
+    const ForwardInput& combined_draft_input =
+        use_prelaunched_first_draft ? pending_draft_context_.prepared_input
+                                    : current_draft_input;
+    const int64_t batch_size = input.input_params.meta.num_sequences;
+    CHECK_EQ(combined_draft_input.positions.numel(), batch_size * 2)
+        << "combined draft positions must contain [repair,current] rows";
+    CHECK_EQ(
+        combined_draft_input.input_params.attention.device.kv_seq_lens.numel(),
+        batch_size * 2)
+        << "combined draft KV lengths must contain [repair,current] rows";
+    accepted_base_positions =
+        combined_draft_input.positions.view({batch_size, 2}).select(1, 1);
+    accepted_base_kv_seq_lens =
+        combined_draft_input.input_params.attention.device.kv_seq_lens
+            .view({batch_size, 2})
+            .select(1, 1);
+
+    for (int32_t draft_idx = 1; draft_idx < num_speculative_tokens;
+         ++draft_idx) {
+      // Only the fixed B layout is needed on prepare_stream. Reusing offset 0
+      // avoids extending an already conservative Host template past the
+      // scheduler-allocated block range; device metadata is replaced below.
+      prepare_draft_inputs(metadata_template,
+                           later_draft_inputs[draft_idx],
+                           /*position_offset=*/0);
+    }
+  }
+
+  const auto materialize_pending_target_host_state = [&]() {
+    flush_pending_target_context();
+    std::vector<EmbeddingCache::DecodeState> resolved_states =
+        embedding_cache_->read_decode_states(
+            input.input_params.embedding.embedding_ids,
+            input.input_params.embedding.request_ids);
+    // The scheduler input contains the conservative overlap placeholder.
+    // Force cache correction before comparing it with the accepted target.
+    input.token_ids_host = torch::full_like(input.token_ids_host, -1);
+    update_decode_step_input(input, resolved_states);
+    check_mtp_decode_states(resolved_states,
+                            input.input_params.embedding.request_ids,
+                            input.token_ids_host,
+                            /*allow_overlap_fake_token=*/false);
+    metadata_template = input;
+  };
+
   draft_outputs.reserve(num_speculative_tokens);
   const bool reuse_mtp_topk_state = layer::is_mtp_dsa_topk_reuse_enabled(
       draft_impl_->context_.get_model_args());
@@ -1261,7 +1315,7 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
   for (int32_t draft_idx = 0; draft_idx < num_speculative_tokens; ++draft_idx) {
     const bool is_final_draft = draft_idx == num_speculative_tokens - 1;
     const bool static_graph_tasks_prepared =
-        is_final_draft &&
+        is_final_draft && !use_continuous_dsa_drafts &&
         prepare_static_mtp_graph_tasks_before_final_draft(input);
     if (reuse_mtp_topk_state) {
       current_draft_input.input_params.mtp_topk_state = mtp_topk_state;
@@ -1281,34 +1335,62 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
     }
 
     if ((use_device_target_context || use_prelaunched_first_draft) &&
-        draft_idx == 0) {
+        !use_continuous_dsa_drafts && draft_idx == 0) {
       // The next draft forward is already queued behind target validation.
       // It can start immediately when rejection sampling finishes while the
       // worker materializes the accepted state for later draft/target metadata
       // on CPU.  This synchronization is therefore outside the NPU critical
       // path rather than sitting between target and draft launches.
-      flush_pending_target_context();
-      std::vector<EmbeddingCache::DecodeState> resolved_states =
-          embedding_cache_->read_decode_states(
-              input.input_params.embedding.embedding_ids,
-              input.input_params.embedding.request_ids);
-      // The scheduler input still contains the conservative placeholder used
-      // to launch the first draft.  Materialize the accepted host state before
-      // comparing token ids; otherwise this check compares the new target
-      // result with the intentionally stale overlap template.
-      input.token_ids_host = torch::full_like(input.token_ids_host, -1);
-      update_decode_step_input(input, resolved_states);
-      check_mtp_decode_states(resolved_states,
-                              input.input_params.embedding.request_ids,
-                              input.token_ids_host,
-                              /*allow_overlap_fake_token=*/false);
-      metadata_template = input;
+      materialize_pending_target_host_state();
+    }
+
+    if (use_continuous_dsa_drafts && is_final_draft) {
+      // Queue target metadata before the Host target-context wait. The fixed
+      // template can be copied immediately; its real device values are
+      // corrected after a prepare-stream wait on the previous target event.
+      prepare_validate_inputs(metadata_template,
+                              validate_input,
+                              /*static_graph_tasks_prepared=*/false,
+                              /*record_ready_event=*/false);
+      {
+        c10::StreamGuard stream_guard = prepare_stream_->set_stream_guard();
+        CHECK(prepare_stream_->wait_event(pending_target_context_.ready_event))
+            << "failed to wait pending target state on prepare stream";
+        mtp_async::prepare_target_verify_from_accepted_state(
+            validate_input,
+            pending_target_context_.accepted_tokens,
+            pending_target_context_.base_positions,
+            pending_target_context_.base_kv_seq_lens,
+            options_.block_size());
+        validate_input.retained_device_tensors = {
+            pending_target_context_.accepted_tokens,
+            pending_target_context_.base_positions,
+            pending_target_context_.base_kv_seq_lens};
+        finish_metadata_prepare(*prepare_stream_, validate_input);
+      }
+
+      // Host cache materialization is still required before staging the next
+      // target context, but it no longer blocks target metadata submission.
+      materialize_pending_target_host_state();
     }
 
     // Overlap next-step input preparation with async draft forward.
     if (is_final_draft) {
-      prepare_validate_inputs(
-          metadata_template, validate_input, static_graph_tasks_prepared);
+      if (!use_continuous_dsa_drafts) {
+        prepare_validate_inputs(
+            metadata_template, validate_input, static_graph_tasks_prepared);
+      }
+    } else if (use_continuous_dsa_drafts) {
+      next_step_input = std::move(later_draft_inputs[draft_idx + 1]);
+      c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
+      wait_metadata_ready_event(next_step_input, *compute_stream_);
+      clear_ready_events(next_step_input);
+      mtp_async::prepare_later_draft_from_device_base(next_step_input,
+                                                      input,
+                                                      accepted_base_positions,
+                                                      accepted_base_kv_seq_lens,
+                                                      draft_idx + 1,
+                                                      options_.block_size());
     } else {
       prepare_draft_inputs(metadata_template, next_step_input, draft_idx + 1);
     }
@@ -1317,12 +1399,13 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
         << "draft output is empty in speculative step";
 
     draft_outputs.emplace_back(std::move(draft_output_opt.value()));
+    const SamplingParameters& draft_sampling_params =
+        draft_prepared[draft_idx].sampling_params;
     {
       c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
       if (reuse_mtp_topk_state) {
         mtp_topk_state = specBuilder::select_mtp_topk_state_for_next_step(
-            draft_outputs.back().mtp_topk_state,
-            current_draft_input.sampling_params);
+            draft_outputs.back().mtp_topk_state, draft_sampling_params);
       }
       // Unify this step's draft next_tokens across the consensus group before
       // process_draft_sample_output() compresses the still-full [batch, vocab]
@@ -1331,7 +1414,7 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
       if (should_broadcast_spec_tokens(
               parallel_args_,
               get_optimization_config().enable_spec_token_broadcast,
-              current_draft_input.sampling_params.all_greedy_sample)) {
+              draft_sampling_params.all_greedy_sample)) {
         SampleOutput& draft_sample = draft_outputs.back().sample_output;
         broadcast_spec_tokens(draft_sample.next_tokens, parallel_args_);
       }
@@ -1499,8 +1582,11 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
     base_positions = validate_input.positions.view({batch_size, num_val_tokens})
                          .select(/*dim=*/1, /*index=*/0)
                          .contiguous();
-    base_kv_seq_lens = validate_kv_seq_lens.flatten().slice(0, 0, batch_size) -
-                       options_.num_speculative_tokens();
+    base_kv_seq_lens = mtp_async::extract_target_base_kv_seq_lens(
+        validate_kv_seq_lens,
+        batch_size,
+        num_val_tokens,
+        use_chunked_prefill_spec_verify_path());
 
     accepted_tokens_host.copy_(val_output.next_tokens,
                                /*non_blocking=*/true);
@@ -1651,20 +1737,19 @@ bool MTPWorkerImpl::supports_combined_first_draft_execution() const {
     return false;
   }
 
-  // The prelaunch builds an eager two-row DECODE input. The ATB speculative
-  // path expects CHUNKED_PREFILL metadata instead, and the current device
-  // target-context prelaunch is rank-local rather than DP-aware.
-  if (::xllm::SpeculativeConfig::get_instance().enable_atb_spec_kernel() ||
-      parallel_args_.dp_size() > 1) {
+  // The ATB speculative path expects CHUNKED_PREFILL metadata instead of the
+  // eager two-row DECODE input used by the prelaunch.
+  if (::xllm::SpeculativeConfig::get_instance().enable_atb_spec_kernel()) {
     return false;
   }
 
-  const ModelArgs& draft_args = draft_impl_->context_.get_model_args();
-  return mtp_async::classify_combined_draft_execution_path(
-             draft_args.model_type()) ==
-             mtp_async::CombinedDraftExecutionPath::QWEN3_5_PAGED_ATTENTION &&
-         device_.unwrap().is_privateuseone() &&
-         ::xllm::KernelConfig::get_instance().npu_kernel_backend() == "TORCH";
+  const std::string& npu_backend =
+      ::xllm::KernelConfig::get_instance().npu_kernel_backend();
+  return device_.unwrap().is_privateuseone() &&
+         mtp_async::supports_combined_draft_configuration(
+             combined_draft_execution_path_,
+             npu_backend,
+             parallel_args_.dp_size());
 #else
   return false;
 #endif
@@ -1757,6 +1842,10 @@ void MTPWorkerImpl::enqueue_next_first_draft(
   pending_draft_context_.embedding_ids =
       input.input_params.embedding.embedding_ids;
   pending_draft_context_.request_ids = input.input_params.embedding.request_ids;
+  pending_draft_context_.dp_global_token_nums =
+      input.input_params.parallel.dp_global_token_nums;
+  pending_draft_context_.raw_dp_global_token_nums =
+      input.input_params.parallel.raw_dp_global_token_nums;
   pending_draft_context_.output =
       run_llm_no_sync_impl(*draft_impl_,
                            combined_input,
@@ -1773,7 +1862,11 @@ bool MTPWorkerImpl::pending_draft_context_matches(
          pending_draft_context_.embedding_ids ==
              input.input_params.embedding.embedding_ids &&
          pending_draft_context_.request_ids ==
-             input.input_params.embedding.request_ids;
+             input.input_params.embedding.request_ids &&
+         pending_draft_context_.dp_global_token_nums ==
+             input.input_params.parallel.dp_global_token_nums &&
+         pending_draft_context_.raw_dp_global_token_nums ==
+             input.input_params.parallel.raw_dp_global_token_nums;
 }
 
 void MTPWorkerImpl::process_draft_sample_output(SampleOutput& sample_output) {
@@ -1909,7 +2002,8 @@ void MTPWorkerImpl::update_decode_step_input(
 
 void MTPWorkerImpl::prepare_validate_inputs(const ForwardInput& input,
                                             ForwardInput& validate_input,
-                                            bool static_graph_tasks_prepared) {
+                                            bool static_graph_tasks_prepared,
+                                            bool record_ready_event) {
   c10::StreamGuard stream_guard = prepare_stream_->set_stream_guard();
   validate_input = input;
   clear_ready_events(validate_input);
@@ -2229,7 +2323,9 @@ void MTPWorkerImpl::prepare_validate_inputs(const ForwardInput& input,
   input_params.graph.spec_verify_static_graph_tasks_prepared =
       use_explicit_spec_verify_replay_update && static_graph_tasks_prepared;
 #endif
-  finish_metadata_prepare(*prepare_stream_, validate_input);
+  if (record_ready_event) {
+    finish_metadata_prepare(*prepare_stream_, validate_input);
+  }
 }
 
 bool MTPWorkerImpl::prepare_static_mtp_graph_tasks_before_final_draft(
@@ -2491,6 +2587,11 @@ void MTPWorkerImpl::prepare_draft_extend_inputs(
     }
   }
 
+#if defined(USE_NPU)
+  // The extend layout is the 2B cache variant during steady overlap decode.
+  draft_impl_->prepare_dp_ep_padding_on_stream(input_params, *prepare_stream_);
+#endif
+
   auto& params = extend_input.sampling_params;
   torch::TensorOptions idx_options =
       params.selected_token_idxes.defined()
@@ -2576,6 +2677,10 @@ void MTPWorkerImpl::prepare_draft_inputs(const ForwardInput& input,
     }
   }
   input_params.attention.rebuild_device_buffer(device_);
+#if defined(USE_NPU)
+  // Later draft steps share the B cache variant.
+  draft_impl_->prepare_dp_ep_padding_on_stream(input_params, *prepare_stream_);
+#endif
   // token_ids is intentionally filled later from the previous draft output.
   draft_input.device_tensors_ready = false;
 

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -638,10 +638,13 @@ bool MTPWorkerImpl::init_model(const std::string& model_weights_path,
 
   if (draft_impl_ != nullptr &&
       draft_impl_->get_status() == WorkerImpl::Status::LOADED) {
+    combined_draft_execution_path_ =
+        mtp_async::classify_combined_draft_execution_path(
+            draft_impl_->context_.get_model_args().model_type());
     const bool draft_owns_shared_weights =
         options_.enable_mtp_draft_body_tp1() &&
-        is_qwen3_5_draft_model_type(
-            draft_impl_->context_.get_model_args().model_type());
+        combined_draft_execution_path_ ==
+            mtp_async::CombinedDraftExecutionPath::QWEN3_5_PAGED_ATTENTION;
     // Qwen3.5 draft checkpoints contain complete embedding and LMHead weights.
     // Other MTP drafts retain their existing target-weight sharing contract;
     // only their transformer body is replicated with TP1 parallel arguments.
@@ -970,7 +973,7 @@ void MTPWorkerImpl::prepare_work_before_execute(const ForwardInput& input,
   SpeculativeWorkerImpl::prepare_work_before_execute(input, processed_input);
 }
 
-bool MTPWorkerImpl::owns_npu_cp_plan_build() const { return false; }
+bool MTPWorkerImpl::owns_npu_parallel_input_prepare() const { return false; }
 
 std::optional<ForwardOutput> MTPWorkerImpl::step_empty(
     const ForwardInput& input) {
@@ -1298,7 +1301,8 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
   if (use_prelaunched_first_draft) {
     // The first draft was fully prepared and submitted by the preceding
     // run_validate(). Host metadata is corrected below after the accepted-token
-    // update; it is only needed for draft steps 1..N-1 and target verification.
+    // update; continuous DSA drafts use device correction, while target
+    // verification still consumes the exact Host metadata.
   } else if (use_device_target_context) {
     c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
 
@@ -1375,6 +1379,60 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
     prepare_draft_extend_inputs(input, last_states, current_draft_input);
   }
 
+  const bool use_continuous_dsa_drafts =
+      (use_device_target_context || use_prelaunched_first_draft) &&
+      combined_draft_execution_path_ ==
+          mtp_async::CombinedDraftExecutionPath::GLM_MOE_DSA_SPARSE_ATTENTION;
+  std::vector<ForwardInput> later_draft_inputs;
+  torch::Tensor accepted_base_positions;
+  torch::Tensor accepted_base_kv_seq_lens;
+  if (use_continuous_dsa_drafts) {
+    later_draft_inputs.resize(num_speculative_tokens);
+    const ForwardInput& combined_draft_input =
+        use_prelaunched_first_draft ? pending_draft_context_.prepared_input
+                                    : current_draft_input;
+    const int64_t batch_size = input.input_params.meta.num_sequences;
+    CHECK_EQ(combined_draft_input.positions.numel(), batch_size * 2)
+        << "combined draft positions must contain [repair,current] rows";
+    CHECK_EQ(
+        combined_draft_input.input_params.attention.device.kv_seq_lens.numel(),
+        batch_size * 2)
+        << "combined draft KV lengths must contain [repair,current] rows";
+    accepted_base_positions =
+        combined_draft_input.positions.view({batch_size, 2}).select(1, 1);
+    accepted_base_kv_seq_lens =
+        combined_draft_input.input_params.attention.device.kv_seq_lens
+            .view({batch_size, 2})
+            .select(1, 1);
+
+    for (int32_t draft_idx = 1; draft_idx < num_speculative_tokens;
+         ++draft_idx) {
+      // Only the fixed B layout is needed on prepare_stream. Reusing offset 0
+      // avoids extending an already conservative Host template past the
+      // scheduler-allocated block range; device metadata is replaced below.
+      prepare_draft_inputs(metadata_template,
+                           later_draft_inputs[draft_idx],
+                           /*position_offset=*/0);
+    }
+  }
+
+  const auto materialize_pending_target_host_state = [&]() {
+    flush_pending_target_context();
+    std::vector<EmbeddingCache::DecodeState> resolved_states =
+        embedding_cache_->read_decode_states(
+            input.input_params.embedding.embedding_ids,
+            input.input_params.embedding.request_ids);
+    // The scheduler input contains the conservative overlap placeholder.
+    // Force cache correction before comparing it with the accepted target.
+    input.token_ids_host = torch::full_like(input.token_ids_host, -1);
+    update_decode_step_input(input, resolved_states);
+    check_mtp_decode_states(resolved_states,
+                            input.input_params.embedding.request_ids,
+                            input.token_ids_host,
+                            /*allow_overlap_fake_token=*/false);
+    metadata_template = input;
+  };
+
   draft_outputs.reserve(num_speculative_tokens);
   const bool reuse_mtp_topk_state = layer::is_mtp_dsa_topk_reuse_enabled(
       draft_impl_->context_.get_model_args());
@@ -1383,7 +1441,7 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
   for (int32_t draft_idx = 0; draft_idx < num_speculative_tokens; ++draft_idx) {
     const bool is_final_draft = draft_idx == num_speculative_tokens - 1;
     const bool static_graph_tasks_prepared =
-        is_final_draft &&
+        is_final_draft && !use_continuous_dsa_drafts &&
         prepare_static_mtp_graph_tasks_before_final_draft(input);
     if (reuse_mtp_topk_state) {
       current_draft_input.input_params.mtp_topk_state = mtp_topk_state;
@@ -1403,34 +1461,62 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
     }
 
     if ((use_device_target_context || use_prelaunched_first_draft) &&
-        draft_idx == 0) {
+        !use_continuous_dsa_drafts && draft_idx == 0) {
       // The next draft forward is already queued behind target validation.
       // It can start immediately when rejection sampling finishes while the
       // worker materializes the accepted state for later draft/target metadata
       // on CPU.  This synchronization is therefore outside the NPU critical
       // path rather than sitting between target and draft launches.
-      flush_pending_target_context();
-      std::vector<EmbeddingCache::DecodeState> resolved_states =
-          embedding_cache_->read_decode_states(
-              input.input_params.embedding.embedding_ids,
-              input.input_params.embedding.request_ids);
-      // The scheduler input still contains the conservative placeholder used
-      // to launch the first draft.  Materialize the accepted host state before
-      // comparing token ids; otherwise this check compares the new target
-      // result with the intentionally stale overlap template.
-      input.token_ids_host = torch::full_like(input.token_ids_host, -1);
-      update_decode_step_input(input, resolved_states);
-      check_mtp_decode_states(resolved_states,
-                              input.input_params.embedding.request_ids,
-                              input.token_ids_host,
-                              /*allow_overlap_fake_token=*/false);
-      metadata_template = input;
+      materialize_pending_target_host_state();
+    }
+
+    if (use_continuous_dsa_drafts && is_final_draft) {
+      // Queue target metadata before the Host target-context wait. The fixed
+      // template can be copied immediately; its real device values are
+      // corrected after a prepare-stream wait on the previous target event.
+      prepare_validate_inputs(metadata_template,
+                              validate_input,
+                              /*static_graph_tasks_prepared=*/false,
+                              /*record_ready_event=*/false);
+      {
+        c10::StreamGuard stream_guard = prepare_stream_->set_stream_guard();
+        CHECK(prepare_stream_->wait_event(pending_target_context_.ready_event))
+            << "failed to wait pending target state on prepare stream";
+        mtp_async::prepare_target_verify_from_accepted_state(
+            validate_input,
+            pending_target_context_.accepted_tokens,
+            pending_target_context_.base_positions,
+            pending_target_context_.base_kv_seq_lens,
+            options_.block_size());
+        validate_input.retained_device_tensors = {
+            pending_target_context_.accepted_tokens,
+            pending_target_context_.base_positions,
+            pending_target_context_.base_kv_seq_lens};
+        finish_metadata_prepare(*prepare_stream_, validate_input);
+      }
+
+      // Host cache materialization is still required before staging the next
+      // target context, but it no longer blocks target metadata submission.
+      materialize_pending_target_host_state();
     }
 
     // Overlap next-step input preparation with async draft forward.
     if (is_final_draft) {
-      prepare_validate_inputs(
-          metadata_template, validate_input, static_graph_tasks_prepared);
+      if (!use_continuous_dsa_drafts) {
+        prepare_validate_inputs(
+            metadata_template, validate_input, static_graph_tasks_prepared);
+      }
+    } else if (use_continuous_dsa_drafts) {
+      next_step_input = std::move(later_draft_inputs[draft_idx + 1]);
+      c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
+      wait_metadata_ready_event(next_step_input, *compute_stream_);
+      clear_ready_events(next_step_input);
+      mtp_async::prepare_later_draft_from_device_base(next_step_input,
+                                                      input,
+                                                      accepted_base_positions,
+                                                      accepted_base_kv_seq_lens,
+                                                      draft_idx + 1,
+                                                      options_.block_size());
     } else {
       prepare_draft_inputs(metadata_template, next_step_input, draft_idx + 1);
     }
@@ -1439,12 +1525,13 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
         << "draft output is empty in speculative step";
 
     draft_outputs.emplace_back(std::move(draft_output_opt.value()));
+    const SamplingParameters& draft_sampling_params =
+        draft_prepared[draft_idx].sampling_params;
     {
       c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
       if (reuse_mtp_topk_state) {
         mtp_topk_state = specBuilder::select_mtp_topk_state_for_next_step(
-            draft_outputs.back().mtp_topk_state,
-            current_draft_input.sampling_params);
+            draft_outputs.back().mtp_topk_state, draft_sampling_params);
       }
       // Unify this step's draft next_tokens across the consensus group before
       // process_draft_sample_output() compresses the still-full [batch, vocab]
@@ -1453,7 +1540,7 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
       if (should_broadcast_spec_tokens(
               parallel_args_,
               get_optimization_config().enable_spec_token_broadcast,
-              current_draft_input.sampling_params.all_greedy_sample)) {
+              draft_sampling_params.all_greedy_sample)) {
         SampleOutput& draft_sample = draft_outputs.back().sample_output;
         broadcast_spec_tokens(draft_sample.next_tokens, parallel_args_);
       }
@@ -1981,8 +2068,11 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
     base_positions = validate_input.positions.view({batch_size, num_val_tokens})
                          .select(/*dim=*/1, /*index=*/0)
                          .contiguous();
-    base_kv_seq_lens = validate_kv_seq_lens.flatten().slice(0, 0, batch_size) -
-                       options_.num_speculative_tokens();
+    base_kv_seq_lens = mtp_async::extract_target_base_kv_seq_lens(
+        validate_kv_seq_lens,
+        batch_size,
+        num_val_tokens,
+        use_chunked_prefill_spec_verify_path());
 
     accepted_tokens_host.copy_(val_output.next_tokens,
                                /*non_blocking=*/true);
@@ -2149,20 +2239,19 @@ bool MTPWorkerImpl::supports_combined_first_draft_execution() const {
     return false;
   }
 
-  // The prelaunch builds an eager two-row DECODE input. The ATB speculative
-  // path expects CHUNKED_PREFILL metadata instead, and the current device
-  // target-context prelaunch is rank-local rather than DP-aware.
-  if (::xllm::SpeculativeConfig::get_instance().enable_atb_spec_kernel() ||
-      parallel_args_.dp_size() > 1) {
+  // The ATB speculative path expects CHUNKED_PREFILL metadata instead of the
+  // eager two-row DECODE input used by the prelaunch.
+  if (::xllm::SpeculativeConfig::get_instance().enable_atb_spec_kernel()) {
     return false;
   }
 
-  const ModelArgs& draft_args = draft_impl_->context_.get_model_args();
-  return mtp_async::classify_combined_draft_execution_path(
-             draft_args.model_type()) ==
-             mtp_async::CombinedDraftExecutionPath::QWEN3_5_PAGED_ATTENTION &&
-         device_.unwrap().is_privateuseone() &&
-         ::xllm::KernelConfig::get_instance().npu_kernel_backend() == "TORCH";
+  const std::string& npu_backend =
+      ::xllm::KernelConfig::get_instance().npu_kernel_backend();
+  return device_.unwrap().is_privateuseone() &&
+         mtp_async::supports_combined_draft_configuration(
+             combined_draft_execution_path_,
+             npu_backend,
+             parallel_args_.dp_size());
 #else
   return false;
 #endif
@@ -2255,6 +2344,10 @@ void MTPWorkerImpl::enqueue_next_first_draft(
   pending_draft_context_.embedding_ids =
       input.input_params.embedding.embedding_ids;
   pending_draft_context_.request_ids = input.input_params.embedding.request_ids;
+  pending_draft_context_.dp_global_token_nums =
+      input.input_params.parallel.dp_global_token_nums;
+  pending_draft_context_.raw_dp_global_token_nums =
+      input.input_params.parallel.raw_dp_global_token_nums;
   pending_draft_context_.output =
       run_llm_no_sync_impl(*draft_impl_,
                            combined_input,
@@ -2271,7 +2364,11 @@ bool MTPWorkerImpl::pending_draft_context_matches(
          pending_draft_context_.embedding_ids ==
              input.input_params.embedding.embedding_ids &&
          pending_draft_context_.request_ids ==
-             input.input_params.embedding.request_ids;
+             input.input_params.embedding.request_ids &&
+         pending_draft_context_.dp_global_token_nums ==
+             input.input_params.parallel.dp_global_token_nums &&
+         pending_draft_context_.raw_dp_global_token_nums ==
+             input.input_params.parallel.raw_dp_global_token_nums;
 }
 
 void MTPWorkerImpl::record_validate_metrics(
@@ -2461,7 +2558,8 @@ void MTPWorkerImpl::update_decode_step_input(
 
 void MTPWorkerImpl::prepare_validate_inputs(const ForwardInput& input,
                                             ForwardInput& validate_input,
-                                            bool static_graph_tasks_prepared) {
+                                            bool static_graph_tasks_prepared,
+                                            bool record_ready_event) {
   c10::StreamGuard stream_guard = prepare_stream_->set_stream_guard();
   validate_input = input;
   clear_ready_events(validate_input);
@@ -2797,7 +2895,9 @@ void MTPWorkerImpl::prepare_validate_inputs(const ForwardInput& input,
   input_params.graph.spec_verify_static_graph_tasks_prepared =
       use_explicit_spec_verify_replay_update && static_graph_tasks_prepared;
 #endif
-  finish_metadata_prepare(*prepare_stream_, validate_input);
+  if (record_ready_event) {
+    finish_metadata_prepare(*prepare_stream_, validate_input);
+  }
 }
 
 bool MTPWorkerImpl::prepare_static_mtp_graph_tasks_before_final_draft(
@@ -3237,6 +3337,11 @@ void MTPWorkerImpl::prepare_draft_extend_inputs(
     }
   }
 
+#if defined(USE_NPU)
+  // The extend layout is the 2B cache variant during steady overlap decode.
+  draft_impl_->prepare_dp_ep_padding_on_stream(input_params, *prepare_stream_);
+#endif
+
   auto& params = extend_input.sampling_params;
   torch::TensorOptions idx_options =
       params.selected_token_idxes.defined()
@@ -3328,6 +3433,10 @@ void MTPWorkerImpl::prepare_draft_inputs(const ForwardInput& input,
     }
   }
   input_params.attention.rebuild_device_buffer(device_);
+#if defined(USE_NPU)
+  // Later draft steps share the B cache variant.
+  draft_impl_->prepare_dp_ep_padding_on_stream(input_params, *prepare_stream_);
+#endif
   // token_ids is intentionally filled later from the previous draft output.
   draft_input.device_tensors_ready = false;
 

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -75,6 +75,17 @@ void clamp_gdn_conv_history(std::vector<int32_t>& accepted_prefix_lengths) {
   }
 }
 
+bool has_active_dp_tokens(const ForwardInput& input) {
+  const ParallelInput& parallel = input.input_params.parallel;
+  const std::vector<int32_t>& token_nums =
+      parallel.raw_dp_global_token_nums.empty()
+          ? parallel.dp_global_token_nums
+          : parallel.raw_dp_global_token_nums;
+  return std::any_of(token_nums.begin(), token_nums.end(), [](int32_t count) {
+    return count > 0;
+  });
+}
+
 void broadcast_tokens_in_group(torch::Tensor& tokens,
                                ProcessGroup* process_group,
                                int32_t root_rank = 0) {
@@ -977,8 +988,12 @@ bool MTPWorkerImpl::owns_npu_parallel_input_prepare() const { return false; }
 
 std::optional<ForwardOutput> MTPWorkerImpl::step_empty(
     const ForwardInput& input) {
-  if (pending_draft_context_.output.has_value()) {
-    // The preceding validation may have speculatively submitted draft1 before
+  const bool use_prelaunched_first_draft =
+      input.input_params.meta.batch_forward_type.is_decode() &&
+      can_use_combined_first_draft() && pending_draft_context_matches(input);
+  if (pending_draft_context_.output.has_value() &&
+      !use_prelaunched_first_draft) {
+    // The preceding validation may have speculatively submitted draft-0 before
     // the scheduler learned that the batch had finished.  Keep its graph/input
     // buffers alive until the queued work completes, then discard the result.
     // This is a batch-exit slow path and is never taken in steady decode.
@@ -1023,12 +1038,19 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_empty(
          new_input.input_params.parallel.raw_dp_global_token_nums) {
       token_num *= 2;
     }
-    draft_outputs.emplace_back(run_llm_no_sync_impl(*draft_impl_,
-                                                    new_input,
-                                                    *prepare_stream_,
-                                                    *compute_stream_,
-                                                    draft_extend_prepared)
-                                   .value());
+    if (use_prelaunched_first_draft) {
+      draft_outputs.emplace_back(
+          std::move(pending_draft_context_.output.value()));
+      draft_extend_prepared = std::move(pending_draft_context_.prepared_input);
+      pending_draft_context_ = PendingDraftContext();
+    } else {
+      draft_outputs.emplace_back(run_llm_no_sync_impl(*draft_impl_,
+                                                      new_input,
+                                                      *prepare_stream_,
+                                                      *compute_stream_,
+                                                      draft_extend_prepared)
+                                     .value());
+    }
 
     for (int32_t i = 1; i < options_.num_speculative_tokens(); ++i) {
       draft_outputs.emplace_back(run_llm_no_sync_impl(*draft_impl_,
@@ -1060,6 +1082,18 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_empty(
     clear_all_output_embeddings(output);
     finalize_output_on_stream(
         output, *compute_stream_, enable_schedule_overlap());
+    if (can_prelaunch_next_first_draft(input)) {
+      ForwardInput next_first_draft_input = input;
+      for (int32_t& token_num :
+           next_first_draft_input.input_params.parallel.dp_global_token_nums) {
+        token_num *= 2;
+      }
+      for (int32_t& token_num : next_first_draft_input.input_params.parallel
+                                    .raw_dp_global_token_nums) {
+        token_num *= 2;
+      }
+      submit_pending_first_draft(input, std::move(next_first_draft_input));
+    }
     return output;
   }
 }
@@ -1219,6 +1253,19 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
   const bool use_device_target_context =
       can_use_combined_first_draft() && matching_device_target_context &&
       device_target_context_ready_for_batch(input);
+  // Keep the device-side accepted state alive across a first-transition Host
+  // cache flush. The prelaunched draft can be valid before the batch is marked
+  // device-context ready, while flush_pending_target_context() clears the
+  // owning context below.
+  const torch::Tensor accepted_tokens = pending_target_context_.accepted_tokens;
+  const torch::Tensor accepted_embeddings =
+      pending_target_context_.accepted_embeddings;
+  const torch::Tensor target_base_positions =
+      pending_target_context_.base_positions;
+  const torch::Tensor target_base_kv_seq_lens =
+      pending_target_context_.base_kv_seq_lens;
+  const StreamEventPtr target_context_ready_event =
+      pending_target_context_.ready_event;
   if (pending_draft_context_.output.has_value() &&
       !use_prelaunched_first_draft) {
     // A batch transition invalidates the speculative prelaunch.  Drain it
@@ -1354,11 +1401,11 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
     mtp_async::prepare_next_draft_from_accepted_state(
         current_draft_input,
         input,
-        pending_target_context_.accepted_tokens,
-        pending_target_context_.accepted_embeddings,
+        accepted_tokens,
+        accepted_embeddings,
         embedding_cache_->embedding_placeholder(),
-        pending_target_context_.base_positions,
-        pending_target_context_.base_kv_seq_lens,
+        target_base_positions,
+        target_base_kv_seq_lens,
         /*use_chunked_prefill=*/false,
         options_.block_size());
   } else {
@@ -1480,18 +1527,16 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
                               /*record_ready_event=*/false);
       {
         c10::StreamGuard stream_guard = prepare_stream_->set_stream_guard();
-        CHECK(prepare_stream_->wait_event(pending_target_context_.ready_event))
+        CHECK(prepare_stream_->wait_event(target_context_ready_event))
             << "failed to wait pending target state on prepare stream";
         mtp_async::prepare_target_verify_from_accepted_state(
             validate_input,
-            pending_target_context_.accepted_tokens,
-            pending_target_context_.base_positions,
-            pending_target_context_.base_kv_seq_lens,
+            accepted_tokens,
+            target_base_positions,
+            target_base_kv_seq_lens,
             options_.block_size());
         validate_input.retained_device_tensors = {
-            pending_target_context_.accepted_tokens,
-            pending_target_context_.base_positions,
-            pending_target_context_.base_kv_seq_lens};
+            accepted_tokens, target_base_positions, target_base_kv_seq_lens};
         finish_metadata_prepare(*prepare_stream_, validate_input);
       }
 
@@ -1983,8 +2028,7 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
       needs_padding ? *padded_target_output_slow : uniform_target_view;
 
   const bool prelaunch_next_first_draft =
-      pruned_prefix_lengths == nullptr && can_use_combined_first_draft() &&
-      device_target_context_ready_for_batch(input);
+      pruned_prefix_lengths == nullptr && can_prelaunch_next_first_draft(input);
   ForwardInput next_first_draft_input;
   if (prelaunch_next_first_draft) {
     // This input is independent of the accepted token.  Prepare it on the
@@ -2261,6 +2305,21 @@ bool MTPWorkerImpl::can_use_combined_first_draft() const {
   return enable_schedule_overlap() && supports_combined_first_draft_execution();
 }
 
+bool MTPWorkerImpl::can_prelaunch_next_first_draft(
+    const ForwardInput& input) const {
+  if (!can_use_combined_first_draft()) {
+    return false;
+  }
+  const bool requires_dp_symmetric_prelaunch =
+      parallel_args_.dp_size() > 1 &&
+      combined_draft_execution_path_ ==
+          mtp_async::CombinedDraftExecutionPath::GLM_MOE_DSA_SPARSE_ATTENTION;
+  if (requires_dp_symmetric_prelaunch) {
+    return has_active_dp_tokens(input);
+  }
+  return device_target_context_ready_for_batch(input);
+}
+
 void MTPWorkerImpl::prepare_next_first_draft_template(
     const ForwardInput& input,
     ForwardInput& combined_input) {
@@ -2316,8 +2375,6 @@ void MTPWorkerImpl::enqueue_next_first_draft(
     const torch::Tensor& base_positions,
     const torch::Tensor& base_kv_seq_lens,
     ForwardInput combined_input) {
-  CHECK(!pending_draft_context_.output.has_value())
-      << "MTP first-draft prelaunch was not consumed";
   CHECK(validate_output.next_tokens.defined());
   CHECK(validate_output.embeddings.defined());
   CHECK(embedding_cache_ != nullptr);
@@ -2341,16 +2398,27 @@ void MTPWorkerImpl::enqueue_next_first_draft(
       /*use_chunked_prefill=*/false,
       options_.block_size());
 
+  submit_pending_first_draft(input, std::move(combined_input));
+}
+
+void MTPWorkerImpl::submit_pending_first_draft(
+    const ForwardInput& batch_identity_input,
+    ForwardInput draft_input) {
+  CHECK(!pending_draft_context_.output.has_value())
+      << "MTP first-draft prelaunch was not consumed";
   pending_draft_context_.embedding_ids =
-      input.input_params.embedding.embedding_ids;
-  pending_draft_context_.request_ids = input.input_params.embedding.request_ids;
+      batch_identity_input.input_params.embedding.embedding_ids;
+  pending_draft_context_.request_ids =
+      batch_identity_input.input_params.embedding.request_ids;
   pending_draft_context_.dp_global_token_nums =
-      input.input_params.parallel.dp_global_token_nums;
+      batch_identity_input.input_params.parallel.dp_global_token_nums;
   pending_draft_context_.raw_dp_global_token_nums =
-      input.input_params.parallel.raw_dp_global_token_nums;
+      batch_identity_input.input_params.parallel.raw_dp_global_token_nums;
+  pending_draft_context_.dp_global_batch_generations =
+      batch_identity_input.input_params.parallel.dp_global_batch_generations;
   pending_draft_context_.output =
       run_llm_no_sync_impl(*draft_impl_,
-                           combined_input,
+                           draft_input,
                            *compute_stream_,
                            *compute_stream_,
                            pending_draft_context_.prepared_input);
@@ -2368,7 +2436,9 @@ bool MTPWorkerImpl::pending_draft_context_matches(
          pending_draft_context_.dp_global_token_nums ==
              input.input_params.parallel.dp_global_token_nums &&
          pending_draft_context_.raw_dp_global_token_nums ==
-             input.input_params.parallel.raw_dp_global_token_nums;
+             input.input_params.parallel.raw_dp_global_token_nums &&
+         pending_draft_context_.dp_global_batch_generations ==
+             input.input_params.parallel.dp_global_batch_generations;
 }
 
 void MTPWorkerImpl::record_validate_metrics(

--- a/xllm/core/runtime/mtp_worker_impl.h
+++ b/xllm/core/runtime/mtp_worker_impl.h
@@ -75,10 +75,9 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
                                    ForwardInput& processed_inputs) override;
 
  protected:
-  // MTP composite: leaves own NpuCpPlan::prepare.
-  bool owns_npu_cp_plan_build() const override;
+  // MTP composite: leaves own model-specific NPU input preparation.
+  bool owns_npu_parallel_input_prepare() const override;
 
- protected:
   std::optional<ForwardOutput> step_prefill(const ForwardInput& input) override;
   std::optional<ForwardOutput> step_decode(const ForwardInput& inputs) override;
   std::optional<ForwardOutput> step_empty(const ForwardInput& inputs) override;
@@ -124,7 +123,8 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
   // Prepare target validate input from cached target context.
   void prepare_validate_inputs(const ForwardInput& inputs,
                                ForwardInput& validate_inputs,
-                               bool static_graph_tasks_prepared = false);
+                               bool static_graph_tasks_prepared = false,
+                               bool record_ready_event = true);
   bool prepare_static_mtp_graph_tasks_before_final_draft(
       const ForwardInput& input);
 
@@ -162,6 +162,8 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
   struct PendingDraftContext {
     std::vector<int32_t> embedding_ids;
     std::vector<std::string> request_ids;
+    std::vector<int32_t> dp_global_token_nums;
+    std::vector<int32_t> raw_dp_global_token_nums;
     std::optional<ForwardOutput> output;
     ForwardInput prepared_input;
   };
@@ -215,10 +217,12 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
   // If false, selected-only cache values are restored to dense [B, S, V].
   bool enable_opt_validate_probs_ = false;
 
-  // Classified once when the target model is loaded. Decode-path decisions
-  // only read this closed policy and never traverse the model implementation.
+  // Classified once when the corresponding models are loaded. Decode-path
+  // decisions only read these closed policies.
   mtp_async::TargetSpecVerifyMode target_spec_verify_mode_ =
       mtp_async::TargetSpecVerifyMode::GENERIC;
+  mtp_async::CombinedDraftExecutionPath combined_draft_execution_path_ =
+      mtp_async::CombinedDraftExecutionPath::UNSUPPORTED;
 
 #if defined(USE_NPU)
   // Stable-address sources consumed by the target ACL graph's leading input

--- a/xllm/core/runtime/mtp_worker_impl.h
+++ b/xllm/core/runtime/mtp_worker_impl.h
@@ -212,6 +212,7 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
     std::vector<std::string> request_ids;
     std::vector<int32_t> dp_global_token_nums;
     std::vector<int32_t> raw_dp_global_token_nums;
+    std::vector<uint64_t> dp_global_batch_generations;
     std::optional<ForwardOutput> output;
     ForwardInput prepared_input;
   };
@@ -229,6 +230,7 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
   void flush_pending_target_context();
   bool supports_combined_first_draft_execution() const;
   bool can_use_combined_first_draft() const;
+  bool can_prelaunch_next_first_draft(const ForwardInput& input) const;
   void prepare_next_first_draft_template(const ForwardInput& input,
                                          ForwardInput& combined_input);
   void enqueue_next_first_draft(const ForwardInput& input,
@@ -236,6 +238,8 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
                                 const torch::Tensor& base_positions,
                                 const torch::Tensor& base_kv_seq_lens,
                                 ForwardInput combined_input);
+  void submit_pending_first_draft(const ForwardInput& batch_identity_input,
+                                  ForwardInput draft_input);
   bool pending_draft_context_matches(const ForwardInput& input) const;
 
   void write_target_context_to_cache(const ForwardInput& input,

--- a/xllm/core/runtime/mtp_worker_impl.h
+++ b/xllm/core/runtime/mtp_worker_impl.h
@@ -86,10 +86,9 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
                                    ForwardInput& processed_inputs) override;
 
  protected:
-  // MTP composite: leaves own NpuCpPlan::prepare.
-  bool owns_npu_cp_plan_build() const override;
+  // MTP composite: leaves own model-specific NPU input preparation.
+  bool owns_npu_parallel_input_prepare() const override;
 
- protected:
   std::optional<ForwardOutput> step_prefill(const ForwardInput& input) override;
   std::optional<ForwardOutput> step_decode(const ForwardInput& inputs) override;
   std::optional<ForwardOutput> step_empty(const ForwardInput& inputs) override;
@@ -169,7 +168,8 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
   // Prepare target validate input from cached target context.
   void prepare_validate_inputs(const ForwardInput& inputs,
                                ForwardInput& validate_inputs,
-                               bool static_graph_tasks_prepared = false);
+                               bool static_graph_tasks_prepared = false,
+                               bool record_ready_event = true);
   void prepare_validate_inputs(const ForwardInput& inputs,
                                ForwardInput& validate_inputs,
                                const std::vector<int32_t>& per_seq_val_tokens);
@@ -210,6 +210,8 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
   struct PendingDraftContext {
     std::vector<int32_t> embedding_ids;
     std::vector<std::string> request_ids;
+    std::vector<int32_t> dp_global_token_nums;
+    std::vector<int32_t> raw_dp_global_token_nums;
     std::optional<ForwardOutput> output;
     ForwardInput prepared_input;
   };
@@ -273,10 +275,12 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
   bool enable_opt_validate_probs_ = false;
   std::unique_ptr<AdaptiveSpeculativeController> adaptive_spec_controller_;
 
-  // Classified once when the target model is loaded. Decode-path decisions
-  // only read this closed policy and never traverse the model implementation.
+  // Classified once when the corresponding models are loaded. Decode-path
+  // decisions only read these closed policies.
   mtp_async::TargetSpecVerifyMode target_spec_verify_mode_ =
       mtp_async::TargetSpecVerifyMode::GENERIC;
+  mtp_async::CombinedDraftExecutionPath combined_draft_execution_path_ =
+      mtp_async::CombinedDraftExecutionPath::UNSUPPORTED;
 
 #if defined(USE_NPU)
   // Stable-address sources consumed by the target ACL graph's leading input

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -715,7 +715,7 @@ const CpPlanRuntimeConfig& WorkerImpl::npu_cp_plan_runtime_config() const {
   cfg.enabled =
       parallel_args_.cp_size() > 1 && Platform::uses_model_cp_sharding() &&
       ::xllm::KernelConfig::get_instance().npu_kernel_backend() == "ATB" &&
-      owns_npu_cp_plan_build() && model_supports_model_cp();
+      owns_npu_parallel_input_prepare() && model_supports_model_cp();
   cfg.has_prefix_slots =
       KVCacheConfig::get_instance().enable_prefix_cache() ||
       SchedulerConfig::get_instance().enable_chunked_prefill();
@@ -748,6 +748,78 @@ const CpPlanRuntimeConfig& WorkerImpl::npu_cp_plan_runtime_config() const {
   npu_cp_runtime_config_ = std::move(cfg);
   npu_cp_runtime_config_computed_ = true;
   return npu_cp_runtime_config_;
+}
+#endif
+
+#if defined(USE_NPU)
+bool WorkerImpl::uses_npu_dp_ep_padding() const {
+  const ParallelArgs& parallel_args = context_.get_parallel_args();
+  return !parallel_args.mapping_data().empty() &&
+         parallel_args.cp_size() <= 1 &&
+         (parallel_args.dp_size() > 1 || parallel_args.ep_size() > 1);
+}
+
+void WorkerImpl::prepare_dp_ep_padding(ModelInputParams& input_params) {
+  if (!uses_npu_dp_ep_padding()) {
+    return;
+  }
+
+  const std::vector<int32_t>& token_sizes =
+      input_params.parallel.dp_global_token_nums;
+  const std::vector<int32_t>& raw_token_sizes =
+      input_params.parallel.raw_dp_global_token_nums;
+  const bool is_prefill = input_params.meta.batch_forward_type.no_decode();
+  const bool use_draft_decode_cache = options_.is_draft_engine() && !is_prefill;
+  if (use_draft_decode_cache) {
+    const DpEpPaddingData* cached =
+        draft_dp_ep_padding_cache_.find(token_sizes, raw_token_sizes);
+    if (cached != nullptr) {
+      input_params.parallel.dp_ep_padding_data = *cached;
+      return;
+    }
+  }
+
+  torch::Tensor token_size_per_dp_group =
+      torch::tensor(token_sizes,
+                    torch::TensorOptions()
+                        .device(torch::kCPU)
+                        .dtype(torch::kInt32)
+                        .pinned_memory(true));
+  torch::Tensor raw_token_size_per_dp_group =
+      raw_token_sizes.empty() ? torch::Tensor()
+                              : torch::tensor(raw_token_sizes,
+                                              torch::TensorOptions()
+                                                  .device(torch::kCPU)
+                                                  .dtype(torch::kInt32)
+                                                  .pinned_memory(true));
+  DpEpPadding dp_ep_padding(token_size_per_dp_group,
+                            raw_token_size_per_dp_group,
+                            context_.get_model_args().num_experts_per_tok(),
+                            context_.get_parallel_args().mapping_data(),
+                            device_,
+                            dtype_,
+                            is_prefill);
+  DpEpPaddingData data = dp_ep_padding.build();
+  input_params.parallel.dp_ep_padding_data = data;
+  if (use_draft_decode_cache) {
+    draft_dp_ep_padding_cache_.insert(token_sizes, raw_token_sizes, data);
+  }
+}
+
+void WorkerImpl::prepare_dp_ep_padding_on_stream(ModelInputParams& input_params,
+                                                 Stream& prepare_stream) {
+  if (!uses_npu_dp_ep_padding()) {
+    return;
+  }
+  std::optional<std::unique_lock<std::mutex>> lock_guard;
+  if (::xllm::ExecutionConfig::get_instance().enable_graph()) {
+    auto& capture_lock =
+        ::xllm::npu::DeviceCaptureLock::get_instance().get_lock(
+            device_.index());
+    lock_guard.emplace(capture_lock);
+  }
+  c10::StreamGuard stream_guard = prepare_stream.set_stream_guard();
+  prepare_dp_ep_padding(input_params);
 }
 #endif
 
@@ -830,36 +902,10 @@ void WorkerImpl::prepare_work_before_execute_on_stream(
       prepare_mla_prefixcache_inputs(input_params);
     }
 
-    if (!context_.get_parallel_args().mapping_data().empty() &&
-        !(context_.get_parallel_args().cp_size() > 1) &&
-        (context_.get_parallel_args().dp_size() > 1 ||
-         context_.get_parallel_args().ep_size() > 1)) {
-      torch::Tensor token_size_per_dp_group = torch::tensor(
-          processed_input.input_params.parallel.dp_global_token_nums,
-          torch::TensorOptions()
-              .device(torch::kCPU)
-              .dtype(torch::kInt32)
-              .pinned_memory(true));
-      const auto& raw_dp_token_nums =
-          processed_input.input_params.parallel.raw_dp_global_token_nums;
-      torch::Tensor raw_token_size_per_dp_group =
-          raw_dp_token_nums.empty() ? torch::Tensor()
-                                    : torch::tensor(raw_dp_token_nums,
-                                                    torch::TensorOptions()
-                                                        .device(torch::kCPU)
-                                                        .dtype(torch::kInt32)
-                                                        .pinned_memory(true));
-      const bool is_prefill =
-          processed_input.input_params.meta.batch_forward_type.no_decode();
-      DpEpPadding dp_ep_padding(token_size_per_dp_group,
-                                raw_token_size_per_dp_group,
-                                context_.get_model_args().num_experts_per_tok(),
-                                context_.get_parallel_args().mapping_data(),
-                                device_,
-                                dtype_,
-                                is_prefill);
-      processed_input.input_params.parallel.dp_ep_padding_data =
-          dp_ep_padding.build();
+    if (owns_npu_parallel_input_prepare()) {
+      prepare_dp_ep_padding(processed_input.input_params);
+    }
+    if (uses_npu_dp_ep_padding()) {
       if (::xllm::EPLBConfig::get_instance().enable_eplb()) {
         processed_input.input_params.expert.expert_load_data =
             expert_load_data_;

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -758,7 +758,7 @@ const CpPlanRuntimeConfig& WorkerImpl::npu_cp_plan_runtime_config() const {
   cfg.enabled =
       parallel_args_.cp_size() > 1 && Platform::uses_model_cp_sharding() &&
       ::xllm::KernelConfig::get_instance().npu_kernel_backend() == "ATB" &&
-      owns_npu_cp_plan_build() && model_supports_model_cp();
+      owns_npu_parallel_input_prepare() && model_supports_model_cp();
   cfg.has_prefix_slots =
       KVCacheConfig::get_instance().enable_prefix_cache() ||
       SchedulerConfig::get_instance().enable_chunked_prefill();
@@ -791,6 +791,78 @@ const CpPlanRuntimeConfig& WorkerImpl::npu_cp_plan_runtime_config() const {
   npu_cp_runtime_config_ = std::move(cfg);
   npu_cp_runtime_config_computed_ = true;
   return npu_cp_runtime_config_;
+}
+#endif
+
+#if defined(USE_NPU)
+bool WorkerImpl::uses_npu_dp_ep_padding() const {
+  const ParallelArgs& parallel_args = context_.get_parallel_args();
+  return !parallel_args.mapping_data().empty() &&
+         parallel_args.cp_size() <= 1 &&
+         (parallel_args.dp_size() > 1 || parallel_args.ep_size() > 1);
+}
+
+void WorkerImpl::prepare_dp_ep_padding(ModelInputParams& input_params) {
+  if (!uses_npu_dp_ep_padding()) {
+    return;
+  }
+
+  const std::vector<int32_t>& token_sizes =
+      input_params.parallel.dp_global_token_nums;
+  const std::vector<int32_t>& raw_token_sizes =
+      input_params.parallel.raw_dp_global_token_nums;
+  const bool is_prefill = input_params.meta.batch_forward_type.no_decode();
+  const bool use_draft_decode_cache = options_.is_draft_engine() && !is_prefill;
+  if (use_draft_decode_cache) {
+    const DpEpPaddingData* cached =
+        draft_dp_ep_padding_cache_.find(token_sizes, raw_token_sizes);
+    if (cached != nullptr) {
+      input_params.parallel.dp_ep_padding_data = *cached;
+      return;
+    }
+  }
+
+  torch::Tensor token_size_per_dp_group =
+      torch::tensor(token_sizes,
+                    torch::TensorOptions()
+                        .device(torch::kCPU)
+                        .dtype(torch::kInt32)
+                        .pinned_memory(true));
+  torch::Tensor raw_token_size_per_dp_group =
+      raw_token_sizes.empty() ? torch::Tensor()
+                              : torch::tensor(raw_token_sizes,
+                                              torch::TensorOptions()
+                                                  .device(torch::kCPU)
+                                                  .dtype(torch::kInt32)
+                                                  .pinned_memory(true));
+  DpEpPadding dp_ep_padding(token_size_per_dp_group,
+                            raw_token_size_per_dp_group,
+                            context_.get_model_args().num_experts_per_tok(),
+                            context_.get_parallel_args().mapping_data(),
+                            device_,
+                            dtype_,
+                            is_prefill);
+  DpEpPaddingData data = dp_ep_padding.build();
+  input_params.parallel.dp_ep_padding_data = data;
+  if (use_draft_decode_cache) {
+    draft_dp_ep_padding_cache_.insert(token_sizes, raw_token_sizes, data);
+  }
+}
+
+void WorkerImpl::prepare_dp_ep_padding_on_stream(ModelInputParams& input_params,
+                                                 Stream& prepare_stream) {
+  if (!uses_npu_dp_ep_padding()) {
+    return;
+  }
+  std::optional<std::unique_lock<std::mutex>> lock_guard;
+  if (::xllm::ExecutionConfig::get_instance().enable_graph()) {
+    auto& capture_lock =
+        ::xllm::npu::DeviceCaptureLock::get_instance().get_lock(
+            device_.index());
+    lock_guard.emplace(capture_lock);
+  }
+  c10::StreamGuard stream_guard = prepare_stream.set_stream_guard();
+  prepare_dp_ep_padding(input_params);
 }
 #endif
 
@@ -875,36 +947,10 @@ void WorkerImpl::prepare_work_before_execute_on_stream(
       prepare_mla_prefixcache_inputs(input_params);
     }
 
-    if (!context_.get_parallel_args().mapping_data().empty() &&
-        !(context_.get_parallel_args().cp_size() > 1) &&
-        (context_.get_parallel_args().dp_size() > 1 ||
-         context_.get_parallel_args().ep_size() > 1)) {
-      torch::Tensor token_size_per_dp_group = torch::tensor(
-          processed_input.input_params.parallel.dp_global_token_nums,
-          torch::TensorOptions()
-              .device(torch::kCPU)
-              .dtype(torch::kInt32)
-              .pinned_memory(true));
-      const auto& raw_dp_token_nums =
-          processed_input.input_params.parallel.raw_dp_global_token_nums;
-      torch::Tensor raw_token_size_per_dp_group =
-          raw_dp_token_nums.empty() ? torch::Tensor()
-                                    : torch::tensor(raw_dp_token_nums,
-                                                    torch::TensorOptions()
-                                                        .device(torch::kCPU)
-                                                        .dtype(torch::kInt32)
-                                                        .pinned_memory(true));
-      const bool is_prefill =
-          processed_input.input_params.meta.batch_forward_type.no_decode();
-      DpEpPadding dp_ep_padding(token_size_per_dp_group,
-                                raw_token_size_per_dp_group,
-                                context_.get_model_args().num_experts_per_tok(),
-                                context_.get_parallel_args().mapping_data(),
-                                device_,
-                                dtype_,
-                                is_prefill);
-      processed_input.input_params.parallel.dp_ep_padding_data =
-          dp_ep_padding.build();
+    if (owns_npu_parallel_input_prepare()) {
+      prepare_dp_ep_padding(processed_input.input_params);
+    }
+    if (uses_npu_dp_ep_padding()) {
       if (::xllm::EPLBConfig::get_instance().enable_eplb()) {
         processed_input.input_params.expert.expert_load_data =
             expert_load_data_;

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -1153,6 +1153,15 @@ folly::SemiFuture<std::optional<ForwardOutput>> WorkerImpl::step_async(
       }
 
       const auto output = this->step_for_schedule_overlap(input);
+#if defined(USE_NPU)
+      if (output.has_value() && !output->sample_output.next_tokens.defined() &&
+          output->ready_event != nullptr &&
+          (output->retained_input != nullptr ||
+           !output->retained_input_dependencies.empty())) {
+        CHECK(output->ready_event->synchronize())
+            << "failed to retire asynchronous output without tokens";
+      }
+#endif
       if (output.has_value()) {
         if (is_driver() || ::xllm::EPLBConfig::get_instance().enable_eplb()) {
           std::unique_lock<std::mutex> lock(mtx_);
@@ -1161,6 +1170,24 @@ folly::SemiFuture<std::optional<ForwardOutput>> WorkerImpl::step_async(
           is_recorded_ = true;
           cv_.notify_one();
         } else {
+#if defined(USE_NPU)
+          // Driver outputs are copied by GetLastStepResult, which waits for the
+          // ready event before the retained no-sync inputs can be released.
+          // Non-driver ranks are not queried by LLMEngine. In eager DP MTP,
+          // overwriting their previous output can therefore release temporary
+          // DP/EP padding tensors while ATB still holds their device addresses.
+          // Keep one-step scheduler overlap, but retire the previous eager
+          // output only after its compute event has completed.
+          const bool wait_for_eager_dp_spec_input_lifetime =
+              last_step_output_valid_ && options_.enable_speculative_decode() &&
+              parallel_args_.dp_size() > 1 &&
+              !::xllm::ExecutionConfig::get_instance().enable_graph() &&
+              last_step_output_.ready_event != nullptr;
+          if (wait_for_eager_dp_spec_input_lifetime) {
+            CHECK(last_step_output_.ready_event->synchronize())
+                << "failed to retire previous eager DP speculative input";
+          }
+#endif
           update_last_step_output(output);
         }
       } else {

--- a/xllm/core/runtime/worker_impl.h
+++ b/xllm/core/runtime/worker_impl.h
@@ -43,6 +43,7 @@ limitations under the License.
 #include "util/threadpool.h"
 #if defined(USE_NPU)
 #include "framework/kv_cache_transfer/mooncake_weight_transfer.h"
+#include "framework/parallel_state/npu_dp_ep_padding.h"
 #include "layers/npu/loader/rolling_load_manager.h"
 #endif
 
@@ -119,10 +120,16 @@ class WorkerImpl {
   // Per-worker-static configuration handed to NpuCpPlan::prepare(); built once
   // and cached.
   const CpPlanRuntimeConfig& npu_cp_plan_runtime_config() const;
+  // Builds or reuses draft decode padding on the current stream. MTP calls this
+  // while preparing B/2B metadata so the compute stream only observes hits.
+  bool uses_npu_dp_ep_padding() const;
+  void prepare_dp_ep_padding(ModelInputParams& input_params);
+  void prepare_dp_ep_padding_on_stream(ModelInputParams& input_params,
+                                       Stream& prepare_stream);
 #endif
 
-  // False on MTP composite: only leaf workers run NpuCpPlan::prepare.
-  virtual bool owns_npu_cp_plan_build() const { return true; }
+  // False on composites where only leaf workers consume parallel metadata.
+  virtual bool owns_npu_parallel_input_prepare() const { return true; }
 
   // Cached: whether the loaded model advertises NPU model-side CP.
   bool model_supports_model_cp() const;
@@ -285,6 +292,9 @@ class WorkerImpl {
 #endif
 
 #if defined(USE_NPU)
+  static constexpr size_t kDraftDpEpPaddingCacheCapacity = 2;
+  DpEpPaddingCache draft_dp_ep_padding_cache_{kDraftDpEpPaddingCacheCapacity};
+
   bool wakeup_from_remote_weights(const WakeupOptions& options);
   // Complete rolling initialization by delegating to model-owned rolling
   // runtime (manager + buffer): decoder preload, non-decoder reload, and

--- a/xllm/core/runtime/worker_impl.h
+++ b/xllm/core/runtime/worker_impl.h
@@ -43,6 +43,7 @@ limitations under the License.
 #include "util/threadpool.h"
 #if defined(USE_NPU)
 #include "framework/kv_cache_transfer/mooncake_weight_transfer.h"
+#include "framework/parallel_state/npu_dp_ep_padding.h"
 #include "layers/npu/loader/rolling_load_manager.h"
 #endif
 
@@ -119,10 +120,16 @@ class WorkerImpl {
   // Per-worker-static configuration handed to NpuCpPlan::prepare(); built once
   // and cached.
   const CpPlanRuntimeConfig& npu_cp_plan_runtime_config() const;
+  // Builds or reuses draft decode padding on the current stream. MTP calls this
+  // while preparing B/2B metadata so the compute stream only observes hits.
+  bool uses_npu_dp_ep_padding() const;
+  void prepare_dp_ep_padding(ModelInputParams& input_params);
+  void prepare_dp_ep_padding_on_stream(ModelInputParams& input_params,
+                                       Stream& prepare_stream);
 #endif
 
-  // False on MTP composite: only leaf workers run NpuCpPlan::prepare.
-  virtual bool owns_npu_cp_plan_build() const { return true; }
+  // False on composites where only leaf workers consume parallel metadata.
+  virtual bool owns_npu_parallel_input_prepare() const { return true; }
 
   // Cached: whether the loaded model advertises NPU model-side CP.
   bool model_supports_model_cp() const;
@@ -289,6 +296,9 @@ class WorkerImpl {
 #endif
 
 #if defined(USE_NPU)
+  static constexpr size_t kDraftDpEpPaddingCacheCapacity = 2;
+  DpEpPaddingCache draft_dp_ep_padding_cache_{kDraftDpEpPaddingCacheCapacity};
+
   bool wakeup_from_remote_weights(const WakeupOptions& options);
   // Complete rolling initialization by delegating to model-owned rolling
   // runtime (manager + buffer): decoder preload, non-decoder reload, and


### PR DESCRIPTION
Prelaunch and continuously enqueue GLM DSA draft steps without host synchronization, overlap target metadata preparation, and cache draft DP/EP padding layouts. Preserve asynchronous tensor lifetimes and enable the optimized path for validated DP configurations.

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
