### PR TITLE
bugfix: canonicalize empty DP decode metadata for hybrid ACL graphs. 

### DIFF
--- a/tests/core/runtime/acl_graph_executor_test.cpp
+++ b/tests/core/runtime/acl_graph_executor_test.cpp
@@ -40,6 +40,7 @@ limitations under the License.
 #include "core/framework/request/stopping_checker.h"
 #include "core/framework/sampling/sampling_params.h"
 #include "core/layers/common/attention_metadata.h"
+#include "core/layers/common/attention_metadata_builder.h"
 #include "core/layers/npu/npu_lm_head_impl.h"
 #include "core/layers/npu/npu_word_embedding_impl.h"
 #include "core/layers/npu_torch/tests_utils.h"
@@ -1114,6 +1115,208 @@ TEST(AclGraphPersistentParamTest,
   EXPECT_EQ(stable->graph.expanded_block_tables.size(0), kSpecWidth);
   EXPECT_EQ(stable->graph.expanded_block_tables.size(1),
             kActiveBlockTableWidth);
+}
+
+TEST(AclGraphPersistentParamTest,
+     EmptyDpDecodeUsesCanonicalHybridGraphMetadata) {
+  ModelArgs args;
+  args.model_type("qwen3_5_moe_text");
+  args.dtype("float32");
+  args.hidden_size(8);
+  args.max_position_embeddings(4);
+
+  runtime::Options options;
+  options.block_size(4);
+  options.world_size(2);
+  options.dp_size(2);
+  options.max_seqs_per_batch(4);
+  options.max_tokens_per_batch(8);
+  options.num_decoding_tokens(1);
+
+  const torch::Device device("npu:0");
+  const torch::TensorOptions int_options =
+      torch::dtype(torch::kInt).device(device);
+  ::xllm::npu::GraphPersistentParam persistent_param(
+      args,
+      device,
+      options,
+      /*need_update_attn_mask=*/true,
+      /*is_hybrid_linear_attention=*/true);
+
+  const auto make_active_params = [&](int32_t kv_seq_len,
+                                      int32_t linear_state_id,
+                                      int32_t cache_slot,
+                                      int32_t block_id) {
+    ModelInputParams params;
+    params.meta.batch_forward_type = BatchForwardType::DECODE;
+    params.meta.num_sequences = 1;
+    params.meta.actual_num_sequences = 1;
+    params.meta.q_max_seq_len = 1;
+    params.meta.kv_max_seq_len = 4;
+    params.parallel.dp_global_token_nums = {1, 0};
+    params.parallel.raw_dp_global_token_nums = {1, 0};
+    params.parallel.dp_is_decode = {1, 1};
+    params.parallel.query_start_loc = {0, 1};
+    params.linear_state_validity_mask = {1};
+    params.attention.host.q_seq_lens = {1};
+    params.attention.host.q_cu_seq_lens = {1};
+    params.attention.host.kv_seq_lens = {kv_seq_len};
+    params.attention.host.kv_cache_tokens_nums = {kv_seq_len - 1};
+    params.attention.device.q_seq_lens = torch::ones({1}, int_options);
+    params.attention.device.q_cu_seq_lens = torch::ones({1}, int_options);
+    params.attention.device.kv_seq_lens =
+        torch::tensor({kv_seq_len}, int_options);
+    params.attention.device.kv_cache_tokens_nums =
+        torch::tensor({kv_seq_len - 1}, int_options);
+    params.attention.device.new_cache_slots =
+        torch::tensor({cache_slot}, int_options);
+    params.attention.device.block_tables =
+        torch::tensor({block_id}, int_options).reshape({1, 1});
+    params.embedding.linear_state_ids = {linear_state_id};
+    params.embedding.linear_state_indices =
+        torch::tensor({linear_state_id}, int_options);
+    return params;
+  };
+
+  const auto make_empty_params = []() {
+    ModelInputParams params;
+    params.meta.batch_forward_type = BatchForwardType::DECODE;
+    params.meta.num_sequences = 0;
+    params.meta.actual_num_sequences = 0;
+    params.meta.q_max_seq_len = 0;
+    params.meta.kv_max_seq_len = 0;
+    params.parallel.dp_global_token_nums = {1, 0};
+    params.parallel.raw_dp_global_token_nums = {1, 0};
+    params.parallel.dp_is_decode = {1, 1};
+    return params;
+  };
+
+  const torch::Tensor tokens = torch::ones({1}, int_options);
+  const torch::Tensor positions = torch::zeros({1}, int_options);
+  ModelInputParams empty_params = make_empty_params();
+  std::optional<ModelInputParams> initial_empty_capture =
+      persistent_param.update(tokens,
+                              torch::Tensor(),
+                              torch::Tensor(),
+                              positions,
+                              empty_params,
+                              /*padded_num_tokens=*/1,
+                              /*return_capture_params=*/true,
+                              /*skip_token_update=*/false,
+                              /*for_capture=*/true);
+  ASSERT_TRUE(initial_empty_capture.has_value());
+  EXPECT_EQ(initial_empty_capture->meta.q_max_seq_len, 1);
+  EXPECT_EQ(initial_empty_capture->meta.kv_max_seq_len, 1);
+  EXPECT_EQ(initial_empty_capture->linear_state_validity_mask,
+            std::vector<int64_t>({0}));
+  EXPECT_FALSE(layer::AttentionMetadataBuilder::build(*initial_empty_capture,
+                                                      /*enable_mla=*/false)
+                   .is_dummy);
+
+  ModelInputParams first_active = make_active_params(/*kv_seq_len=*/3,
+                                                     /*linear_state_id=*/7,
+                                                     /*cache_slot=*/5,
+                                                     /*block_id=*/6);
+  std::optional<ModelInputParams> first_capture =
+      persistent_param.update(tokens,
+                              torch::Tensor(),
+                              torch::Tensor(),
+                              positions,
+                              first_active,
+                              /*padded_num_tokens=*/1,
+                              /*return_capture_params=*/true);
+  ASSERT_TRUE(first_capture.has_value());
+  EXPECT_EQ(first_capture->embedding.linear_state_ids,
+            std::vector<int32_t>({7}));
+  EXPECT_EQ(first_capture->embedding.linear_state_indices.item<int32_t>(), 7);
+  EXPECT_EQ(first_capture->attention.device.kv_seq_lens.item<int32_t>(), 3);
+  EXPECT_EQ(first_capture->attention.device.new_cache_slots.item<int32_t>(), 5);
+  EXPECT_EQ(first_capture->attention.device.block_tables
+                .select(/*dim=*/0, /*index=*/0)
+                .select(/*dim=*/0, /*index=*/0)
+                .item<int32_t>(),
+            6);
+  EXPECT_TRUE(torch::allclose(first_capture->graph.attn_mask.to(torch::kCPU),
+                              torch::tensor({{0.0f, 0.0f, 0.0f, -9984.0f}})));
+
+  std::optional<ModelInputParams> empty_capture;
+  EXPECT_NO_THROW(empty_capture =
+                      persistent_param.update(tokens,
+                                              torch::Tensor(),
+                                              torch::Tensor(),
+                                              positions,
+                                              empty_params,
+                                              /*padded_num_tokens=*/1,
+                                              /*return_capture_params=*/true));
+  ASSERT_TRUE(empty_capture.has_value());
+  EXPECT_EQ(empty_capture->meta.num_sequences, 1);
+  EXPECT_EQ(empty_capture->meta.actual_num_sequences, 0);
+  EXPECT_EQ(empty_capture->meta.q_max_seq_len, 1);
+  EXPECT_EQ(empty_capture->meta.kv_max_seq_len, 1);
+  EXPECT_EQ(empty_capture->attention.host.q_seq_lens,
+            std::vector<int32_t>({1}));
+  EXPECT_EQ(empty_capture->attention.host.kv_seq_lens,
+            std::vector<int32_t>({1}));
+  EXPECT_EQ(empty_capture->attention.host.q_cu_seq_lens,
+            std::vector<int32_t>({0, 1}));
+  EXPECT_EQ(empty_capture->embedding.linear_state_ids,
+            std::vector<int32_t>({kPaddingLinearStateId}));
+  EXPECT_EQ(empty_capture->parallel.query_start_loc,
+            std::vector<int64_t>({0, 1}));
+  EXPECT_EQ(empty_capture->linear_state_validity_mask,
+            std::vector<int64_t>({0}));
+  EXPECT_EQ(empty_capture->attention.device.q_seq_lens.item<int32_t>(), 1);
+  EXPECT_EQ(empty_capture->attention.device.kv_seq_lens.item<int32_t>(), 1);
+  EXPECT_EQ(empty_capture->attention.device.new_cache_slots.item<int32_t>(), 0);
+  EXPECT_EQ(empty_capture->embedding.linear_state_indices.item<int32_t>(),
+            kPaddingLinearStateId);
+  EXPECT_TRUE(torch::equal(
+      empty_capture->attention.device.q_cu_seq_lens.to(torch::kCPU),
+      torch::tensor({0, 1}, torch::kInt)));
+  const torch::Tensor empty_block_tables_cpu =
+      empty_capture->attention.device.block_tables.to(torch::kCPU);
+  EXPECT_TRUE(torch::equal(empty_block_tables_cpu,
+                           torch::zeros_like(empty_block_tables_cpu)));
+  const layer::AttentionMetadata empty_metadata =
+      layer::AttentionMetadataBuilder::build(*empty_capture,
+                                             /*enable_mla=*/false);
+  EXPECT_FALSE(empty_metadata.is_dummy);
+  EXPECT_TRUE(torch::equal(empty_metadata.q_cu_seq_lens.to(torch::kCPU),
+                           torch::tensor({0, 1}, torch::kInt)));
+  EXPECT_TRUE(torch::allclose(
+      empty_capture->graph.attn_mask.slice(/*dim=*/1, /*start=*/0, /*end=*/1)
+          .to(torch::kCPU),
+      torch::zeros({1, 1}, torch::kFloat32)));
+
+  ModelInputParams second_active = make_active_params(/*kv_seq_len=*/2,
+                                                      /*linear_state_id=*/9,
+                                                      /*cache_slot=*/8,
+                                                      /*block_id=*/10);
+  std::optional<ModelInputParams> second_capture =
+      persistent_param.update(tokens,
+                              torch::Tensor(),
+                              torch::Tensor(),
+                              positions,
+                              second_active,
+                              /*padded_num_tokens=*/1,
+                              /*return_capture_params=*/true);
+  ASSERT_TRUE(second_capture.has_value());
+  EXPECT_EQ(second_capture->embedding.linear_state_ids,
+            std::vector<int32_t>({9}));
+  EXPECT_EQ(second_capture->embedding.linear_state_indices.item<int32_t>(), 9);
+  EXPECT_EQ(second_capture->linear_state_validity_mask,
+            std::vector<int64_t>({1}));
+  EXPECT_EQ(second_capture->attention.device.kv_seq_lens.item<int32_t>(), 2);
+  EXPECT_EQ(second_capture->attention.device.new_cache_slots.item<int32_t>(),
+            8);
+  EXPECT_EQ(second_capture->attention.device.block_tables
+                .select(/*dim=*/0, /*index=*/0)
+                .select(/*dim=*/0, /*index=*/0)
+                .item<int32_t>(),
+            10);
+  EXPECT_TRUE(
+      torch::allclose(second_capture->graph.attn_mask.to(torch::kCPU),
+                      torch::tensor({{0.0f, 0.0f, -9984.0f, -9984.0f}})));
 }
 
 TEST(AclGraphPersistentParamTest, AuxHiddenStatesUseGraphTokenCapacity) {

--- a/xllm/core/runtime/acl_graph_persistent_param.cpp
+++ b/xllm/core/runtime/acl_graph_persistent_param.cpp
@@ -305,10 +305,19 @@ GraphPersistentParam::GraphPersistentParam(const ModelArgs& args,
                     torch::dtype(dtype).device(device));
   }
 
