### PR TITLE
refactor: unify qwen3.5 target model-type classifier.

### DIFF
--- a/xllm/core/framework/kv_cache/kv_cache_estimation.cpp
+++ b/xllm/core/framework/kv_cache/kv_cache_estimation.cpp
@@ -122,12 +122,6 @@ int64_t standard_full_cache_block_size_in_bytes(
   return logical_block_bytes;
 }
 
-bool is_qwen3_5_target_model_type(const std::string& model_type) {
-  return model_type == "qwen3_5" || model_type == "qwen3_5_moe" ||
-         model_type == "qwen3_5_text" || model_type == "qwen3_5_moe_text" ||
-         model_type.rfind("qwen3_5_", 0) == 0;
-}
-
 bool enable_qwen3_5_spec_verify(const ModelArgs& model_args,
                                 const KVCacheEstimateOptions& options) {
   return options.num_speculative_tokens > 0 && !options.is_draft_engine &&

--- a/xllm/core/framework/model/model_args.h
+++ b/xllm/core/framework/model/model_args.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include <optional>
 #include <ostream>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -615,6 +616,14 @@ inline bool has_linear_attention_layers(const ModelArgs& args) {
                        });
   }
   return args.full_attention_interval() > 1;
+}
+
+// Closed set by design: a new target variant must be enumerated here rather
+// than matched by a "qwen3_5_" prefix, so draft bodies ("qwen3_5_mtp") are not
+// silently promoted onto the target spec-verify path.
+inline bool is_qwen3_5_target_model_type(std::string_view model_type) {
+  return model_type == "qwen3_5" || model_type == "qwen3_5_moe" ||
+         model_type == "qwen3_5_text" || model_type == "qwen3_5_moe_text";
 }
 
 inline std::ostream& operator<<(std::ostream& os, const ModelArgs& args) {

--- a/xllm/core/runtime/mtp_async_state.cpp
+++ b/xllm/core/runtime/mtp_async_state.cpp
@@ -19,6 +19,8 @@ limitations under the License.
 
 #include <vector>
 
+#include "core/framework/model/model_args.h"
+
 namespace xllm::mtp_async {
 namespace {
 
@@ -42,8 +44,7 @@ torch::Tensor gather_sequence_rows(const torch::Tensor& values,
 
 TargetSpecVerifyMode classify_target_spec_verify_mode(
     std::string_view model_type) {
-  if (model_type == "qwen3_5" || model_type == "qwen3_5_moe" ||
-      model_type == "qwen3_5_text" || model_type == "qwen3_5_moe_text") {
+  if (is_qwen3_5_target_model_type(model_type)) {
     return TargetSpecVerifyMode::QWEN3_5_EXPANDED_VERIFY;
   }
   if (model_type == "mimo") {


### PR DESCRIPTION
## Description

The qwen3.5 target model-type check was duplicated: a local
`is_qwen3_5_target_model_type` in `kv_cache_estimation.cpp` and an inline
four-way string comparison in `mtp_async_state.cpp`. This PR hoists it into a
single `is_qwen3_5_target_model_type()` in `model_args.h` and points both call
sites at it.

It also narrows the set to the four exact target types
(`qwen3_5`, `qwen3_5_moe`, `qwen3_5_text`, `qwen3_5_moe_text`). The old
`kv_cache_estimation.cpp` copy additionally matched any `qwen3_5_` prefix, which
would incorrectly promote draft bodies (e.g. `qwen3_5_mtp`) and unvetted variants
onto the target spec-verify path. Making the set closed is intentional: a new
target variant must be enumerated explicitly.

AI assistance: this PR was prepared with Claude Code.

## Related Issues

<!-- none -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Test Plan / Result

- Ascend 910B, `python setup.py build --device npu`: incremental build passed.
- Behavior note: the only functional change is the removal of the `qwen3_5_`
  prefix match in the kv-cache-estimation path; the four exact target types that
  the prefix also covered still resolve identically. Draft/MTP bodies were never
  intended to hit this path.

## Reviewer Notes

- The narrowing (dropping the prefix match) is the one behavioral change; the
  rest is a pure de-duplication.
- Out of scope: `mtp_async_state.cpp`'s separate `qwen3_5_mtp` / `qwen3_5_moe_mtp`
  draft-path check is a different classifier and is intentionally left untouched.
