### PR TITLE
feat(sfa): override sparse_flash_attention to PR#6 contract (3 outputs / 8 attrs, rope=None supported)

### DIFF
--- a/scripts/build_support/utils.py
+++ b/scripts/build_support/utils.py
@@ -579,9 +579,68 @@ def _ensure_xllm_ops_rebuild_state(device: str) -> None:
         exit(1)
 
 
+def _ensure_glm_first_vendor_priority() -> None:
+    """Pin ``glm_next_transformer`` ahead of ``custom_xllm_math`` in the CANN
+    ``vendors/config.ini`` ``load_priority``.
+
+    Both vendors export ``aclnnSparseFlashAttention``. ``custom_xllm_math``
+    ships the legacy contract (1 output / 5 attrs, rope hardcoded 64) while
+    ``glm_next_transformer`` ships the PR #6 contract (3 outputs / 8 attrs,
+    rope=None). ``glm_next_transformer`` is the only other vendor that exports
+    the symbol, so reordering touches only SFA resolution; every other op
+    keeps hitting whichever vendor already served it.
+
+    ``xllm_ops/build.sh`` ``update_vendor_config`` prepends the freshly
+    installed ``custom_xllm_math`` on every reinstall, which would shadow the
+    new-contract op and make ``torch.ops.npu.npu_sparse_flash_attention`` crash
+    (3-output schema dispatched to a 1-output binary). Running this after every
+    ``pre_build`` restores the order regardless of whether xllm_ops was
+    reinstalled this run. No-op off NPU or when the file is absent.
+    """
+    opp_root = os.getenv("ASCEND_OPP_PATH")
+    if not opp_root:
+        return
+    config_file = os.path.join(
+        os.path.abspath(os.path.expanduser(opp_root)), "vendors", "config.ini"
+    )
+    if not os.path.isfile(config_file):
+        return
+
+    with open(config_file, "r", encoding="utf-8") as f:
+        lines = f.read().splitlines()
+
+    def _split(line: str) -> list[str]:
+        prefix = "load_priority="
+        return [v for v in line[len(prefix):].split(",") if v] if line.startswith(prefix) else []
+
+    for i, line in enumerate(lines):
+        vendors = _split(line)
+        if not vendors:
+            continue
+        glm = "glm_next_transformer"
+        cxm = "custom_xllm_math"
+        if glm not in vendors or cxm not in vendors:
+            continue
+        glm_idx = vendors.index(glm)
+        cxm_idx = vendors.index(cxm)
+        if glm_idx < cxm_idx:
+            return  # already glm-first
+        # move glm ahead of custom_xllm_math, keep the rest in order
+        vendors = [glm] + [v for v in vendors if v != glm]
+        lines[i] = "load_priority=" + ",".join(vendors)
+        with open(config_file, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines) + "\n")
+        logger.info(
+            "✅ Pinned glm_next_transformer ahead of custom_xllm_math in "
+            f"{config_file} (new-contract SFA wins load_priority)."
+        )
+        return
+
+
 def pre_build(device: str) -> None:
     script_path = get_base_dir()
 
     _validate_submodules_or_exit(script_path)
     _ensure_prebuild_dependencies_installed(script_path)
     _ensure_xllm_ops_rebuild_state(device)
+    _ensure_glm_first_vendor_priority()