-  q_cu_seq_lens_default_ = torch::zeros(
-      {metadata_capacity + 1}, torch::dtype(torch::kInt).device(device));
-  q_cu_seq_lens_ = torch::zeros({metadata_capacity + 1},
-                                torch::dtype(torch::kInt).device(device));
+  const torch::TensorOptions q_cu_options =
+      torch::dtype(torch::kInt).device(device);
+  if (is_hybrid_linear_attention_) {
+    // Hybrid decode consumes an indptr with a leading zero. Keeping the
+    // canonical one-token-per-row value as the reset template also gives
+    // logically empty graph shards a complete input without replay-time
+    // allocation.
+    q_cu_seq_lens_default_ = torch::arange(metadata_capacity + 1, q_cu_options);
+  } else {
+    q_cu_seq_lens_default_ =
+        torch::zeros({metadata_capacity + 1}, q_cu_options);
+  }
+  q_cu_seq_lens_ = q_cu_seq_lens_default_.clone();
 
   // Pre-allocate persistent dp/cp ep padding buffers with maximum capacity.
   const int64_t padding_buf_capacity =
@@ -819,11 +828,18 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
       is_chunked_prefill
           ? (padded_num_tokens + q_max_seq_len - 1) / q_max_seq_len
           : padded_num_tokens;
