### PR TITLE
feature:support deepseekv4 flashcomm1+PCP+schedule-overlap.

### DIFF
--- a/xllm/core/common/flash_comm1_context.cpp
+++ b/xllm/core/common/flash_comm1_context.cpp
@@ -36,13 +36,67 @@ int32_t round_up_to_multiple(int32_t value, int32_t multiple) {
 
 }  // namespace
 
+namespace {
+
+// TP width of the current rank. Prefers the process group, which is
+// authoritative, and otherwise derives it from the documented rank layout
+// dp_rank * (cp_size * tp_size) + cp_rank * tp_size + tp_rank -- the same
+// arithmetic ParallelArgs::cp_rank() uses. The fallback matters because the
+// eligibility gate is deliberately callable without a live process group.
+int32_t fc1_tp_world_size(const ParallelArgs& parallel_args) {
+  if (parallel_args.tp_group_ != nullptr) {
+    return parallel_args.tp_group_->world_size();
+  }
+  const int32_t dp_size = std::max<int32_t>(parallel_args.dp_size(), 1);
+  const int32_t cp_size = std::max<int32_t>(parallel_args.cp_size(), 1);
+  const int32_t world_size = std::max<int32_t>(parallel_args.world_size(), 1);
+  return std::max<int32_t>(world_size / dp_size / cp_size, 1);
+}
+
+}  // namespace
+
+bool is_flash_comm1_eligible(const FlashComm1TokenGeometry& geometry,
+                             bool is_prefill,
+                             const ParallelArgs& parallel_args,
+                             const FlashComm1Options& options) {
+  if (!options.enable_flashcomm1 || !is_prefill) {
+    return false;
+  }
+  // Threshold on the pre-CP count so the decision is identical on every rank of
+  // the CP group.
+  if (geometry.global_num_tokens < options.min_prefill_tokens) {
+    return false;
+  }
+  if (std::max<int32_t>(parallel_args.cp_size(), 1) == 1) {
+    // No outer CP shard: geometry collapses and the threshold above is the
+    // whole gate, exactly as before CP composition existed.
+    return true;
+  }
+  if (geometry.local_num_tokens <= 0) {
+    return false;
+  }
+  // Uneven CP segments: require the smallest one to still carry a full
+  // alignment unit per TP rank, otherwise padding would dominate the shard and
+  // the thinnest rank could reduce_scatter an all-padding tensor.
+  const int32_t min_rows_per_cp_rank =
+      fc1_tp_world_size(parallel_args) * kFc1LocalTokenAlignment;
+  return geometry.min_local_num_tokens >= min_rows_per_cp_rank;
+}
+
 bool is_flash_comm1_eligible(int32_t num_tokens,
                              bool is_prefill,
                              const ParallelArgs& parallel_args,
                              const FlashComm1Options& options) {
-  return options.enable_flashcomm1 && is_prefill &&
-         parallel_args.cp_size() == 1 &&
-         num_tokens >= options.min_prefill_tokens;
+  // No CP-local geometry available, so this caller shards over tp_group only.
+  // Composing with CP here would shard the sequence twice.
+  if (parallel_args.cp_size() != 1) {
+    return false;
+  }
+  return is_flash_comm1_eligible(
+      FlashComm1TokenGeometry::without_cp(num_tokens),
+      is_prefill,
+      parallel_args,
+      options);
 }
 
 FlashComm1ContextScope::FlashComm1ContextScope(const FlashComm1Context* ctx)
@@ -77,18 +131,18 @@ torch::Tensor pad_rows_by_copy(const torch::Tensor& input,
   return output;
 }
 
