### PR TITLE
bugfix: fix A5 TileLang build and mRoPE correctness.

### DIFF
--- a/xllm/compiler/tilelang/targets/ascend/kernels/spec_verify_attention_tiling_update.py
+++ b/xllm/compiler/tilelang/targets/ascend/kernels/spec_verify_attention_tiling_update.py
@@ -55,7 +55,7 @@ class SpecVerifyAttentionTilingUpdateKernel(TilelangKernel):
     ]
     SPECIALIZATIONS = [
         {
-            "variant_key": f"w{spec_width}",
+            "variant_key": f"attn_tiling_w{spec_width}",
             "spec_width": spec_width,
         }
         for spec_width in SUPPORTED_SPEC_VERIFY_WIDTHS

--- a/xllm/compiler/tilelang/targets/ascend/kernels/spec_verify_token_update.py
+++ b/xllm/compiler/tilelang/targets/ascend/kernels/spec_verify_token_update.py
@@ -91,7 +91,7 @@ def build_spec_verify_token_update_kernel(spec_width: int):
 class SpecVerifyTokenUpdateKernel(TilelangKernel):
     DISPATCH_SCHEMA = [DispatchField("spec_width", "int32")]
     SPECIALIZATIONS = [
-        {"variant_key": f"w{spec_width}", "spec_width": spec_width}
+        {"variant_key": f"token_w{spec_width}", "spec_width": spec_width}
         for spec_width in SUPPORTED_SPEC_VERIFY_WIDTHS
     ]
 

--- a/xllm/compiler/tilelang/targets/ascend/kernels/split_qkv_rmsnorm_mrope.py
+++ b/xllm/compiler/tilelang/targets/ascend/kernels/split_qkv_rmsnorm_mrope.py
@@ -380,7 +380,6 @@ def build_split_qkv_rmsnorm_mrope_kernel(
 
                 # Init: load gather pattern, weights.
                 T.copy(gather_pattern, gather_offset_ub)
-                T.tile.fill(axes_ub, 0.0)
                 T.copy(q_weight[0, 0], q_weight_half_ub[0, :])
                 T.copy(k_weight[0, 0], k_weight_half_ub[0, :])
                 mte2_notify_v(E.INIT_WEIGHTS)

--- a/xllm/compiler/tilelang/targets/ascend/toolchain.py
+++ b/xllm/compiler/tilelang/targets/ascend/toolchain.py
@@ -138,6 +138,7 @@ def bisheng_include_dirs() -> list[str]:
         f"{npu_home_path}/include",
         f"{npu_home_path}/include/experiment/runtime",
         f"{npu_home_path}/include/experiment/msprof",
+        f"{npu_home_path}/pkg_inc",
         f"{npu_home_path}/compiler/tikcpp",
         f"{npu_home_path}/compiler/tikcpp/tikcfw",
         f"{npu_home_path}/compiler/tikcpp/tikcfw/impl",


### PR DESCRIPTION
## Description

This PR fixes two A5-specific TileLang integration issues in the xLLM parent repository:

- Add `${NPU_HOME}/pkg_inc` to the Ascend TileLang toolchain include paths so generated kernels can find CANN package headers.
- Remove the `axes_ub` zero-fill before the cos/sin DMA in the mRoPE kernel. The fill can race with the following MTE2 write and corrupt Q/K results.
- Pin only `third_party/torch_npu_ops` to the companion runtime fix.

## Related Issues

N/A

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [x] Test
- [x] Build or CI
## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

The only cross-repository dependency is xLLM-AI/torch-npu-ops#5. Please review the TileLang include-path addition and the removal of the conflicting mRoPE UB initialization. This PR intentionally does not include the closed MTP packaging change.