+  // WorkerImpl materializes one fake token for a logically empty DP decode
+  // rank so every rank can enter the same collectives. Canonicalize that
+  // physical row for hybrid models instead of letting q_max_seq_len == 0
+  // select dummy host branches while sharing a graph key with a real decode.
   const bool is_empty_dp_decode_rank =
-      is_decode && params.meta.num_sequences == 0 && actual_num_tokens > 0 &&
+      is_decode && params.meta.num_sequences == 0 &&
+      params.meta.actual_num_sequences == 0 && actual_num_tokens > 0 &&
       params.parallel.dp_global_token_nums.size() > 1 &&
       params.attention.host.kv_seq_lens.empty() &&
       params.attention.host.q_seq_lens.empty();
+  const bool canonical_empty_hybrid_decode =
+      is_empty_dp_decode_rank && is_hybrid_linear_attention_;
   const int64_t actual_seq_len_rows =
       is_empty_dp_decode_rank
           ? 0
@@ -927,6 +943,17 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
     zero_tensor_tail(persistent_new_cache_slots_,
                      actual_num_tokens,
                      static_cast<int64_t>(padded_num_tokens));
+  }
+  if (canonical_empty_hybrid_decode && padded_batch_size > 0) {
+    CHECK_LE(padded_batch_size, persistent_linear_state_indices_.size(0))
+        << "padded graph metadata rows exceed persistent linear-state "
+           "capacity";
+    // An empty shard has no source state tensor. Reset the full active slice
+    // before copying real rows so real -> empty -> real replay cannot retain a
+    // live sequence's state id in the reserved padding row.
+    persistent_linear_state_indices_
+        .slice(/*dim=*/0, /*start=*/0, /*end=*/padded_batch_size)
+        .fill_(kPaddingLinearStateId);
   }
   if (!params.embedding.linear_state_ids.empty()) {
     const int64_t linear_copy_len = std::min<int64_t>(
@@ -1086,17 +1113,6 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
     }
   }
 