-FlashComm1Context build_flash_comm1_context(int32_t num_tokens,
-                                            bool is_prefill,
-                                            const ParallelArgs& parallel_args,
-                                            const FlashComm1Options& options) {
+FlashComm1Context build_flash_comm1_context(
+    const FlashComm1TokenGeometry& geometry,
+    bool is_prefill,
+    const ParallelArgs& parallel_args,
+    const FlashComm1Options& options) {
   FlashComm1Context ctx;
 
 #if !defined(USE_NPU)
   return ctx;
 #endif
 
-  if (!is_flash_comm1_eligible(
-          num_tokens, is_prefill, parallel_args, options)) {
+  if (!is_flash_comm1_eligible(geometry, is_prefill, parallel_args, options)) {
     return ctx;
   }
 
@@ -100,17 +154,43 @@ FlashComm1Context build_flash_comm1_context(int32_t num_tokens,
   ctx.enabled = true;
   ctx.tp_rank = tp_group->rank();
   ctx.tp_world_size = tp_group->world_size();
-  ctx.original_num_tokens = num_tokens;
-  ctx.enable_mmrs_fusion = options.enable_mmrs_fusion;
+  // Geometry follows the rows this rank actually holds: under an outer CP shard
+  // that is the CP segment, not the pre-CP batch. shard_sequence() and the
+  // row-parallel reduce paths all validate against original_num_tokens, so this
+  // must be the local count.
+  ctx.original_num_tokens = geometry.local_num_tokens;
+  // MMRS fusion stays off under CP. The fused matmul+reduce_scatter kernel is
+  // already shape-sensitive enough to be default-off (see enable_mmrs_fusion),
+  // and an outer CP shard makes the row counts it sees both smaller and less
+  // regular: local rows are a per-sequence CP segment rather than the whole
+  // batch. The unfused reduce_scatter path is equivalent, so prefer it until
+  // fused MMRS has been measured on CP-local shapes.
+  const bool cp_active = std::max<int32_t>(parallel_args.cp_size(), 1) > 1;
+  ctx.enable_mmrs_fusion = options.enable_mmrs_fusion && !cp_active;
   ctx.mmrs_comm_mode = options.mmrs_comm_mode;
   ctx.tp_group = tp_group;
 
   const int32_t token_alignment = ctx.tp_world_size * kFc1LocalTokenAlignment;
-  ctx.padded_num_tokens = round_up_to_multiple(num_tokens, token_alignment);
-  ctx.pad_size = ctx.padded_num_tokens - num_tokens;
+  ctx.padded_num_tokens =
+      round_up_to_multiple(ctx.original_num_tokens, token_alignment);
+  ctx.pad_size = ctx.padded_num_tokens - ctx.original_num_tokens;
   ctx.padded_local_num_tokens = ctx.padded_num_tokens / ctx.tp_world_size;
 
   return ctx;
+}
+
+FlashComm1Context build_flash_comm1_context(int32_t num_tokens,
+                                            bool is_prefill,
+                                            const ParallelArgs& parallel_args,
+                                            const FlashComm1Options& options) {
+  if (parallel_args.cp_size() != 1) {
+    return FlashComm1Context{};
+  }
+  return build_flash_comm1_context(
+      FlashComm1TokenGeometry::without_cp(num_tokens),
+      is_prefill,
+      parallel_args,
+      options);
 }
 
 torch::Tensor shard_sequence(const torch::Tensor& input,

--- a/xllm/core/common/flash_comm1_context.h
+++ b/xllm/core/common/flash_comm1_context.h
@@ -50,6 +50,41 @@ struct FlashComm1Options {
   std::string mmrs_comm_mode = "aiv";
 };
 
+// Token geometry FC1 needs when it runs inside an outer CP sharding.
+//
+// FC1 and model-side CP both shard the token axis, but over different groups
+// (tp_group vs cp_group) which are orthogonal in the rank layout
+// dp_rank * (cp_size * tp_size) + cp_rank * tp_size + tp_rank. They compose as
+// long as CP is the OUTER shard and FC1 the inner one: CP splits the batch
+// across cp_group first, then FC1 splits each CP rank's rows across tp_group.
+// That requires separating the two token counts FC1 used to conflate:
+//
+//   global_num_tokens - the DP-local batch before CP shards it. Identical on
+//       every rank of the CP group, so it is what the min_prefill_tokens
+//       threshold must be tested against to keep the on/off decision uniform.
+//   local_num_tokens  - this rank's row count after the CP shard. This is the
+//       sequence FC1 actually pads and splits, so it drives all geometry
+//       (padded_num_tokens, padded_local_num_tokens, pad_size) and becomes
+//       ctx.original_num_tokens.
+//   min_local_num_tokens - the smallest local_num_tokens across the CP group.
+//       V4's CP split is per-sequence and contiguous, so segments are uneven
+//       and short batches leave high cp_ranks with few or zero rows. Every rank
+//       can derive this from the global q_seq_lens without communicating, so
+//       gating on it keeps FC1 uniformly on or off across the whole CP group
+//       instead of leaving some ranks sharded and others not.
+//
+// With cp_size == 1 all three are the same value and the geometry collapses to
+// the pre-CP behaviour.
+struct FlashComm1TokenGeometry {
+  int32_t global_num_tokens = 0;
+  int32_t local_num_tokens = 0;
+  int32_t min_local_num_tokens = 0;
+
+  static FlashComm1TokenGeometry without_cp(int32_t num_tokens) {
+    return FlashComm1TokenGeometry{num_tokens, num_tokens, num_tokens};
+  }
+};
+
 class FlashComm1ContextScope {
  public:
   explicit FlashComm1ContextScope(const FlashComm1Context* ctx);
@@ -71,12 +106,32 @@ torch::Tensor pad_rows_by_copy(const torch::Tensor& input, int64_t padded_rows);
 // Topology/config gate for FC1, independent of the process group and platform.
 // FC1 shards the sequence over the TP group, so it only needs a consistent
 // token count within that group: DP is fine (each DP rank owns a whole batch),
-// CP composition is not enabled because FC1 currently shards only over the TP
-// group and has not been validated together with model-side CP partitioning.
+// and CP is fine too because every rank of a TP group shares one cp_rank and
+// therefore one local row count.
+//
+// This CP-aware overload is for callers that apply the CP shard BEFORE building
+// the FC1 context and can describe both token counts (see
+// FlashComm1TokenGeometry). Composition is rejected unless the smallest CP
+// segment still leaves one full alignment unit per TP rank, so no rank ends up
+// reduce-scattering an empty or degenerate shard.
+bool is_flash_comm1_eligible(const FlashComm1TokenGeometry& geometry,
+                             bool is_prefill,
+                             const ParallelArgs& parallel_args,
+                             const FlashComm1Options& options);
+
+// Legacy gate for callers that have NOT been adapted to shard CP first. Such a
+// caller would hand FC1 the pre-CP token count and shard the sequence twice, so
+// this overload keeps refusing to compose with CP.
 bool is_flash_comm1_eligible(int32_t num_tokens,
                              bool is_prefill,
                              const ParallelArgs& parallel_args,
                              const FlashComm1Options& options);
+
+FlashComm1Context build_flash_comm1_context(
+    const FlashComm1TokenGeometry& geometry,
+    bool is_prefill,
+    const ParallelArgs& parallel_args,
+    const FlashComm1Options& options);
 
 FlashComm1Context build_flash_comm1_context(int32_t num_tokens,
                                             bool is_prefill,

--- a/xllm/core/distributed_runtime/llm_engine.cpp
+++ b/xllm/core/distributed_runtime/llm_engine.cpp
@@ -1189,7 +1189,12 @@ void LLMEngine::update_last_step_result(std::vector<Batch>& last_batch) {
   // cause the output on other workers is the same as that on driver.
   // Under data parallelism (DP), we need to get dp_size outputs.
   // The `stride` means the workers num we can skip.
-  uint32_t stride = dp_local_tp_size_;
+  // One retrievable result per DP group lives on its driver worker
+  // (dp_driver_: rank % (tp_size*cp_size) == 0), spaced dp_local_size_
+  // (= tp_size*cp_size) apart. dp_local_tp_size_ divides by cp_size, so
+  // under cp_size>1 it lands on cp_rank=1 non-driver workers whose
+  // get_last_step_result() blocks forever on cv_.wait(is_recorded_).
+  uint32_t stride = dp_local_size_;
   // If EPLB is enabled, we need to get results from all workers,
   // because the experts on each worker are different,
   // and the tokens load of all experts needs to be returned to engine.
@@ -1211,7 +1216,7 @@ void LLMEngine::update_last_step_result(std::vector<Batch>& last_batch) {
   }
 
   for (auto worker_rank = 0; worker_rank < worker_clients_num_;
-       worker_rank += dp_local_tp_size_) {
+       worker_rank += dp_local_size_) {
     auto result = last_step_results[worker_rank / stride].value();
     if (result.has_value()) {
       raw_forward_outputs.emplace_back(std::move(result.value()));

--- a/xllm/models/llm/deepseek_v4.h
+++ b/xllm/models/llm/deepseek_v4.h
@@ -842,9 +842,8 @@ class DeepseekV4ModelImpl
         FlashComm1TokenGeometry::without_cp(fc1_global_num_tokens);
     if (cp_ctx.enabled() && !cp_ctx.tokens_per_rank.empty()) {
       fc1_geometry.local_num_tokens = static_cast<int32_t>(h.size(0));
-      fc1_geometry.min_local_num_tokens =
-          *std::min_element(cp_ctx.tokens_per_rank.begin(),
-                            cp_ctx.tokens_per_rank.end());
+      fc1_geometry.min_local_num_tokens = *std::min_element(
+          cp_ctx.tokens_per_rank.begin(), cp_ctx.tokens_per_rank.end());
     }
     FlashComm1Context fc1_ctx;
     if (!acl_graph_forward && !is_empty_dp_rank) {

--- a/xllm/models/llm/deepseek_v4.h
+++ b/xllm/models/llm/deepseek_v4.h
@@ -783,35 +783,29 @@ class DeepseekV4ModelImpl
       }
     }
 
-    const int32_t fc1_num_tokens = static_cast<int32_t>(h.size(0));
-    FlashComm1Context fc1_ctx;
-    if (!acl_graph_forward && !is_empty_dp_rank) {
-      const bool is_prefill_side =
-          input_params.meta.batch_forward_type.no_decode();
-      fc1_ctx = build_flash_comm1_context(fc1_num_tokens,
-                                          is_prefill_side,
-                                          parallel_args_,
-                                          flash_comm1_options_);
-    }
-    FlashComm1ContextScope fc1_scope(&fc1_ctx);
-    if (is_sequence_sharded(fc1_ctx)) {
-      h = shard_sequence(h, fc1_ctx);
-    }
+    // Row count of the DP-local batch, before any token-axis sharding. FC1
+    // thresholds against this so its on/off decision is identical on every rank
+    // of the CP group even though the CP segments below are uneven.
+    const int32_t fc1_global_num_tokens = static_cast<int32_t>(h.size(0));
 
     // Prefill context parallel. Built here, after the global DSA metadata is
     // complete, because the KV / compressor / index-cache write path keeps the
     // global kv_seq_lens and slot_mapping: only the query axis is localized.
+    //
+    // CP is the OUTER token-axis shard and FlashComm1 below is the inner one:
+    // CP splits the batch across cp_group, then FC1 splits this rank's CP
+    // segment across tp_group. The groups are orthogonal in the rank layout
+    // dp_rank * (cp_size * tp_size) + cp_rank * tp_size + tp_rank, and every
+    // rank of a TP group shares one cp_rank, so all TP peers see the same CP
+    // segment length and FC1's collectives stay symmetric. Both the tail of
+    // this function and the decoder layer unwind in the reverse order (FC1
+    // gather, then CP gather_restore).
     layer::v4_cp::DeepseekV4CpContext cp_ctx;
     const bool cp_enabled = cp_size_ > 1 && cp_group_ != nullptr &&
                             !is_empty_dp_rank &&
                             input_params.meta.batch_forward_type.no_decode() &&
                             attn_metadata.dsa_metadata != nullptr;
     if (cp_enabled) {
-      // FlashComm1 SP and CP both shard tokens; running both would shard twice.
-      CHECK(!is_sequence_sharded(fc1_ctx))
-          << "DeepSeek V4 cannot combine FlashComm1 sequence parallel with "
-             "context parallel; build_flash_comm1_context must disable itself "
-             "when cp_size > 1.";
       auto& dsa = *(attn_metadata.dsa_metadata);
       cp_ctx = layer::v4_cp::build_deepseek_v4_cp_context(
           static_cast<int32_t>(cp_size_),
@@ -836,6 +830,32 @@ class DeepseekV4ModelImpl
         // because the MoE DP gather runs on the already CP-gathered rows.
         dsa.v4_cp_context = &cp_ctx;
       }
+    }
+
+    // FlashComm1 sequence parallel, inner to the CP shard above. h now holds
+    // only this rank's CP rows, so the padding geometry is derived from them
+    // while the min_prefill_tokens threshold stays on the pre-CP count. The
+    // smallest CP segment gates composition: V4 splits each sequence into
+    // contiguous per-rank chunks, so short batches leave high cp_ranks with few
+    // or zero rows and FC1 must then stay off across the whole group.
+    FlashComm1TokenGeometry fc1_geometry =
+        FlashComm1TokenGeometry::without_cp(fc1_global_num_tokens);
+    if (cp_ctx.enabled() && !cp_ctx.tokens_per_rank.empty()) {
+      fc1_geometry.local_num_tokens = static_cast<int32_t>(h.size(0));
+      fc1_geometry.min_local_num_tokens =
+          *std::min_element(cp_ctx.tokens_per_rank.begin(),
+                            cp_ctx.tokens_per_rank.end());
+    }
+    FlashComm1Context fc1_ctx;
+    if (!acl_graph_forward && !is_empty_dp_rank) {
+      const bool is_prefill_side =
+          input_params.meta.batch_forward_type.no_decode();
+      fc1_ctx = build_flash_comm1_context(
+          fc1_geometry, is_prefill_side, parallel_args_, flash_comm1_options_);
+    }
+    FlashComm1ContextScope fc1_scope(&fc1_ctx);
+    if (is_sequence_sharded(fc1_ctx)) {
+      h = shard_sequence(h, fc1_ctx);
     }
 
     std::optional<torch::Tensor> residual;


### PR DESCRIPTION
## Description

本 PR 主要支持 **DeepSeek V4 场景下 FlashComm1 + PCP + Schedule Overlap 的组合使用**。

主要修改包括：

* 支持 **FlashComm1 Sequence Parallel** 与 **DeepSeek V4 Context Parallel（PCP）** 组合使用；
* 增加 CP 场景下 FlashComm1 的 token geometry 计算；
* 调整 token 维度切分顺序为 **CP → FlashComm1**；
* 保证 CP Group 内各 Rank 对 FlashComm1 的启停判断保持一致；
* 修复 `cp_size > 1` 时 Schedule Overlap 场景可能出现的 hang 问题。

## 主要修改

### 1. 支持 FlashComm1 与 PCP 组合使用

此前 FlashComm1 在：

```text
cp_size > 1
```

时会被直接禁用。

原因是 FlashComm1 和 CP 都会在 token 维度进行切分，如果直接同时启用，会造成 token 被重复切分。

本 PR 将两者调整为嵌套的两级切分：

```text
DP-local tokens
      |
      v
+----------------------+
| Context Parallel     |
| 按 cp_group 切分     |
+----------------------+
      |
      v
CP-local tokens
      |
      v
+----------------------+
| FlashComm1 SP        |
| 按 tp_group 切分     |
+----------------------+
      |
      v
FC1-local tokens
```

即：

```text
CP = 外层 token shard
FlashComm1 = 内层 token shard
```

Rank 布局为：

```text
dp_rank * (cp_size * tp_size)
+ cp_rank * tp_size
+ tp_rank
```

`cp_group` 与 `tp_group` 相互正交。

因此，同一个 TP Group 中的 Rank 属于相同的 `cp_rank`，能够获得一致的 CP-local token 数，从而保证 FlashComm1 collective 通信的对称性。

### 2. 增加 CP-aware FlashComm1 Token Geometry

新增：

```cpp
struct FlashComm1TokenGeometry {
  int32_t global_num_tokens;
  int32_t local_num_tokens;
  int32_t min_local_num_tokens;
};
```

分别表示：

#### `global_num_tokens`

CP 切分之前的 DP-local token 总数。

用于：

```text
min_prefill_tokens
```

阈值判断。

使用 global token 数进行判断，可以保证整个 CP Group 中所有 Rank 对 FlashComm1 的启停决策一致。

#### `local_num_tokens`

当前 Rank 经过 CP 切分之后实际持有的 token 数。

FlashComm1 后续的：

```text
padding
sequence shard
reduce scatter
```

等操作均基于该值计算。

#### `min_local_num_tokens`

整个 CP Group 中最小的 CP-local token 数。

由于 DeepSeek V4 CP 会按照 sequence 对 token 做连续切分，不同 CP Rank 获得的 token 数可能不完全一致。

当 batch 较短时，高 `cp_rank` 甚至可能获得很少或者 0 个 token。

因此需要通过最小 local token 数决定是否允许开启 FlashComm1。

当：

```text
cp_size == 1
```

时：

```text
global_num_tokens
=
local_num_tokens
=
min_local_num_tokens
```

行为与原 FlashComm1 路径保持一致。

### 3. 增加 CP 场景下 FlashComm1 Eligibility 判断

CP 场景下，只有最小 CP shard 仍满足 FlashComm1 alignment 要求时才允许开启：

```text
min_local_num_tokens
    >= tp_world_size * kFc1LocalTokenAlignment
```

避免某些 CP Rank token 数过少，导致：

```text
padding 占比过高
```

甚至：

```text
reduce_scatter 输入全部为 padding
```

的问题。

对于没有传入 CP-local geometry 的旧接口，仍然保持：

```text
cp_size > 1
→ FlashComm1 disabled
```

避免旧调用路径出现重复 sequence sharding。

### 4. 调整 DeepSeek V4 中 CP 与 FlashComm1 的执行顺序

原先 FlashComm1 Context 在 CP 之前构建。

本 PR 调整为：

```text
Global hidden states
        |
        v
    CP partition
        |
        v
CP-local hidden states
        |
        v
Build FlashComm1 Context
        |
        v
FlashComm1 sequence shard
        |
        v
    Decoder Layers
```

即：

```text
CP → FlashComm1
```

恢复过程按照相反顺序执行：

```text
FlashComm1 gather
        |
        v
CP gather_restore
```

这样 FlashComm1 的：

```text
original_num_tokens
padded_num_tokens
pad_size
padded_local_num_tokens
```

均基于当前 Rank 实际持有的 CP-local token 数进行计算。

```

## Summary

本 PR 实现 DeepSeek V4 下：

```text
FlashComm1
    +
PCP
    +
Schedule Overlap
```

组合场景的支持。

主要解决：

1. FlashComm1 与 CP 同时进行 token 切分时的组合问题；
2. CP 场景下 global/local token geometry 不一致的问题；
3. 不均匀 CP shard 下 FlashComm1 collective 的安全启停问题；
4. `cp_size > 1` 时 Schedule Overlap 获取错误 worker 结果导致的 hang 问题。