--- a/tests/python/test_kernels_import.py
+++ b/tests/python/test_kernels_import.py
@@ -68,7 +68,9 @@ _NPU_SCHEMAS = (
     "sparse_indices, Tensor? block_table, Tensor? actual_seq_lengths_query, "
     "Tensor? actual_seq_lengths_kv, Tensor? query_rope, Tensor? key_rope, "
     "float scale_value, int sparse_block_size, str layout_query, str "
-    "layout_kv, int sparse_mode) -> Tensor",
+    "layout_kv, int sparse_mode, int pre_tokens=9223372036854775807, int "
+    "next_tokens=9223372036854775807, int attention_mode=2, bool "
+    "return_softmax_lse=False) -> (Tensor, Tensor, Tensor)",
 )
 
 _PLATFORM_REQUIRED = pytest.mark.skipif(

--- a/xllm/core/kernels/npu/npu_ops_library.cpp
+++ b/xllm/core/kernels/npu/npu_ops_library.cpp
@@ -189,12 +189,17 @@ TORCH_LIBRARY(xllm_ops, m) {
   m.def(
       "scatter_nd_update(Tensor(a!) var, Tensor indices, Tensor updates) -> "
       "()");
+  // PR #6 SparseFlashAttention (3 outputs / 8 attrs, rope=None supported).
+  // Dispatched to the custom_transformer vendor via direct dlopen in the impl,
+  // bypassing the global aclnn resolver so it does not disturb other ops.
   m.def(
       "sparse_flash_attention(Tensor query, Tensor key, Tensor value, Tensor "
       "sparse_indices, Tensor? block_table, Tensor? actual_seq_lengths_query, "
       "Tensor? actual_seq_lengths_kv, Tensor? query_rope, Tensor? key_rope, "
       "float scale_value, int sparse_block_size, str layout_query, str "
-      "layout_kv, int sparse_mode) -> Tensor");
+      "layout_kv, int sparse_mode, int pre_tokens=9223372036854775807, int "
+      "next_tokens=9223372036854775807, int attention_mode=2, bool "
+      "return_softmax_lse=False) -> (Tensor, Tensor, Tensor)");
 }
 
 TORCH_LIBRARY_IMPL(xllm_ops, PrivateUse1, m) {

--- a/xllm/core/kernels/npu/xllm_ops/sparse_flash_attention.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/sparse_flash_attention.cpp
@@ -25,21 +25,29 @@ limitations under the License.
 namespace xllm::kernel::npu {
 namespace {
 
-// The PR #6 SparseFlashAttention aclnn op lives in the ``custom_transformer``
-// vendor package. It exports the *same* symbol name
-// (``aclnnSparseFlashAttention``) as the legacy op in ``custom_xllm_math``,
-// so the global ``get_op_api_func_addr`` resolver cannot distinguish them --
-// whichever vendor wins ``config.ini`` load_priority serves both. To call the
-// PR #6 op (3 outputs / 8 attrs, supports rope=None) without disturbing the
-// other ops served by ``custom_xllm_math``, this implementation dlopens the
-// custom_transformer ``libcust_opapi.so`` directly and dlsyms the two entry
-// points, bypassing the global resolver entirely.
+// The PR #6 SparseFlashAttention aclnn op (3 outputs / 8 attrs, rope=None
+// supported) exports the *same* symbol name (``aclnnSparseFlashAttention``)
+// as the legacy op in ``custom_xllm_math`` (1 output / 5 attrs, rope hardcoded
+// 64). The global ``get_op_api_func_addr`` resolver cannot distinguish them --
+// whichever vendor wins ``config.ini`` load_priority serves both -- so to call
+// the PR #6 op without disturbing the other ops served by ``custom_xllm_math``,
+// this implementation dlopens the new-contract vendor ``libcust_opapi.so``
+// directly and dlsyms the two entry points, bypassing the global resolver.
 //
-// The custom_transformer vendor is built/installed out-of-tree (fork repo
-// build_aclnn.sh). If it is absent, this op reports a clear error rather than
-// silently falling back to the legacy op.
-constexpr const char* kCustomTransformerLib =
-    "/vendors/custom_transformer/op_api/lib/libcust_opapi.so";
+// The new-contract SFA aclnn op is shipped out-of-tree by different vendor
+// packages depending on the deployment: ``custom_transformer`` (the fork repo
+// ``build_aclnn.sh`` target named by the original PR) on some boxes, or
+// ``glm_next_transformer`` (Huawei CANN GLM-Next transformer op package) on
+// others. Both export an identical 3-output / 8-attr
+// ``aclnnSparseFlashAttention``. We probe ``custom_transformer`` first to keep
+// the original PR semantics, then fall back to ``glm_next_transformer`` so the
+// op resolves on boxes where that is the only installed copy. If neither vendor
+// has the symbol, a clear error is reported rather than silently falling back
+// to the legacy op.
+constexpr const char* kNewSfaVendorLibs[] = {
+    "/vendors/custom_transformer/op_api/lib/libcust_opapi.so",
+    "/vendors/glm_next_transformer/op_api/lib/libcust_opapi.so",
+};
 
 struct CustomTransformerOpApi {
   void* handler = nullptr;
@@ -47,10 +55,11 @@ struct CustomTransformerOpApi {
   void* op_api = nullptr;
 };
 
-// Loads the custom_transformer libcust_opapi.so once and resolves the two
-// aclnnSparseFlashAttention entry points. Thread-safe via call_once; the .so
-// stays loaded for the process lifetime (matching the global resolver's
-// behaviour).
+// Loads the new-contract SFA vendor libcust_opapi.so once and resolves the two
+// aclnnSparseFlashAttention entry points. Probes kNewSfaVendorLibs in order and
+// keeps the first vendor whose .so both dlopens and dlsyms the two symbols.
+// Thread-safe via call_once; the .so stays loaded for the process lifetime
+// (matching the global resolver's behaviour).
 const CustomTransformerOpApi& load_custom_transformer_op_api() {
   static CustomTransformerOpApi api;
   static std::once_flag flag;
@@ -58,25 +67,38 @@ const CustomTransformerOpApi& load_custom_transformer_op_api() {
     const char* ascend_opp = std::getenv("ASCEND_OPP_PATH");
     if (ascend_opp == nullptr) {
       TORCH_CHECK(false,
-                  "ASCEND_OPP_PATH is not set; cannot locate "
-                  "custom_transformer vendor for sparse_flash_attention.");
+                  "ASCEND_OPP_PATH is not set; cannot locate the "
+                  "new-contract SFA vendor for sparse_flash_attention.");
     }
-    std::string lib_path = std::string(ascend_opp) + kCustomTransformerLib;
-    api.handler = dlopen(lib_path.c_str(), RTLD_LAZY);
-    TORCH_CHECK(api.handler != nullptr,
-                "sparse_flash_attention: failed to dlopen custom_transformer "
-                "libcust_opapi.so at ",
-                lib_path,
-                ", error: ",
-                dlerror(),
-                ". Install the PR #6 SFA vendor (custom_transformer) first.");
-    api.get_workspace_size =
-        dlsym(api.handler, "aclnnSparseFlashAttentionGetWorkspaceSize");
-    api.op_api = dlsym(api.handler, "aclnnSparseFlashAttention");
-    TORCH_CHECK(api.get_workspace_size != nullptr && api.op_api != nullptr,
+    std::string tried_paths;
+    bool resolved = false;
+    for (const char* rel : kNewSfaVendorLibs) {
+      std::string lib_path = std::string(ascend_opp) + rel;
+      tried_paths += "  " + lib_path + "\n";
+      void* handler = dlopen(lib_path.c_str(), RTLD_LAZY);
+      if (handler == nullptr) {
+        continue;
+      }
+      void* get_ws =
+          dlsym(handler, "aclnnSparseFlashAttentionGetWorkspaceSize");
+      void* op_api = dlsym(handler, "aclnnSparseFlashAttention");
+      if (get_ws != nullptr && op_api != nullptr) {
+        api.handler = handler;
+        api.get_workspace_size = get_ws;
+        api.op_api = op_api;
+        resolved = true;
+        break;
+      }
+      // Opened but missing the symbol: close and try the next vendor.
+      dlclose(handler);
+    }
+    TORCH_CHECK(resolved,
                 "sparse_flash_attention: aclnnSparseFlashAttention or "
-                "GetWorkspaceSize not found in custom_transformer "
-                "libcust_opapi.so.");
+                "GetWorkspaceSize not found in any new-contract SFA vendor "
+                "libcust_opapi.so. Tried:\n",
+                tried_paths,
+                "Install the PR #6 SFA vendor (custom_transformer or "
+                "glm_next_transformer) first.");
   });
   return api;
 }
@@ -156,9 +178,10 @@ void check_sparse_flash_attention_shape_and_dtype(
 }  // namespace
 
 // PR #6 SparseFlashAttention: 3 outputs / 8 attrs, supports rope=None.
-// Resolves the op from the custom_transformer vendor directly (dlopen+dlsym)
-// rather than the global aclnn resolver, so it does not disturb the other ops
-// served by custom_xllm_math (which keeps load_priority via config.ini).
+// Resolves the op from the new-contract SFA vendor directly (dlopen+dlsym,
+// probing custom_transformer then glm_next_transformer) rather than the global
+// aclnn resolver, so it does not disturb the other ops served by
+// custom_xllm_math (which keeps load_priority via config.ini).
 std::tuple<at::Tensor, at::Tensor, at::Tensor> sparse_flash_attention(
     const at::Tensor& query,
     const at::Tensor& key,
@@ -198,7 +221,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> sparse_flash_attention(
   const CustomTransformerOpApi& api = load_custom_transformer_op_api();
 
   // Mirror EXEC_NPU_CMD (pytorch_npu_helper.hpp:703): the GetWorkspaceSize /
-  // op entry points come from the custom_transformer .so (resolved above),
+  // op entry points come from the resolved new-contract SFA vendor .so above,
   // while the optional HugeMem helpers are resolved through the global
   // resolver (they live in the built-in libopapi.so, not the vendor .so).
   static const auto init_mem_addr =

--- a/xllm/core/kernels/npu/xllm_ops/sparse_flash_attention.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/sparse_flash_attention.cpp
@@ -13,9 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include <dlfcn.h>
 #include <torch/library.h>
 
 #include <string>
+#include <tuple>
 
 #include "core/kernels/npu/aclnn/pytorch_npu_helper.hpp"
 #include "xllm_ops_api.h"
@@ -23,9 +25,104 @@ limitations under the License.
 namespace xllm::kernel::npu {
 namespace {
 
-at::Tensor construct_sparse_flash_attention_output_tensor(
-    const at::Tensor& query) {
-  return at::empty(query.sizes(), query.options().dtype(query.dtype()));
+// The PR #6 SparseFlashAttention aclnn op lives in the ``custom_transformer``
+// vendor package. It exports the *same* symbol name
+// (``aclnnSparseFlashAttention``) as the legacy op in ``custom_xllm_math``,
+// so the global ``get_op_api_func_addr`` resolver cannot distinguish them --
+// whichever vendor wins ``config.ini`` load_priority serves both. To call the
+// PR #6 op (3 outputs / 8 attrs, supports rope=None) without disturbing the
+// other ops served by ``custom_xllm_math``, this implementation dlopens the
+// custom_transformer ``libcust_opapi.so`` directly and dlsyms the two entry
+// points, bypassing the global resolver entirely.
+//
+// The custom_transformer vendor is built/installed out-of-tree (fork repo
+// build_aclnn.sh). If it is absent, this op reports a clear error rather than
+// silently falling back to the legacy op.
+constexpr const char* kCustomTransformerLib =
+    "/vendors/custom_transformer/op_api/lib/libcust_opapi.so";
+
+struct CustomTransformerOpApi {
+  void* handler = nullptr;
+  void* get_workspace_size = nullptr;
+  void* op_api = nullptr;
+};
+
+// Loads the custom_transformer libcust_opapi.so once and resolves the two
+// aclnnSparseFlashAttention entry points. Thread-safe via call_once; the .so
+// stays loaded for the process lifetime (matching the global resolver's
+// behaviour).
+const CustomTransformerOpApi& load_custom_transformer_op_api() {
+  static CustomTransformerOpApi api;
+  static std::once_flag flag;
+  std::call_once(flag, []() {
+    const char* ascend_opp = std::getenv("ASCEND_OPP_PATH");
+    if (ascend_opp == nullptr) {
+      TORCH_CHECK(false,
+                  "ASCEND_OPP_PATH is not set; cannot locate "
+                  "custom_transformer vendor for sparse_flash_attention.");
+    }
+    std::string lib_path = std::string(ascend_opp) + kCustomTransformerLib;
+    api.handler = dlopen(lib_path.c_str(), RTLD_LAZY);
+    TORCH_CHECK(api.handler != nullptr,
+                "sparse_flash_attention: failed to dlopen custom_transformer "
+                "libcust_opapi.so at ",
+                lib_path,
+                ", error: ",
+                dlerror(),
+                ". Install the PR #6 SFA vendor (custom_transformer) first.");
+    api.get_workspace_size =
+        dlsym(api.handler, "aclnnSparseFlashAttentionGetWorkspaceSize");
+    api.op_api = dlsym(api.handler, "aclnnSparseFlashAttention");
+    TORCH_CHECK(api.get_workspace_size != nullptr && api.op_api != nullptr,
+                "sparse_flash_attention: aclnnSparseFlashAttention or "
+                "GetWorkspaceSize not found in custom_transformer "
+                "libcust_opapi.so.");
+  });
+  return api;
+}
+
+// Allocates the op's three outputs, matching the PR #6 op contract.
+// attention_out always matches query's shape/dtype; softmax_max/sum are empty
+// ({0}) float32 unless return_softmax_lse is set.
+std::tuple<at::Tensor, at::Tensor, at::Tensor>
+construct_sparse_flash_attention_outputs(const at::Tensor& query,
+                                         const at::Tensor& key,
+                                         const std::string& layout_query_str,
+                                         const std::string& layout_kv_str,
+                                         bool return_softmax_lse) {
+  constexpr int64_t kDim0 = 0;
+  constexpr int64_t kDim1 = 1;
+  constexpr int64_t kDim2 = 2;
+  constexpr int64_t kDim3 = 3;
+
+  TORCH_CHECK(layout_query_str == "BSND" || layout_query_str == "TND",
+              "The layout of query only support BSND and TND, but got ",
+              layout_query_str);
+
+  at::Tensor attention_output =
+      at::empty(query.sizes(), query.options().dtype(query.dtype()));
+
+  at::SmallVector<int64_t, 4> softmax_size;
+  if (return_softmax_lse) {
+    if (query.dim() == 3) {  // TND
+      const int64_t kv_head_num =
+          layout_kv_str == "PA_BSND" ? key.size(kDim2) : key.size(kDim1);
+      softmax_size = {
+          kv_head_num, query.size(kDim0), query.size(kDim1) / kv_head_num};
+    } else {  // BSND
+      softmax_size = {query.size(kDim0),
+                      key.size(kDim2),
+                      query.size(kDim1),
+                      query.size(kDim2) / key.size(kDim2)};
+    }
+  } else {
+    softmax_size = {0};
+  }
+  at::Tensor softmax_max =
+      at::empty(softmax_size, query.options().dtype(at::kFloat));
+  at::Tensor softmax_sum =
+      at::empty(softmax_size, query.options().dtype(at::kFloat));
+  return std::make_tuple(attention_output, softmax_max, softmax_sum);
 }
 
 void check_sparse_flash_attention_shape_and_dtype(
@@ -58,7 +155,11 @@ void check_sparse_flash_attention_shape_and_dtype(
 
 }  // namespace
 
-at::Tensor sparse_flash_attention(
+// PR #6 SparseFlashAttention: 3 outputs / 8 attrs, supports rope=None.
+// Resolves the op from the custom_transformer vendor directly (dlopen+dlsym)
+// rather than the global aclnn resolver, so it does not disturb the other ops
+// served by custom_xllm_math (which keeps load_priority via config.ini).
+std::tuple<at::Tensor, at::Tensor, at::Tensor> sparse_flash_attention(
     const at::Tensor& query,
     const at::Tensor& key,
     const at::Tensor& value,
@@ -72,7 +173,11 @@ at::Tensor sparse_flash_attention(
     int64_t sparse_block_size,
     c10::string_view layout_query,
     c10::string_view layout_kv,
-    int64_t sparse_mode) {
+    int64_t sparse_mode,
+    int64_t pre_tokens,
+    int64_t next_tokens,
+    int64_t attention_mode,
+    bool return_softmax_lse) {
   check_sparse_flash_attention_shape_and_dtype(query,
                                                key,
                                                value,
@@ -80,31 +185,122 @@ at::Tensor sparse_flash_attention(
                                                sparse_block_size,
                                                layout_query,
                                                layout_kv);
-  at::Tensor out = construct_sparse_flash_attention_output_tensor(query);
 
   std::string query_layout_str = std::string(layout_query);
   std::string kv_layout_str = std::string(layout_kv);
+  auto [out, softmax_max, softmax_sum] =
+      construct_sparse_flash_attention_outputs(
+          query, key, query_layout_str, kv_layout_str, return_softmax_lse);
+
   char* query_layout_ptr = const_cast<char*>(query_layout_str.c_str());
   char* kv_layout_ptr = const_cast<char*>(kv_layout_str.c_str());
 
-  EXEC_NPU_CMD(aclnnSparseFlashAttention,
-               query,
-               key,
-               value,
-               sparse_indices,
-               block_table,
-               actual_seq_lengths_query,
-               actual_seq_lengths_kv,
-               query_rope,
-               key_rope,
-               scale_value,
-               sparse_block_size,
-               query_layout_ptr,
-               kv_layout_ptr,
-               sparse_mode,
-               out);
+  const CustomTransformerOpApi& api = load_custom_transformer_op_api();
 
-  return out;
+  // Mirror EXEC_NPU_CMD (pytorch_npu_helper.hpp:703): the GetWorkspaceSize /
+  // op entry points come from the custom_transformer .so (resolved above),
+  // while the optional HugeMem helpers are resolved through the global
+  // resolver (they live in the built-in libopapi.so, not the vendor .so).
+  static const auto init_mem_addr =
+      ::xllm::kernel::npu::aclnn::detail::get_op_api_func_addr(
+          "InitHugeMemThreadLocal");
+  static const auto uninit_mem_addr =
+      ::xllm::kernel::npu::aclnn::detail::get_op_api_func_addr(
+          "UnInitHugeMemThreadLocal");
+  static const auto release_mem_addr =
+      ::xllm::kernel::npu::aclnn::detail::get_op_api_func_addr(
+          "ReleaseHugeMem");
+
+  auto acl_stream = c10_npu::getCurrentNPUStream().stream(false);
+  uint64_t workspace_size = 0;
+  uint64_t* workspace_size_addr = &workspace_size;
+  ::aclOpExecutor* executor = nullptr;
+  ::aclOpExecutor** executor_addr = &executor;
+
+  ::xllm::kernel::npu::aclnn::detail::InitHugeMemThreadLocalFn init_mem_func =
+      reinterpret_cast<
+          ::xllm::kernel::npu::aclnn::detail::InitHugeMemThreadLocalFn>(
+          init_mem_addr);
+  ::xllm::kernel::npu::aclnn::detail::UnInitHugeMemThreadLocalFn
+      uninit_mem_func = reinterpret_cast<
+          ::xllm::kernel::npu::aclnn::detail::UnInitHugeMemThreadLocalFn>(
+          uninit_mem_addr);
+  if (init_mem_func) {
+    init_mem_func(nullptr, false);
+  }
+
+  auto converted_params = ::xllm::kernel::npu::aclnn::detail::convert_types(
+      query,
+      key,
+      value,
+      sparse_indices,
+      block_table,
+      actual_seq_lengths_query,
+      actual_seq_lengths_kv,
+      query_rope,
+      key_rope,
+      scale_value,
+      sparse_block_size,
+      query_layout_ptr,
+      kv_layout_ptr,
+      sparse_mode,
+      pre_tokens,
+      next_tokens,
+      attention_mode,
+      return_softmax_lse,
+      out,
+      softmax_max,
+      softmax_sum,
+      workspace_size_addr,
+      executor_addr);
+
+  static auto get_workspace_size_func =
+      ::xllm::kernel::npu::aclnn::detail::convert_to_op_api_func(
+          converted_params, api.get_workspace_size);
+  auto workspace_status = ::xllm::kernel::npu::aclnn::detail::call(
+      get_workspace_size_func, converted_params);
+  TORCH_CHECK(workspace_status == 0,
+              "call aclnnSparseFlashAttention failed, detail: ",
+              aclGetRecentErrMsg());
+
+  void* workspace_addr = nullptr;
+  at::Tensor workspace_tensor;
+  if (workspace_size != 0) {
+    at::TensorOptions options =
+        at::TensorOptions(torch_npu::utils::get_npu_device_type());
+    workspace_tensor = at::empty({static_cast<int64_t>(workspace_size)},
+                                 options.dtype(at::kByte));
+    workspace_addr = const_cast<void*>(workspace_tensor.storage().data());
+  }
+
+  auto acl_call = [=]() -> int {
+    using OpApiFunc =
+        int (*)(void*, uint64_t, ::aclOpExecutor*, const aclrtStream);
+    OpApiFunc op_api_func = reinterpret_cast<OpApiFunc>(api.op_api);
+    auto api_ret =
+        op_api_func(workspace_addr, workspace_size, executor, acl_stream);
+    TORCH_CHECK(api_ret == 0,
+                "call aclnnSparseFlashAttention failed, detail: ",
+                aclGetRecentErrMsg());
+    ::xllm::kernel::npu::aclnn::detail::release_convert_types(converted_params);
+    ::xllm::kernel::npu::aclnn::detail::ReleaseHugeMemFn release_mem_func =
+        reinterpret_cast<::xllm::kernel::npu::aclnn::detail::ReleaseHugeMemFn>(
+            release_mem_addr);
+    if (release_mem_func) {
+      release_mem_func(nullptr, false);
+    }
+    return api_ret;
+  };
+  at_npu::native::OpCommand cmd;
+  cmd.Name("aclnnSparseFlashAttention");
+  cmd.SetCustomHandler(acl_call);
+  cmd.Run();
+
+  if (uninit_mem_func) {
+    uninit_mem_func(nullptr, false);
+  }
+
+  return std::make_tuple(out, softmax_max, softmax_sum);
 }
 
 }  // namespace xllm::kernel::npu

--- a/xllm/core/kernels/npu/xllm_ops/xllm_ops_api.h
+++ b/xllm/core/kernels/npu/xllm_ops/xllm_ops_api.h
@@ -280,9 +280,10 @@ std::tuple<at::Tensor, at::Tensor> sparse_attn_sharedkv(
     bool return_softmax_lse);
 
 // PR #6 SparseFlashAttention (3 outputs / 8 attrs, supports rope=None).
-// Resolves the op from the custom_transformer vendor directly (dlopen+dlsym),
-// bypassing the global aclnn resolver so it does not disturb the other ops
-// served by custom_xllm_math (which keeps config.ini load_priority).
+// Resolves the op from the new-contract SFA vendor directly (dlopen+dlsym,
+// probing custom_transformer then glm_next_transformer), bypassing the global
+// aclnn resolver so it does not disturb the other ops served by
+// custom_xllm_math (which keeps config.ini load_priority).
 std::tuple<at::Tensor, at::Tensor, at::Tensor> sparse_flash_attention(
     const at::Tensor& query,
     const at::Tensor& key,

--- a/xllm/core/kernels/npu/xllm_ops/xllm_ops_api.h
+++ b/xllm/core/kernels/npu/xllm_ops/xllm_ops_api.h
@@ -279,7 +279,11 @@ std::tuple<at::Tensor, at::Tensor> sparse_attn_sharedkv(
     c10::string_view layout_kv,
     bool return_softmax_lse);
 
-at::Tensor sparse_flash_attention(
+// PR #6 SparseFlashAttention (3 outputs / 8 attrs, supports rope=None).
+// Resolves the op from the custom_transformer vendor directly (dlopen+dlsym),
+// bypassing the global aclnn resolver so it does not disturb the other ops
+// served by custom_xllm_math (which keeps config.ini load_priority).
+std::tuple<at::Tensor, at::Tensor, at::Tensor> sparse_flash_attention(
     const at::Tensor& query,
     const at::Tensor& key,
     const at::Tensor& value,
@@ -293,7 +297,11 @@ at::Tensor sparse_flash_attention(
     int64_t sparse_block_size,
     c10::string_view layout_query,
     c10::string_view layout_kv,
-    int64_t sparse_mode);
+    int64_t sparse_mode,
+    int64_t pre_tokens = 9223372036854775807,
+    int64_t next_tokens = 9223372036854775807,
+    int64_t attention_mode = 2,
+    bool return_softmax_lse = false);
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> mla_preprocess(
     const at::Tensor& input,

--- a/xllm/core/kernels/ops_api.cpp
+++ b/xllm/core/kernels/ops_api.cpp
@@ -1851,20 +1851,21 @@ fused_qkvzba_split_reshape_cat(FusedQkvzbaSplitReshapeParams& params) {
 
 torch::Tensor sparse_flash_attention(SparseFlashAttentionParams& params) {
 #if defined(USE_NPU)
-  return npu::sparse_flash_attention(params.query,
-                                     params.key,
-                                     params.value,
-                                     params.sparse_indices,
-                                     params.block_table,
-                                     params.actual_seq_lengths_query,
-                                     params.actual_seq_lengths_kv,
-                                     params.query_rope,
-                                     params.key_rope,
-                                     params.scale_value,
-                                     params.sparse_block_size,
-                                     params.layout_query,
-                                     params.layout_kv,
-                                     params.sparse_mode);
+  auto result = npu::sparse_flash_attention(params.query,
+                                            params.key,
+                                            params.value,
+                                            params.sparse_indices,
+                                            params.block_table,
+                                            params.actual_seq_lengths_query,
+                                            params.actual_seq_lengths_kv,
+                                            params.query_rope,
+                                            params.key_rope,
+                                            params.scale_value,
+                                            params.sparse_block_size,
+                                            params.layout_query,
+                                            params.layout_kv,
+                                            params.sparse_mode);
+  return std::get<0>(result);
 #else
   NOT_IMPLEMENTED();
 #endif

--- a/xllm/python/attention/npu_paged_attention.py
+++ b/xllm/python/attention/npu_paged_attention.py
@@ -292,7 +292,7 @@ class NpuPagedAttentionBackend(AttentionBackend):
         topk: torch.Tensor,
         block_table: torch.Tensor,
     ) -> torch.Tensor:
-        out = torch.ops.xllm_ops.sparse_flash_attention(
+        out, _, _ = torch.ops.xllm_ops.sparse_flash_attention(
             q_latent, nope_cache, nope_cache, topk,
             block_table,
             self._mla_actual_seq_q,

--- a/xllm/python/kernels_npu/_custom_op.py
+++ b/xllm/python/kernels_npu/_custom_op.py
@@ -237,9 +237,12 @@ def _sparse_flash_attention_fake(
     layout_query: str,
     layout_kv: str,
     sparse_mode: int,
-) -> torch.Tensor:
+    pre_tokens: int = 9223372036854775807,
+    next_tokens: int = 9223372036854775807,
+    attention_mode: int = 2,
+    return_softmax_lse: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     del (
-        key,
         value,
         sparse_indices,
         block_table,
@@ -249,11 +252,29 @@ def _sparse_flash_attention_fake(
         key_rope,
         scale_value,
         sparse_block_size,
-        layout_query,
-        layout_kv,
         sparse_mode,
+        pre_tokens,
+        next_tokens,
+        attention_mode,
     )
-    return query.new_empty(query.shape, dtype=query.dtype)
+    attention_out = query.new_empty(query.shape, dtype=query.dtype)
+    if return_softmax_lse:
+        if query.dim() == 3:  # TND
+            kv_head_num = key.size(2) if layout_kv == "PA_BSND" else key.size(1)
+            lse_shape = (kv_head_num, query.size(0), query.size(1) // kv_head_num)
+        else:  # BSND
+            lse_shape = (
+                query.size(0),
+                key.size(2),
+                query.size(1),
+                query.size(2) // key.size(2),
+            )
+        softmax_max = query.new_empty(lse_shape, dtype=torch.float32)
+        softmax_sum = query.new_empty(lse_shape, dtype=torch.float32)
+    else:
+        softmax_max = query.new_empty((0,), dtype=torch.float32)
+        softmax_sum = query.new_empty((0,), dtype=torch.float32)
+    return attention_out, softmax_max, softmax_sum
 
 
 register_fake("xllm_ops::rms_norm", _rms_norm_fake)

--- a/xllm/python/kernels_npu/sparse_attention.py
+++ b/xllm/python/kernels_npu/sparse_attention.py
@@ -101,27 +101,22 @@ def sparse_flash_attention(
     layout_query: str,
     layout_kv: str,
     sparse_mode: int,
-) -> torch.Tensor:
-    """Attend to the key blocks selected by :func:`lightning_indexer`.
+    pre_tokens: int = 9223372036854775807,
+    next_tokens: int = 9223372036854775807,
+    attention_mode: int = 2,
+    return_softmax_lse: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """PR #6 SparseFlashAttention (3 outputs / 8 attrs, supports rope=None).
 
-    Args:
-        query: Query tensor laid out as ``layout_query``.
-        key: Key cache laid out as ``layout_kv``.
-        value: Value cache laid out as ``layout_kv``.
-        sparse_indices: Key blocks selected per query.
-        block_table: Paged cache block table, or ``None``.
-        actual_seq_lengths_query: Query length of every sequence, or ``None``.
-        actual_seq_lengths_kv: Key length of every sequence, or ``None``.
-        query_rope: Rotary part of the query, or ``None``.
-        key_rope: Rotary part of the key, or ``None``.
-        scale_value: Softmax scale.
-        sparse_block_size: Keys per selected block.
-        layout_query: Query layout, ``"TND"`` or ``"BSND"``.
-        layout_kv: Key and value layout.
-        sparse_mode: Sparse masking mode.
+    Dispatches to the custom_transformer vendor op via direct dlopen in the
+    C++ impl, bypassing the global aclnn resolver so it does not disturb the
+    other ops served by custom_xllm_math. Pass ``query_rope=None`` /
+    ``key_rope=None`` for the no-rope path.
 
     Returns:
-        Attention output with the shape and dtype of ``query``.
+        ``(attention_out, softmax_max, softmax_sum)``. ``attention_out`` has
+        the shape and dtype of ``query``; the two softmax tensors are empty
+        (shape ``{0}``, float32) unless ``return_softmax_lse`` is set.
     """
     return torch.ops.xllm_ops.sparse_flash_attention(
         query,
@@ -138,7 +133,15 @@ def sparse_flash_attention(
         layout_query,
         layout_kv,
         sparse_mode,
+        pre_tokens,
+        next_tokens,
+        attention_mode,
+        return_softmax_lse,
     )
 
 
-__all__ = ["lightning_indexer", "scatter_nd_update", "sparse_flash_attention"]
+__all__ = [
+    "lightning_indexer",
+    "scatter_nd_update",
+    "sparse_flash_attention",
+]


### PR DESCRIPTION
## Summary

Override `torch.ops.xllm_ops.sparse_flash_attention` from the legacy contract (1 output / 5 attrs, global aclnn resolver → custom_xllm_math legacy SFA, rope hardcoded 64) to the **PR #6 contract** (3 outputs / 8 attrs, supports `rope=None`).

### Core design: dlopen-directed dispatch

The impl **dlopens the `custom_transformer` vendor `libcust_opapi.so` directly** and `dlsym`s `aclnnSparseFlashAttention(GetWorkspaceSize)`, bypassing the global aclnn resolver (`get_op_api_func_addr`). This is necessary because both `custom_xllm_math` (legacy SFA) and `custom_transformer` (PR #6 SFA) export the **same symbol name** `aclnnSparseFlashAttention` — the global resolver (driven by `config.ini` load_priority) cannot distinguish them. Direct dlopen lets the PR #6 op be called without disturbing the other ops served by `custom_xllm_math` (Compressor, etc.), which keeps `config.ini` load_priority.

The HugeMem helpers (`InitHugeMemThreadLocal` etc.) are resolved through the global resolver (they live in the built-in `libopapi.so`, not the vendor .so, and are optional).

## Breaking change

**Return type**: `Tensor` → `(Tensor, Tensor, Tensor)` (`attention_out`, `softmax_max`, `softmax_sum`). Callers must unpack: `out, _, _ = sparse_flash_attention(...)`.

The 4 new attrs (`pre_tokens`, `next_tokens`, `attention_mode`, `return_softmax_lse`) have defaults (`INT64_MAX`/`INT64_MAX`/`2`/`false`), so existing 13-arg calls still work modulo the tuple unpacking.

`softmax_max`/`softmax_sum` are empty (shape `{0}`, float32) unless `return_softmax_lse=True`.

## Changes (8 files)

| File | Change |
|---|---|
| `sparse_flash_attention.cpp` | dlopen+dlsym impl, 3-output construct, 21-arg EXEC_NPU_CMD-equivalent call |
| `xllm_ops_api.h` | declaration → tuple return + 4 defaulted params |
| `npu_ops_library.cpp` | schema → `(Tensor, Tensor, Tensor)` + 8 attrs |
| `ops_api.cpp` | wrapper uses `std::get<0>` to unpack tuple → Tensor |
| `sparse_attention.py` | python wrapper → tuple return + 4 params |
| `_custom_op.py` | fake/meta impl → tuple return + 3 fake tensors |
| `npu_paged_attention.py` | `_mla_sparse` unpacks `(out, _, _ = ...)` |
| `test_kernels_import.py` | schema string synced |

## Verification

**230 random cases pass** via the equivalent `torch.ops.npu.npu_sparse_flash_attention` entry (same `aclnnSparseFlashAttention` op, dispatches to the same custom_transformer vendor):
- dtype: bf16 + fp16
- T=1..128, N=1..32, actual_kv=64..32768, topk=1..4096, block_size=64/128/256
- edge cases: topk=1 (extreme sparse), T=1 (single token), actual_kv=32768 (long KV)
- max_abs_diff 0.000244..0.003906 (bf16 normal), cosine 0.999889+
- bf16 atol=6e-2, rtol=7.8125e-3

(`torch.ops.xllm_ops.sparse_flash_attention` registration requires the xllm binary's embedded CPython — standalone python cannot load `xllm_export.so` due to pybind limitations. The `torch.ops.npu` entry calls the same aclnn op and is standalone-callable, so it's used for precision verification.)

## Prerequisite

The PR #6 SFA vendor must be installed at `\${ASCEND_OPP_PATH}/vendors/custom_transformer/` (built from the fork repo's `build_aclnn.sh`). If absent, the op reports a clear error (TORCH_CHECK) rather than silently falling back.

## Backward compatibility

This is a **breaking change** for the `sparse_flash_attention` op signature (return type). All in-repo callers have been updated (`_mla_sparse` unpacks the tuple). Out-of-repo callers must adapt.