-  // Expanded Qwen hybrid spec verification is represented as chunked prefill
-  // to the scheduler, but AttentionImpl routes it through decoder_forward().
-  // That path consumes expanded KV lengths, block tables and tiling data, not
-  // the dense graph attention mask. Avoid rebuilding the unused mask on every
-  // target replay while preserving all other decode/prefill paths.
-  const bool skip_unused_expanded_verify_mask =
-      can_skip_unused_expanded_verify_mask(params, is_hybrid_linear_attention_);
-  if (need_update_attn_mask_ && !skip_unused_expanded_verify_mask) {
-    update_attention_mask(params);
-  }
-
   std::vector<int32_t> padded_kv_seq_lens_vec(
       static_cast<size_t>(padded_batch_size), 1);
   std::vector<int32_t> padded_q_seq_lens_vec(
@@ -1116,6 +1132,26 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
   for (int64_t i = actual_seq_len_rows; i < padded_batch_size; ++i) {
     padded_q_seq_lens_vec[static_cast<size_t>(i)] =
         is_chunked_prefill ? q_max_seq_len : 1;
+  }
+
+  // Expanded Qwen hybrid spec verification is represented as chunked prefill
+  // to the scheduler, but AttentionImpl routes it through decoder_forward().
+  // That path consumes expanded KV lengths, block tables and tiling data, not
+  // the dense graph attention mask. Avoid rebuilding the unused mask on every
+  // target replay while preserving all other decode/prefill paths.
+  const bool skip_unused_expanded_verify_mask =
+      can_skip_unused_expanded_verify_mask(params, is_hybrid_linear_attention_);
+  if (need_update_attn_mask_ && !skip_unused_expanded_verify_mask) {
+    if (canonical_empty_hybrid_decode) {
+      ModelInputParams mask_params = params;
+      mask_params.attention.device.kv_seq_lens =
+          kv_seq_lens(static_cast<uint32_t>(padded_batch_size));
+      mask_params.meta.q_max_seq_len = 1;
+      mask_params.meta.kv_max_seq_len = 1;
+      update_attention_mask(mask_params);
+    } else {
+      update_attention_mask(params);
+    }
   }
   const bool use_expanded_spec_decode_attention =
       params.graph.use_expanded_decode_for_spec_verify_attention;
@@ -1273,6 +1309,12 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
     }
     graph_params->meta.num_sequences = static_cast<int32_t>(padded_batch_size);
     graph_params->meta.batch_forward_type = params.meta.batch_forward_type;
