### PR TITLE
refactor: extract shared Stream record-or-sync helper.

### DIFF
--- a/xllm/core/platform/stream.cpp
+++ b/xllm/core/platform/stream.cpp
@@ -139,6 +139,14 @@ StreamEventPtr Stream::record_event() const {
 #endif
 }
 
+StreamEventPtr Stream::record_event_or_sync() const {
+  StreamEventPtr event = record_event();
+  if (event == nullptr) {
+    synchronize();
+  }
+  return event;
+}
+
 bool Stream::wait_event(const StreamEventPtr& event) const {
   if (event == nullptr) {
     return true;

--- a/xllm/core/platform/stream.h
+++ b/xllm/core/platform/stream.h
@@ -75,6 +75,7 @@ class Stream {
   const PlatformStream* get_stream() const { return &stream_; }
   void wait_stream(const Stream& other_stream);
   StreamEventPtr record_event() const;
+  StreamEventPtr record_event_or_sync() const;
   bool wait_event(const StreamEventPtr& event) const;
 
   // Support for LOG(INFO) output

--- a/xllm/core/runtime/llm_worker_impl.cpp
+++ b/xllm/core/runtime/llm_worker_impl.cpp
@@ -56,11 +56,7 @@ void wait_input_ready_events(const ForwardInput& input, const Stream& stream) {
 
 StreamEventPtr record_current_stream_event(const Device& device) {
   std::unique_ptr<Stream> stream = device.current_stream();
-  StreamEventPtr event = stream->record_event();
-  if (event == nullptr) {
-    stream->synchronize();
-  }
-  return event;
+  return stream->record_event_or_sync();
 }
 
 }  // namespace

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -947,11 +947,8 @@ void WorkerImpl::prepare_work_before_execute_on_stream(
   prepare_device_on_stream();
 
   if (record_ready_event) {
-    StreamEventPtr event = prepare_stream.record_event();
-    if (event == nullptr) {
-      prepare_stream.synchronize();
-    }
-    processed_input.metadata_ready_event = event;
+    processed_input.metadata_ready_event =
+        prepare_stream.record_event_or_sync();
   } else {
     processed_input.metadata_ready_event.reset();
   }


### PR DESCRIPTION
## Description

The pattern "record a stream event, and fall back to a blocking `synchronize()`
when recording returns `nullptr`" was duplicated inline in two call sites
(`record_current_stream_event` in `llm_worker_impl.cpp` and
`prepare_work_before_execute_on_stream` in `worker_impl.cpp`). This PR pushes
that fallback down onto `Stream` as a single `record_event_or_sync()` method and
has both call sites use it. Keeping the record-or-sync policy in one place means
a future change to the fallback (e.g. logging on null) is edited once instead of
per call site. No behavior change.

I considered a free helper next to the callers instead of a method, but the
logic only combines two operations that `Stream` already owns
(`record_event()` + `synchronize()`), so it belongs on `Stream`.

AI assistance: this PR was prepared with Claude Code.

## Related Issues

<!-- none -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Test Plan / Result

Pure refactor with no behavior change; the fallback semantics
(`record_event()` then `synchronize()` on null) are preserved verbatim.

- Ascend 910B, `python setup.py build --device npu`: incremental build passed
  (exit 0), so both call sites and the new method compile and link.
- `clang-format` pre-commit hook: passed.

## Reviewer Notes

- Reading order: `stream.h` / `stream.cpp` introduce the method; the two runtime
  files are mechanical substitutions.
- Rollback path: the new method is additive; reverting the two call sites back to
  the inline form restores the prior code exactly.
- Out of scope: a third instance of this pattern exists on a separate
  speculative-worker refactor branch (via a `spec::record_metadata_ready`
  helper) and is intentionally NOT included here; it will consolidate onto this
  same method when that branch lands. A fourth site
  (`record_output_ready_event` in `mtp_worker_impl.cpp`) adds a `CHECK_EQ` on the
  synchronize result, a deliberate semantic difference, and is left as-is.
