### PR TITLE
feat: support host kv offload for pd and mtp.

### DIFF
--- a/tests/core/framework/kv_cache/kv_cache_test.cpp
+++ b/tests/core/framework/kv_cache/kv_cache_test.cpp
@@ -856,6 +856,46 @@ TEST_F(HostKVCacheConfigTest, AcceptsQuantizedIndexerCache) {
   EXPECT_FALSE(validate_host_cache_options(options).has_value());
 }
 
+TEST_F(HostKVCacheConfigTest, AcceptsDisaggregatedPrefillInstance) {
+  HostCacheValidationOptions options;
+  options.host_blocks_factor = 2.0;
+  options.device_block_count = 128;
+  options.supports_host_kv_offload = true;
+  options.enable_disagg_pd = true;
+  options.instance_role = InstanceRole::PREFILL;
+
+  EXPECT_FALSE(validate_host_cache_options(options).has_value());
+}
+
+TEST_F(HostKVCacheConfigTest, RejectsDisaggregatedDecodeInstance) {
+  HostCacheValidationOptions options;
+  options.host_blocks_factor = 2.0;
+  options.device_block_count = 128;
+  options.supports_host_kv_offload = true;
+  options.enable_disagg_pd = true;
+  options.instance_role = InstanceRole::DECODE;
+
+  const std::optional<std::string> error = validate_host_cache_options(options);
+
+  ASSERT_TRUE(error.has_value());
+  EXPECT_NE(error->find("PREFILL"), std::string::npos);
+}
+
+TEST_F(HostKVCacheConfigTest, RejectsDisaggregatedPrefillOocMode) {
+  HostCacheValidationOptions options;
+  options.host_blocks_factor = 2.0;
+  options.device_block_count = 128;
+  options.supports_host_kv_offload = true;
+  options.enable_disagg_pd = true;
+  options.enable_pd_ooc = true;
+  options.instance_role = InstanceRole::PREFILL;
+
+  const std::optional<std::string> error = validate_host_cache_options(options);
+
+  ASSERT_TRUE(error.has_value());
+  EXPECT_NE(error->find("PD-OOC"), std::string::npos);
+}
+
 TEST_F(HostKVCacheConfigTest, RejectsQuantizedKVCache) {
   HostCacheValidationOptions options;
   options.host_blocks_factor = 2.0;

--- a/tests/core/framework/kv_cache_transfer/hierarchy_kv_cache_transfer_test.cpp
+++ b/tests/core/framework/kv_cache_transfer/hierarchy_kv_cache_transfer_test.cpp
@@ -33,6 +33,95 @@ namespace xllm {
 namespace {
 
 TEST(HierarchyKVCacheTransferTest,
+     RestoreRegistersReadyEventsForConfiguredLayerGroups) {
+  if (Platform::device_count() < 1) {
+    GTEST_SKIP() << "MLU device is required for hierarchy KV cache transfer.";
+  }
+
+  constexpr int64_t kBlockCount = 2;
+  constexpr int64_t kBlockSize = 4;
+  constexpr int64_t kLayerCount = 3;
+  constexpr int64_t kSourceBlockId = 0;
+  constexpr int64_t kDestinationBlockId = 1;
+  constexpr uint64_t kBatchId = 7;
+  constexpr double kHostBlocksFactor = 2.0;
+
+  Device device(/*device_index=*/0);
+  device.set_device();
+  device.init_device_context();
+
+  KVCacheCapacity capacity;
+  capacity.n_blocks(kBlockCount).block_size(kBlockSize);
+
+  ModelArgs model_args;
+  model_args.model_type("test_model")
+      .n_layers(kLayerCount)
+      .n_heads(2)
+      .n_kv_heads(1)
+      .head_dim(8);
+  const KVCacheShape cache_shape(capacity, model_args, /*world_size=*/1);
+
+  KVCacheCreateOptions create_options;
+  create_options.device(device.unwrap())
+      .dtype(torch::kFloat32)
+      .num_layers(kLayerCount)
+      .model_type("test_model");
+  std::vector<KVCache> caches;
+  allocate_kv_caches(caches, cache_shape, create_options);
+  ASSERT_EQ(caches.size(), static_cast<size_t>(kLayerCount));
+
+  for (size_t layer_idx = 0; layer_idx < caches.size(); ++layer_idx) {
+    const double layer_value = static_cast<double>(layer_idx);
+    caches[layer_idx].get_k_cache()[kSourceBlockId].fill_(3.0 + layer_value);
+    caches[layer_idx].get_v_cache()[kSourceBlockId].fill_(7.0 + layer_value);
+    caches[layer_idx].get_k_cache()[kDestinationBlockId].zero_();
+    caches[layer_idx].get_v_cache()[kDestinationBlockId].zero_();
+  }
+  ASSERT_EQ(device.synchronize_default_stream(), 0);
+
+  HierarchyKVCacheTransfer::Options transfer_options;
+  transfer_options.tp_rank(0)
+      .tp_size(1)
+      .layers(kLayerCount)
+      .host_blocks_factor(kHostBlocksFactor)
+      .layers_wise_copy_batchs(2);
+  std::unique_ptr<Stream> compute_stream = device.current_stream();
+  HierarchyKVCacheTransfer transfer(transfer_options,
+                                    device.unwrap(),
+                                    compute_stream.get(),
+                                    &caches,
+                                    cache_shape,
+                                    create_options);
+
+  BlockTransferInfo offload_info(kSourceBlockId, /*dst_block_id=*/0);
+  offload_info.block_type = BlockType::KV;
+  offload_info.transfer_type = TransferType::D2H2G;
+  EXPECT_EQ(transfer.transfer_kv_blocks(kBatchId, {offload_info}), 1U);
+
+  BlockTransferInfo load_info(/*src_block_id=*/0, kDestinationBlockId);
+  load_info.block_type = BlockType::KV;
+  load_info.transfer_type = TransferType::H2D;
+  EXPECT_EQ(transfer.transfer_kv_blocks(kBatchId, {load_info}), 1U);
+
+  ModelInputParams input_params;
+  input_params.meta.batch_id = kBatchId;
+  transfer.set_layer_synchronizer(input_params);
+  ASSERT_NE(input_params.parallel.layer_wise_load_synchronizer, nullptr);
+  EXPECT_EQ(input_params.parallel.layer_wise_load_synchronizer->size(), 3U);
+  EXPECT_EQ(input_params.parallel.layers_per_bacth_copy, 1U);
+  for (uint32_t layer_idx = 0; layer_idx < kLayerCount; ++layer_idx) {
+    ASSERT_TRUE(input_params.synchronize_layer(layer_idx));
+  }
+
+  for (KVCache& cache : caches) {
+    EXPECT_TRUE(torch::equal(cache.get_k_cache()[kSourceBlockId],
+                             cache.get_k_cache()[kDestinationBlockId]));
+    EXPECT_TRUE(torch::equal(cache.get_v_cache()[kSourceBlockId],
+                             cache.get_v_cache()[kDestinationBlockId]));
+  }
+}
+
+TEST(HierarchyKVCacheTransferTest,
      QuantizedIndexerRoundTripRestoresIndexAndScale) {
   if (Platform::device_count() < 1) {
     GTEST_SKIP() << "MLU device is required for hierarchy KV cache transfer.";

--- a/tests/core/runtime/CMakeLists.txt
+++ b/tests/core/runtime/CMakeLists.txt
@@ -111,6 +111,21 @@ if(USE_MLU)
       GTest::gtest_main
       torch_mlu
   )
+
+  cc_test(
+    NAME
+      mtp_host_offload_test
+    SRCS
+      mtp_host_offload_test.cpp
+    DEPS
+      :runtime
+      :model_loader
+      :batch
+      :kv_cache
+      :platform
+      GTest::gtest_main
+      torch_mlu
+  )
 endif()
 
 if(USE_CUDA)

--- a/tests/core/runtime/mtp_host_offload_test.cpp
+++ b/tests/core/runtime/mtp_host_offload_test.cpp
@@ -1,0 +1,164 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "core/framework/model/model_input_params.h"
+#include "core/framework/parallel_state/parallel_args.h"
+#include "core/platform/platform.h"
+#include "core/runtime/llm_worker_impl.h"
+#include "core/runtime/mtp_worker_impl.h"
+#include "core/runtime/options.h"
+#include "core/util/slice.h"
+
+namespace xllm {
+namespace {
+
+class RecordingTransferWorker final : public LLMWorkerImpl {
+ public:
+  RecordingTransferWorker(const ParallelArgs& parallel_args,
+                          const torch::Device& device,
+                          const runtime::Options& options,
+                          uint32_t transfer_result)
+      : LLMWorkerImpl(parallel_args, device, options),
+        transfer_result_(transfer_result) {}
+
+  uint32_t transfer_kv_blocks(
+      uint64_t batch_id,
+      const std::vector<BlockTransferInfo>& block_transfer_info) override {
+    last_batch_id_ = batch_id;
+    last_transfer_size_ = block_transfer_info.size();
+    ++vector_transfer_count_;
+    return transfer_result_;
+  }
+
+  uint32_t transfer_kv_blocks(
+      uint64_t batch_id,
+      Slice<BlockTransferInfo>& block_transfer_info) override {
+    last_batch_id_ = batch_id;
+    last_transfer_size_ = block_transfer_info.size();
+    ++slice_transfer_count_;
+    return transfer_result_;
+  }
+
+  uint32_t vector_transfer_count() const { return vector_transfer_count_; }
+  uint32_t slice_transfer_count() const { return slice_transfer_count_; }
+  uint64_t last_batch_id() const { return last_batch_id_; }
+  size_t last_transfer_size() const { return last_transfer_size_; }
+
+ private:
+  uint32_t transfer_result_ = 0;
+  uint32_t vector_transfer_count_ = 0;
+  uint32_t slice_transfer_count_ = 0;
+  uint64_t last_batch_id_ = 0;
+  size_t last_transfer_size_ = 0;
+};
+
+class TestMTPWorker final : public MTPWorkerImpl {
+ public:
+  TestMTPWorker(const ParallelArgs& parallel_args,
+                const torch::Device& device,
+                const runtime::Options& options)
+      : MTPWorkerImpl(parallel_args, device, options) {}
+
+  void replace_transfer_workers(std::unique_ptr<LLMWorkerImpl> target,
+                                std::unique_ptr<LLMWorkerImpl> draft) {
+    impl_ = std::move(target);
+    draft_impl_ = std::move(draft);
+  }
+};
+
+class MTPHostOffloadTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    if (Platform::device_count() < 1) {
+      GTEST_SKIP() << "MLU device is required for MTP host offload tests.";
+    }
+  }
+};
+
+TEST_F(MTPHostOffloadTest, TransfersEveryBlockToTargetAndDraft) {
+  constexpr uint64_t kBatchId = 42;
+  const torch::Device device("mlu:0");
+  ParallelArgs parallel_args(
+      /*rank=*/0, /*world_size=*/1, /*process_group=*/nullptr);
+  runtime::Options options;
+  options.block_size(16).num_speculative_tokens(1);
+  TestMTPWorker worker(parallel_args, device, options);
+
+  const std::vector<BlockTransferInfo> transfer_info = {
+      BlockTransferInfo(/*src_block_id=*/1, /*dst_block_id=*/2),
+      BlockTransferInfo(/*src_block_id=*/3, /*dst_block_id=*/4)};
+  auto target = std::make_unique<RecordingTransferWorker>(
+      parallel_args,
+      device,
+      options,
+      static_cast<uint32_t>(transfer_info.size()));
+  auto draft = std::make_unique<RecordingTransferWorker>(
+      parallel_args,
+      device,
+      options,
+      static_cast<uint32_t>(transfer_info.size()));
+  RecordingTransferWorker* target_ptr = target.get();
+  RecordingTransferWorker* draft_ptr = draft.get();
+  worker.replace_transfer_workers(std::move(target), std::move(draft));
+
+  const uint32_t transferred =
+      worker.transfer_kv_blocks(kBatchId, transfer_info);
+
+  EXPECT_EQ(transferred, transfer_info.size());
+  EXPECT_EQ(target_ptr->vector_transfer_count(), 1);
+  EXPECT_EQ(draft_ptr->vector_transfer_count(), 1);
+  EXPECT_EQ(target_ptr->last_batch_id(), kBatchId);
+  EXPECT_EQ(draft_ptr->last_batch_id(), kBatchId);
+  EXPECT_EQ(target_ptr->last_transfer_size(), transfer_info.size());
+  EXPECT_EQ(draft_ptr->last_transfer_size(), transfer_info.size());
+}
+
+TEST_F(MTPHostOffloadTest, RejectsMismatchedTargetAndDraftTransferCounts) {
+  constexpr uint64_t kBatchId = 73;
+  const torch::Device device("mlu:0");
+  ParallelArgs parallel_args(
+      /*rank=*/0, /*world_size=*/1, /*process_group=*/nullptr);
+  runtime::Options options;
+  options.block_size(16).num_speculative_tokens(1);
+  TestMTPWorker worker(parallel_args, device, options);
+
+  const std::vector<BlockTransferInfo> transfer_info = {
+      BlockTransferInfo(/*src_block_id=*/5, /*dst_block_id=*/6)};
+  auto target = std::make_unique<RecordingTransferWorker>(
+      parallel_args, device, options, /*transfer_result=*/1);
+  auto draft = std::make_unique<RecordingTransferWorker>(
+      parallel_args, device, options, /*transfer_result=*/0);
+  RecordingTransferWorker* target_ptr = target.get();
+  RecordingTransferWorker* draft_ptr = draft.get();
+  worker.replace_transfer_workers(std::move(target), std::move(draft));
+  Slice<BlockTransferInfo> transfer_slice(transfer_info);
+
+  const uint32_t transferred =
+      worker.transfer_kv_blocks(kBatchId, transfer_slice);
+
+  EXPECT_EQ(transferred, 0);
+  EXPECT_EQ(target_ptr->slice_transfer_count(), 1);
+  EXPECT_EQ(draft_ptr->slice_transfer_count(), 1);
+}
+
+}  // namespace
+}  // namespace xllm

--- a/xllm/core/distributed_runtime/llm_engine.cpp
+++ b/xllm/core/distributed_runtime/llm_engine.cpp
@@ -539,6 +539,10 @@ bool LLMEngine::allocate_kv_cache(const KVCacheCapacity& kv_cache_cap) {
       .device_block_count = kv_cache_cap.n_blocks(),
       .supports_host_kv_offload = Platform::supports_host_kv_offload(),
       .enable_prefix_cache = options_.enable_prefix_cache(),
+      .enable_disagg_pd = options_.enable_disagg_pd(),
+      .enable_pd_ooc = options_.enable_pd_ooc(),
+      .enable_kvcache_store = options_.enable_kvcache_store(),
+      .instance_role = options_.instance_role(),
       .has_key_cache_shape = kv_cache_shape.has_key_cache_shape(),
       .has_grouped_cache_layout = kv_cache_shape.has_grouped_cache_layout(),
       .supports_grouped_cache_offload =

--- a/xllm/core/distributed_runtime/master.cpp
+++ b/xllm/core/distributed_runtime/master.cpp
@@ -53,6 +53,7 @@ limitations under the License.
 #include "platform/platform.h"
 #include "rec_engine.h"
 #include "rec_master.h"
+#include "runtime/options.h"
 #include "speculative_engine.h"
 #include "util/model_config_utils.h"
 #include "util/scope_guard.h"
@@ -68,6 +69,19 @@ DECLARE_bool(graceful_quit_on_sighup);
 
 namespace xllm {
 namespace {
+
+void apply_runtime_kv_cache_options(const Options& source,
+                                    runtime::Options& destination) {
+  destination.host_blocks_factor(source.host_blocks_factor())
+      .enable_kvcache_store(source.enable_kvcache_store())
+      .store_protocol(source.store_protocol())
+      .store_master_server_address(source.store_master_server_address())
+      .store_metadata_server(source.store_metadata_server())
+      .store_local_hostname(source.store_local_hostname())
+      .prefetch_batch_size(source.prefetch_batch_size())
+      .layers_wise_copy_batchs(source.layers_wise_copy_batchs())
+      .kv_cache_dtype(source.kv_cache_dtype());
+}
 
 std::optional<std::string> validate_model_cp(const Options& options,
                                              EngineType engine_type,
@@ -290,6 +304,15 @@ Master::Master(const Options& options, EngineType type)
       master_status_(options.master_status()) {
   const auto model_path =
       std::filesystem::path(options_.model_path()).lexically_normal();
+  if (options_.host_blocks_factor() > 1.0) {
+    const bool supports_host_offload =
+        type == EngineType::LLM ||
+        (type == EngineType::SSM &&
+         SpeculativeConfig::is_mtp_algorithm(options_.speculative_algorithm()));
+    CHECK(supports_host_offload)
+        << "Basic host KV cache offload supports the LLM engine and the MTP "
+           "speculative engine only.";
+  }
   // Multi-process serving runs one worker per process. Select one runtime
   // logical device from the process-visible devices while keeping node_rank as
   // the global distributed identity.
@@ -494,6 +517,7 @@ Master::Master(const Options& options, EngineType type)
         .kv_cache_transfer_mode(options_.kv_cache_transfer_mode())
         .transfer_listen_port(options_.transfer_listen_port())
         .enable_disagg_pd(options_.enable_disagg_pd())
+        .enable_pd_ooc(options_.enable_pd_ooc())
         .enable_service_routing(options_.enable_service_routing())
         .enable_schedule_overlap(options_.enable_schedule_overlap())
         .enable_offline_inference(options_.enable_offline_inference())
@@ -509,6 +533,7 @@ Master::Master(const Options& options, EngineType type)
         .enable_prefill_piecewise_graph(
             options_.enable_prefill_piecewise_graph())
         .max_tokens_for_graph_mode(options_.max_tokens_for_graph_mode());
+    apply_runtime_kv_cache_options(options_, spec_options);
 
     if (use_suffix_spec) {
       engine_ = std::make_unique<SuffixSpeculativeEngine>(spec_options);
@@ -554,14 +579,6 @@ Master::Master(const Options& options, EngineType type)
         .enable_disagg_pd(options_.enable_disagg_pd())
         .enable_service_routing(options_.enable_service_routing())
         .enable_schedule_overlap(options_.enable_schedule_overlap())
-        .host_blocks_factor(options_.host_blocks_factor())
-        .enable_kvcache_store(options_.enable_kvcache_store())
-        .store_protocol(options_.store_protocol())
-        .store_master_server_address(options_.store_master_server_address())
-        .store_metadata_server(options_.store_metadata_server())
-        .store_local_hostname(options_.store_local_hostname())
-        .prefetch_batch_size(options_.prefetch_batch_size())
-        .layers_wise_copy_batchs(options_.layers_wise_copy_batchs())
         .enable_offline_inference(options_.enable_offline_inference())
         .disable_log_stats(options_.disable_log_stats())
         .spawn_worker_path(options_.spawn_worker_path())
@@ -576,9 +593,9 @@ Master::Master(const Options& options, EngineType type)
         .enable_prefill_piecewise_graph(
             options_.enable_prefill_piecewise_graph())
         .max_tokens_for_graph_mode(options_.max_tokens_for_graph_mode())
-        .kv_cache_dtype(options_.kv_cache_dtype())
         .enable_sleep_mode(options_.enable_sleep_mode())
         .model_id(options_.model_id());
+    apply_runtime_kv_cache_options(options_, eng_options);
 
     engine_ = std::make_unique<LLMEngine>(eng_options);
   } else if (type == EngineType::REC) {

--- a/xllm/core/distributed_runtime/master.cpp
+++ b/xllm/core/distributed_runtime/master.cpp
@@ -53,6 +53,7 @@ limitations under the License.
 #include "platform/platform.h"
 #include "rec_engine.h"
 #include "rec_master.h"
+#include "runtime/options.h"
 #include "speculative_engine.h"
 #include "util/model_config_utils.h"
 #include "util/scope_guard.h"
@@ -68,6 +69,19 @@ DECLARE_bool(graceful_quit_on_sighup);
 
 namespace xllm {
 namespace {
+
+void apply_runtime_kv_cache_options(const Options& source,
+                                    runtime::Options& destination) {
+  destination.host_blocks_factor(source.host_blocks_factor())
+      .enable_kvcache_store(source.enable_kvcache_store())
+      .store_protocol(source.store_protocol())
+      .store_master_server_address(source.store_master_server_address())
+      .store_metadata_server(source.store_metadata_server())
+      .store_local_hostname(source.store_local_hostname())
+      .prefetch_batch_size(source.prefetch_batch_size())
+      .layers_wise_copy_batchs(source.layers_wise_copy_batchs())
+      .kv_cache_dtype(source.kv_cache_dtype());
+}
 
 std::optional<std::string> validate_model_cp(const Options& options,
                                              EngineType engine_type,
@@ -290,6 +304,15 @@ Master::Master(const Options& options, EngineType type)
       master_status_(options.master_status()) {
   const auto model_path =
       std::filesystem::path(options_.model_path()).lexically_normal();
+  if (options_.host_blocks_factor() > 1.0) {
+    const bool supports_host_offload =
+        type == EngineType::LLM ||
+        (type == EngineType::SSM &&
+         SpeculativeConfig::is_mtp_algorithm(options_.speculative_algorithm()));
+    CHECK(supports_host_offload)
+        << "Basic host KV cache offload supports the LLM engine and the MTP "
+           "speculative engine only.";
+  }
   // Multi-process serving runs one worker per process. Select one runtime
   // logical device from the process-visible devices while keeping node_rank as
   // the global distributed identity.
@@ -485,6 +508,7 @@ Master::Master(const Options& options, EngineType type)
         .kv_cache_transfer_mode(options_.kv_cache_transfer_mode())
         .transfer_listen_port(options_.transfer_listen_port())
         .enable_disagg_pd(options_.enable_disagg_pd())
+        .enable_pd_ooc(options_.enable_pd_ooc())
         .enable_service_routing(options_.enable_service_routing())
         .enable_schedule_overlap(options_.enable_schedule_overlap())
         .enable_offline_inference(options_.enable_offline_inference())
@@ -500,6 +524,7 @@ Master::Master(const Options& options, EngineType type)
         .enable_prefill_piecewise_graph(
             options_.enable_prefill_piecewise_graph())
         .max_tokens_for_graph_mode(options_.max_tokens_for_graph_mode());
+    apply_runtime_kv_cache_options(options_, spec_options);
 
     if (use_suffix_spec) {
       engine_ = std::make_unique<SuffixSpeculativeEngine>(spec_options);
@@ -545,14 +570,6 @@ Master::Master(const Options& options, EngineType type)
         .enable_disagg_pd(options_.enable_disagg_pd())
         .enable_service_routing(options_.enable_service_routing())
         .enable_schedule_overlap(options_.enable_schedule_overlap())
-        .host_blocks_factor(options_.host_blocks_factor())
-        .enable_kvcache_store(options_.enable_kvcache_store())
-        .store_protocol(options_.store_protocol())
-        .store_master_server_address(options_.store_master_server_address())
-        .store_metadata_server(options_.store_metadata_server())
-        .store_local_hostname(options_.store_local_hostname())
-        .prefetch_batch_size(options_.prefetch_batch_size())
-        .layers_wise_copy_batchs(options_.layers_wise_copy_batchs())
         .enable_offline_inference(options_.enable_offline_inference())
         .disable_log_stats(options_.disable_log_stats())
         .spawn_worker_path(options_.spawn_worker_path())
@@ -567,9 +584,9 @@ Master::Master(const Options& options, EngineType type)
         .enable_prefill_piecewise_graph(
             options_.enable_prefill_piecewise_graph())
         .max_tokens_for_graph_mode(options_.max_tokens_for_graph_mode())
-        .kv_cache_dtype(options_.kv_cache_dtype())
         .enable_sleep_mode(options_.enable_sleep_mode())
         .model_id(options_.model_id());
+    apply_runtime_kv_cache_options(options_, eng_options);
 
     engine_ = std::make_unique<LLMEngine>(eng_options);
   } else if (type == EngineType::REC) {

--- a/xllm/core/framework/kv_cache/kv_cache_utils.cpp
+++ b/xllm/core/framework/kv_cache/kv_cache_utils.cpp
@@ -531,6 +531,25 @@ std::optional<std::string> validate_host_cache_options(
     violations.emplace_back(
         "prefix caching is disabled; set --enable_prefix_cache=true");
   }
+  if (options.enable_kvcache_store) {
+    violations.emplace_back(
+        "basic host offload does not support KV cache store; disable it");
+  }
+  if (options.enable_disagg_pd) {
+    if (options.instance_role != InstanceRole::PREFILL) {
+      violations.emplace_back(
+          "disaggregated host offload is supported only on the PREFILL "
+          "instance");
+    }
+    if (options.enable_pd_ooc) {
+      violations.emplace_back(
+          "disaggregated PREFILL host offload does not support PD-OOC");
+    }
+  } else if (options.instance_role != InstanceRole::DEFAULT) {
+    violations.emplace_back(
+        "host offload outside disaggregated serving requires the DEFAULT "
+        "instance role");
+  }
 
   // Quantized KV caches add scale tensors whose host offload and restore
   // lifecycle is not supported consistently by the common path yet.

--- a/xllm/core/framework/kv_cache/kv_cache_utils.h
+++ b/xllm/core/framework/kv_cache/kv_cache_utils.h
@@ -27,6 +27,7 @@ limitations under the License.
 
 #include "common/macros.h"
 #include "core/common/constants.h"
+#include "core/common/types.h"
 #include "util/tensor_helper.h"
 
 #if defined(USE_NPU)
@@ -119,6 +120,10 @@ struct HostCacheValidationOptions {
   int64_t device_block_count = 0;
   bool supports_host_kv_offload = false;
   bool enable_prefix_cache = true;
+  bool enable_disagg_pd = false;
+  bool enable_pd_ooc = false;
+  bool enable_kvcache_store = false;
+  InstanceRole instance_role = InstanceRole::DEFAULT;
   bool has_key_cache_shape = true;
   bool has_grouped_cache_layout = false;
   bool supports_grouped_cache_offload = false;

--- a/xllm/core/platform/platform.h
+++ b/xllm/core/platform/platform.h
@@ -68,8 +68,8 @@ class Platform final {
     return is_mlu();
   }
 
-  // Host KV offload requires both a batch memcpy provider and a layer-wise
-  // synchronization implementation.
+  // Host KV offload requires a batch memcpy provider with stream
+  // synchronization support.
   static constexpr bool supports_host_kv_offload() {
     return is_npu() || is_mlu();
   }

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -338,6 +338,7 @@ std::optional<ForwardOutput> run_llm_no_sync_impl(
       processed_input,
       prepare_stream,
       /*record_ready_event=*/&prepare_stream != &compute_stream);
+  worker.set_hierarchy_layer_synchronizer(processed_input.input_params);
   return worker.execute_no_sync_on_stream(
       processed_input, compute_stream, /*record_ready_event=*/false);
 }
@@ -531,6 +532,16 @@ KVCacheShape MTPDraftKVCacheShape(const KVCacheShape& target_shape,
 bool is_qwen3_5_draft_model_type(const std::string& model_type) {
   return mtp_async::classify_combined_draft_execution_path(model_type) ==
          mtp_async::CombinedDraftExecutionPath::QWEN3_5_PAGED_ATTENTION;
+}
+
+uint32_t validate_paired_transfer_counts(uint32_t target_transferred,
+                                         uint32_t draft_transferred) {
+  if (target_transferred != draft_transferred) {
+    LOG(ERROR) << "MTP target/draft KV block transfer count mismatch: target="
+               << target_transferred << ", draft=" << draft_transferred;
+    return 0;
+  }
+  return target_transferred;
 }
 
 }  // namespace
@@ -772,6 +783,32 @@ bool MTPWorkerImpl::allocate_kv_cache(const KVCacheShape& kv_cache_shape) {
   }
 
   return target_allocated && draft_allocated;
+}
+
+uint32_t MTPWorkerImpl::transfer_kv_blocks(
+    uint64_t batch_id,
+    const std::vector<BlockTransferInfo>& block_transfer_info) {
+  CHECK(impl_ != nullptr);
+  CHECK(draft_impl_ != nullptr);
+
+  const uint32_t target_transferred =
+      impl_->transfer_kv_blocks(batch_id, block_transfer_info);
+  const uint32_t draft_transferred =
+      draft_impl_->transfer_kv_blocks(batch_id, block_transfer_info);
+  return validate_paired_transfer_counts(target_transferred, draft_transferred);
+}
+
+uint32_t MTPWorkerImpl::transfer_kv_blocks(
+    uint64_t batch_id,
+    Slice<BlockTransferInfo>& block_transfer_info) {
+  CHECK(impl_ != nullptr);
+  CHECK(draft_impl_ != nullptr);
+
+  const uint32_t target_transferred =
+      impl_->transfer_kv_blocks(batch_id, block_transfer_info);
+  const uint32_t draft_transferred =
+      draft_impl_->transfer_kv_blocks(batch_id, block_transfer_info);
+  return validate_paired_transfer_counts(target_transferred, draft_transferred);
 }
 
 #if defined(USE_NPU) || defined(USE_MLU)

--- a/xllm/core/runtime/mtp_worker_impl.h
+++ b/xllm/core/runtime/mtp_worker_impl.h
@@ -65,6 +65,14 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
 
   bool allocate_kv_cache(const KVCacheShape& kv_cache_shape) override;
 
+  uint32_t transfer_kv_blocks(
+      uint64_t batch_id,
+      const std::vector<BlockTransferInfo>& block_transfer_info) override;
+
+  uint32_t transfer_kv_blocks(
+      uint64_t batch_id,
+      Slice<BlockTransferInfo>& block_transfer_info) override;
+
 #if defined(USE_NPU) || defined(USE_MLU)
   bool allocate_kv_cache_with_transfer(
       const KVCacheShape& kv_cache_shape) override;

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -1782,6 +1782,13 @@ uint32_t WorkerImpl::transfer_kv_blocks(
   return 0;
 }
 
+void WorkerImpl::set_hierarchy_layer_synchronizer(
+    ModelInputParams& input_params) {
+  if (hierarchy_kv_cache_transfer_ != nullptr) {
+    hierarchy_kv_cache_transfer_->set_layer_synchronizer(input_params);
+  }
+}
+
 int64_t WorkerImpl::get_active_activation_memory() {
   return DeviceMonitor::get_instance()
       .get_device_stats(device_.index())

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -1778,6 +1778,13 @@ uint32_t WorkerImpl::transfer_kv_blocks(
   return 0;
 }
 
+void WorkerImpl::set_hierarchy_layer_synchronizer(
+    ModelInputParams& input_params) {
+  if (hierarchy_kv_cache_transfer_ != nullptr) {
+    hierarchy_kv_cache_transfer_->set_layer_synchronizer(input_params);
+  }
+}
+
 int64_t WorkerImpl::get_active_activation_memory() {
   return DeviceMonitor::get_instance()
       .get_device_stats(device_.index())

--- a/xllm/core/runtime/worker_impl.h
+++ b/xllm/core/runtime/worker_impl.h
@@ -184,6 +184,8 @@ class WorkerImpl {
       const uint64_t batch_id,
       Slice<BlockTransferInfo>& block_transfer_info);
 
+  void set_hierarchy_layer_synchronizer(ModelInputParams& input_params);
+
   // Run the model on the given input. async call
   // the future returns a successfull status with no meaningful value
   virtual folly::SemiFuture<std::optional<ForwardOutput>> step_async(

--- a/xllm/models/llm/deepseek_v2.h
+++ b/xllm/models/llm/deepseek_v2.h
@@ -191,6 +191,9 @@ class DeepseekV2ModelImpl : public torch::nn::Module {
                           std::vector<KVCache>& kv_caches,
                           const ModelInputParams& input_params) {
     for (size_t i = 0; i < layers_.size(); ++i) {
+      if (!input_params.synchronize_layer(static_cast<uint32_t>(i))) {
+        return false;
+      }
       // NOTE: we will remove this until refactor flashinfer API
 #if defined(USE_CUDA) || defined(USE_MUSA)
       attn_metadata.plan_info->layer_id = i;

--- a/xllm/models/llm/llm_model_base.h
+++ b/xllm/models/llm/llm_model_base.h
@@ -105,6 +105,9 @@ class LlmModelImplBase : public torch::nn::Module {
 
     std::optional<torch::Tensor> residual;
     for (size_t i = 0; i < layers_.size(); i++) {
+      if (!modified_input_params.synchronize_layer(static_cast<uint32_t>(i))) {
+        return ModelOutput();
+      }
       if (llmrec_params != nullptr) {
         attn_metadata.full_k_cache = llmrec_params->full_k_caches[i];
         attn_metadata.full_v_cache = llmrec_params->full_v_caches[i];

--- a/xllm/models/llm/mimo_mtp.h
+++ b/xllm/models/llm/mimo_mtp.h
@@ -175,6 +175,9 @@ class MiMoMtpModelImpl final : public torch::nn::Module {
 
     std::optional<torch::Tensor> residual;
     for (size_t i = 0; i < mtp_layers_.size(); i++) {
+      if (!modified_input_params.synchronize_layer(static_cast<uint32_t>(i))) {
+        return ModelOutput();
+      }
 #if defined(USE_CUDA)
       attn_metadata.plan_info->layer_id = static_cast<int32_t>(i);
 #endif

--- a/xllm/models/llm/mlu/deepseek_v4_mtp.h
+++ b/xllm/models/llm/mlu/deepseek_v4_mtp.h
@@ -256,6 +256,9 @@ class DeepseekV4MtpModelImpl final : public torch::nn::Module,
 
     torch::Tensor aux_hidden_states;
     for (size_t i = 0; i < mtp_layers_.size(); ++i) {
+      if (!modified_input_params.synchronize_layer(static_cast<uint32_t>(i))) {
+        return ModelOutput();
+      }
       const int32_t layer_id = static_cast<int32_t>(i);
       prepare_layer_metadata(attn_metadata, layer_id);
       hidden_states = mtp_layers_[i](hidden_states,

--- a/xllm/models/llm/mtp_model_base.h
+++ b/xllm/models/llm/mtp_model_base.h
@@ -421,6 +421,9 @@ class MtpModelImplBase : public torch::nn::Module {
     LayerForwardAdapter forward_adapter(
         input_params.mtp_topk_state, mtp_layers_.size(), device_);
     for (size_t i = 0; i < mtp_layers_.size(); i++) {
+      if (!modified_input_params.synchronize_layer(static_cast<uint32_t>(i))) {
+        return ModelOutput();
+      }
 #if defined(USE_CUDA) || defined(USE_MUSA)
       attn_metadata.plan_info->layer_id = i;
 #endif

--- a/xllm/models/llm/qwen3.h
+++ b/xllm/models/llm/qwen3.h
@@ -140,6 +140,9 @@ class QWen3ModelImpl : public LlmModelImplBase<layer::Qwen3DecoderLayer> {
 
     std::optional<torch::Tensor> residual;
     for (size_t i = 0; i < layers_.size(); i++) {
+      if (!input_params_new.synchronize_layer(static_cast<uint32_t>(i))) {
+        return ModelOutput();
+      }
       if (is_rec_multi_round_mode() && input_params_new.has_llmrec_params()) {
         const auto& llmrec_params = input_params_new.llmrec_params();
         attn_metadata.full_k_cache = llmrec_params->full_k_caches[i];

--- a/xllm/models/llm/qwen3_5_mtp_base.h
+++ b/xllm/models/llm/qwen3_5_mtp_base.h
@@ -141,6 +141,9 @@ class Qwen3_5MtpModelImplBase : public Qwen3HybridModelImplBase {
 
     std::optional<torch::Tensor> residual = std::nullopt;
     for (size_t i = 0; i < layers_.size(); ++i) {
+      if (!input_params.synchronize_layer(static_cast<uint32_t>(i))) {
+        return ModelOutput();
+      }
       mtp_hidden = layers_[i]->forward(mtp_hidden,
                                        residual,
                                        positions,

--- a/xllm/models/llm/qwen3_moe.h
+++ b/xllm/models/llm/qwen3_moe.h
@@ -148,6 +148,9 @@ class Qwen3MoeModelImpl : public LlmModelImplBase<layer::Qwen3MoeDecoderLayer> {
 
     std::optional<torch::Tensor> residual;
     for (size_t i = 0; i < layers_.size(); i++) {
+      if (!modified_input_params.synchronize_layer(static_cast<uint32_t>(i))) {
+        return ModelOutput();
+      }
       if (llmrec_params != nullptr) {
         attn_metadata.full_k_cache = llmrec_params->full_k_caches[i];
         attn_metadata.full_v_cache = llmrec_params->full_v_caches[i];


### PR DESCRIPTION
## Description

This PR extends basic host KV cache offload support to disaggregated prefill (PD) and MTP speculative decoding workloads.

 - Propagate host KV cache configuration consistently to both LLM and speculative runtime options.
  - Allow host KV offload for:
    - Standard LLM engines.
    - MTP speculative engines.
    - Disaggregated PD prefill instances.
  - Reject unsupported configurations early:
    - Non-MTP speculative engines.
    - Disaggregated decode instances.
    - PD-OOC combined with host offload.
    - KV cache store combined with basic host offload.
    - Non-default instance roles outside disaggregated serving.
  - Register hierarchy KV-cache layer synchronizers before MTP execution and wait for restored KV-cache
  data before each model layer runs.
  - Apply layer-wise restore synchronization across supported LLM and MTP model implementations.
  - Forward KV block transfers to both MTP target and draft workers, and reject mismatched transfer
  counts.

 ### Tests

  Added MLU-gated coverage for:

  - Host-offload validation in disaggregated prefill, decode, and PD-OOC modes.
  - Hierarchical KV-cache restore events and per-layer synchronization.
  - MTP target/draft KV block transfer forwarding and transfer-count mismatch handling.


## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