+    if (canonical_empty_hybrid_decode) {
+      // Keep logical sequence counts empty while presenting a complete,
+      // non-dummy execution shape to every captured/replayed operator.
+      graph_params->meta.q_max_seq_len = 1;
+      graph_params->meta.kv_max_seq_len = 1;
+    }
     graph_params->enable_graph = true;
     if (graph_params->parallel.dp_global_token_nums.size() > 1) {
       graph_params->parallel.dp_global_token_nums = std::vector<int32_t>(
@@ -1283,7 +1325,8 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
         persistent_new_cache_slots(padded_num_tokens);
     graph_params->attention.device.block_tables =
         persistent_block_tables(static_cast<uint32_t>(padded_batch_size));
-    if (!params.embedding.linear_state_ids.empty()) {
+    if (!params.embedding.linear_state_ids.empty() ||
+        canonical_empty_hybrid_decode) {
       graph_params->embedding.linear_state_ids =
           params.embedding.linear_state_ids;
       graph_params->embedding.linear_state_ids.resize(
@@ -1329,7 +1372,8 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
       graph_params->graph.expanded_tiling_data =
           uses_paged_attention_tiling() ? tiling_data() : torch::Tensor();
     }
-    if (params.attention.device.q_cu_seq_lens.defined()) {
+    if (params.attention.device.q_cu_seq_lens.defined() ||
+        canonical_empty_hybrid_decode) {
       const bool use_hybrid_query_start_loc = is_hybrid_linear_attention_;
       graph_params->attention.device.q_cu_seq_lens = q_cu_seq_lens_.slice(
           /*dim=*/0,
@@ -1358,6 +1402,14 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
     for (int64_t i = 0; i < padded_batch_size; ++i) {
       qsl.emplace_back(qsl.back() +
                        padded_q_seq_lens_vec[static_cast<size_t>(i)]);
+    }
+    if (canonical_empty_hybrid_decode) {
+      auto& host_q_cu_seq_lens = graph_params->attention.host.q_cu_seq_lens;
+      host_q_cu_seq_lens.clear();
+      host_q_cu_seq_lens.reserve(qsl.size());
+      for (int64_t offset : qsl) {
+        host_q_cu_seq_lens.emplace_back(static_cast<int32_t>(offset));
+      }
     }
 
     if (!params.linear_state_validity_mask.empty()) {


### PR DESCRIPTION
# bugfix: canonicalize empty DP decode metadata for hybrid ACL graphs. 

## Related Issue
Fixes #2135 

## Description

### Summary

This PR fixes a correctness and stability issue in the NPU ACL Graph decode path when:

- data parallelism is enabled;
- one DP replica is logically empty while another replica has active tokens;
- the model uses hybrid linear attention, such as Qwen3.5;
- ACL Graph decode is enabled.

An empty DP replica is a normal online-serving state. For example, with `dp_size=2`, a single decode request naturally produces a token distribution similar to:

```text
dp_global_token_nums = [1, 0]
```

The first replica processes a real token, while the second replica has no real sequence. Clients should not be required to submit requests in multiples of the DP size.

The empty replica cannot simply skip the forward pass when expert parallelism or other distributed collectives are enabled. Every rank must still enter compatible EP/HCCL operations. xLLM therefore materializes one fake token for the logically empty decode shard.

Before this change, the fake token provided a physical token row, but the corresponding hybrid graph metadata could still describe a logically empty input:

- `num_sequences == 0`;
- `actual_num_sequences == 0`;
- `q_max_seq_len == 0`;
- `kv_max_seq_len == 0`;
- empty host query/KV lengths;
- undefined device KV-length metadata;
- missing `q_cu_seq_lens`;
- missing linear-state metadata.

This mixed representation did not satisfy the fixed-input contract required by ACL Graph capture and replay.

### Production scenario

The issue was reproduced in an online inference deployment with:

- Qwen3.5-397B-A17B BF16;
- 16 Ascend NPUs on one host;
- world size 16;
- attention DP=2;
- attention TP=8;
- MoE EP=16;
- ACL Graph enabled;
- decode-no-padding enabled;
- graph decode batch-size limit 2.

With only one active request, one DP replica owns the request and the other replica becomes logically empty. The empty replica still has to participate in the EP16 collective execution, which is why a physical padding input is required.

This is an engine-side execution state rather than an invalid client request pattern.

### Root cause

ACL Graph decode selects its token bucket using the maximum token count across DP replicas. Therefore, an active replica and a logically empty replica can use the same physical graph bucket.

`GraphPersistentParam` is responsible for converting dynamic request metadata into fixed, address-stable graph inputs. Before this change, it preserved too much of the logical empty representation when preparing the physical graph input for a hybrid model.

This caused several problems.

#### Incompatible graph topology

`q_max_seq_len == 0` can cause `AttentionMetadataBuilder`, attention, or GDN code to select dummy or early-return paths.

A real one-token decode input selects the complete attention/GDN path, while an empty shard can select a dummy path, even though both use the same graph bucket.

As a result, the same graph key may represent incompatible operator topologies across capture and replay.

#### Undefined attention-mask input

Attention-mask construction expects valid device KV-length metadata. A logically empty shard does not naturally provide that tensor.

Passing the original empty parameters to the mask builder can therefore access an undefined KV-length tensor.

#### Missing hybrid query offsets

Hybrid GDN decode consumes query segmentation metadata such as `q_cu_seq_lens` or `query_start_loc`.

For a one-row physical graph input, the canonical query indptr is:

```text
[0, 1]
```

The original empty input could leave this metadata undefined or reset it to an all-zero representation.

#### Persistent linear-state leakage

ACL Graph inputs use persistent buffers so their device addresses remain stable during replay.

If an active decode step writes a real `linear_state_id` and the following empty step has no source state tensor, the previous ID may remain in the persistent buffer.

The fake token could then address a real sequence's recurrent state during an `active -> empty -> active` transition.

#### Incomplete graph-task metadata

The hybrid causal-convolution graph-task update also expects complete host-side query offsets and linear-state IDs. The original empty input did not satisfy this contract.

These inconsistencies can result in direct input errors, invalid graph replay, stale state access, or asynchronous distributed failures that later appear as HCCL stalls or device timeouts.

### Solution

This PR canonicalizes logically empty hybrid DP decode shards at the `GraphPersistentParam` boundary.

It keeps the logical and physical meanings separate:

| Field | Canonical empty-shard value |
| --- | --- |
| Logical sequence count | `actual_num_sequences = 0` |
| Physical graph row count | `num_sequences = padded_batch_size` |
| Query/KV maximum length | `q_max_seq_len = 1`, `kv_max_seq_len = 1` |
| Per-row query/KV lengths | One safe token per padding row |
| Query offsets | `[0, 1, ..., padded_batch_size]` |
| Hybrid `q_cu_seq_lens` | `[0, 1, ..., padded_batch_size]` |
| Linear-state ID | `kPaddingLinearStateId` |
| Linear-state validity | Zero |
| Cache and block metadata | Safe padding values |

The physical padding rows are valid graph inputs, but `actual_num_sequences` remains zero. They therefore do not become user-visible sequences.

The implementation performs the following changes.

1. **Create a canonical hybrid q-cu reset template**

   Hybrid `q_cu_seq_lens` persistent buffers are initialized with `arange` rather than zeros:

   ```text
   [0, 1, 2, ..., metadata_capacity]
   ```

   Real active rows are still overwritten with their actual query offsets. Empty and padded rows naturally retain a valid one-token-per-row representation without replay-time allocation.

2. **Detect logically empty DP decode shards conservatively**

   The new path requires:

   - decode mode;
   - `num_sequences == 0`;
   - `actual_num_sequences == 0`;
   - a worker-provided physical token;
   - more than one DP replica;
   - empty host query and KV metadata;
   - a hybrid linear-attention model.

   This keeps the behavior change limited to the failing execution mode.

3. **Reset persistent linear-state indices**

   Before copying any real rows, the persistent state-index slice used by an empty hybrid shard is reset to `kPaddingLinearStateId`.

   This prevents a previous active sequence ID from surviving an empty replay step.

4. **Build the attention mask from canonical KV metadata**

   For an empty hybrid shard, attention-mask construction uses a local canonical view of the input:

   - persistent KV lengths;
   - `q_max_seq_len = 1`;
   - `kv_max_seq_len = 1`.

   The existing mask-generation implementation can then be reused without reading an undefined tensor.

5. **Keep the graph-facing metadata non-dummy**

   The graph input receives valid query and KV maxima of one. This prevents the empty shard from selecting a dummy host branch while sharing a graph bucket with active decode inputs.

6. **Bind padding linear-state metadata explicitly**

   Even when the source input has no linear-state tensor, the graph input receives:

   - `kPaddingLinearStateId`;
   - persistent device state indices;
   - a zero validity mask.

   The fake row can execute safely without representing or updating a real user's recurrent state.

7. **Bind persistent query offsets explicitly**

   Empty hybrid inputs receive stable device `q_cu_seq_lens` and corresponding host query offsets, even when the original request metadata does not define them.

8. **Preserve logical emptiness**

   `actual_num_sequences` remains zero throughout the conversion. The change only canonicalizes the physical graph representation required for execution.

### Why this boundary

The change is intentionally localized to `GraphPersistentParam`.

This component already owns the conversion from dynamic eager inputs to fixed, address-stable ACL Graph inputs. Handling the canonical empty-row representation here avoids:

- requiring clients to batch requests in multiples of DP size;
- disabling DP;
- disabling ACL Graph;
- adding a batch-wide eager fallback;
- introducing separate active and empty graph keys;
- changing individual Attention, GDN, MoE, or HCCL kernels;
- changing public APIs or scheduler behavior.

The graph key and captured topology remain stable while the persistent input values are updated safely.

### Scope

This PR changes only:

- `xllm/core/runtime/acl_graph_persistent_param.cpp`;
- `tests/core/runtime/acl_graph_executor_test.cpp`.

It does not change:

- public APIs;
- launch arguments;
- scheduler placement;
- worker fake-token creation;
- graph-key construction;
- model kernels;
- prefill behavior;
- non-hybrid model behavior.

### Performance impact

The normal active path only gains narrowly scoped boolean checks.

The hybrid q-cu reset template is created once during persistent-buffer initialization. The existing per-step reset still performs the same persistent tensor copy, so this does not introduce an additional synchronization or host-to-device round trip.

The logically empty hybrid path adds:

- a small persistent state-index fill;
- canonical metadata preparation;
- a local `ModelInputParams` copy for attention-mask construction;
- safe padding-row execution.

An empty rank now executes padding rows matching the selected graph bucket instead of taking a dummy early-return path. This is required to keep the graph topology and collective ordering compatible.

The change does not add:

- a new graph variant;
- graph recapture for empty ranks;
- replay-time tensor allocation;
- a global eager fallback.

The serving results below are functional validation rather than a controlled before/after benchmark, but no obvious throughput regression was observed.

### Regression test

A new test, `EmptyDpDecodeUsesCanonicalHybridGraphMetadata`, covers both first-capture and persistent-buffer transition scenarios:

```text
initial empty
  -> active(state=7, kv=3, cache slot=5, block=6)
  -> empty
  -> active(state=9, kv=2, cache slot=8, block=10)
```

The test verifies that the empty graph input:

- remains logically empty;
- receives a complete non-dummy physical shape;
- exposes canonical host and device query offsets;
- uses `kPaddingLinearStateId`;
- has zero linear-state validity;
- clears padding cache-slot and block-table metadata;
- produces a valid attention mask;
- does not retain state from the preceding active request;
- can be overwritten correctly by a subsequent active request.

### Local test results

### Local test results

A full local NPU build and test run completed successfully:

```bash
python setup.py build test
```
All tests passed.
Additional validation included:
- AclGraphPersistentParamTest.EmptyDpDecodeUsesCanonicalHybridGraphMetadata;
- all AclGraphPersistentParamTest.* cases;
- complete acl_graph_executor_test;
- complete acl_graph_task_update_test;
- staged git clang-format with clang-format 20.1.6;
- git diff --cached --check.

### Manual integration validation

The rebuilt server was tested with the 16-NPU DP2/TP8/EP16 topology described above.

Two single-request online inference runs completed successfully:

| Request | Prompt tokens | Generated tokens | Finish reason | TTFT | Total time | Generation rate |
| --- | ---: | ---: | --- | ---: | ---: | ---: |
| 1 | 14 | 1,504 | `stop` | 84 ms | 35.649 s | 42.3 tokens/s |
| 2 | 24 | 4,096 | `length` | 84 ms | 84.299 s | 48.6 tokens/s |

A single request with DP=2 naturally exercises one active replica and one empty replica.

During this validation:

- all 16 ranks remained alive;
- bucket-1 graph capture completed;
- subsequent decode steps reused the captured graph;
- the second request reused the existing graph;
- both HTTP requests completed successfully;
- no request-time graph-capture failure, fatal HCCL error, AICore timeout, or CANN error was observed.

## Related Issues

N/A

<!-- Replace N/A with `Fixes #<issue-number>` if a corresponding issue exists. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [x] Test
- [ ] Build or CI

## Pull Request Checklist

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.