### PR TITLE
perf: optimize deepseek v4 mlu decode paths.

### DIFF
--- a/tests/core/layers/mlu/deepseek_v4_attention_test.cpp
+++ b/tests/core/layers/mlu/deepseek_v4_attention_test.cpp
@@ -223,7 +223,7 @@ class DeepseekV4AttentionTest : public ::testing::Test {
   test::Dsv4AttentionRefConfig make_config(int64_t compress_ratio) const {
     test::Dsv4AttentionRefConfig config;
     config.hidden_dim = 32;
-    config.q_lora_rank = 16;
+    config.q_lora_rank = 1024;
     config.n_heads = 4;
     config.head_dim = 512;
     config.rope_head_dim = 64;

--- a/tests/core/layers/mlu/deepseek_v4_decoder_layer_test.cpp
+++ b/tests/core/layers/mlu/deepseek_v4_decoder_layer_test.cpp
@@ -409,7 +409,7 @@ class DeepseekV4DecoderLayerTest : public ::testing::Test {
     std::optional<torch::Tensor> input_ids = std::nullopt;
     if (pass_input_ids) {
       input_ids = torch::arange(
-          seq_len, torch::TensorOptions().dtype(torch::kInt32).device(device_));
+          seq_len, torch::TensorOptions().dtype(torch::kInt64).device(device_));
     }
 
     torch::Tensor output = layer->forward(hidden,

--- a/tests/core/layers/mlu/deepseek_v4_hyper_connection_test.cpp
+++ b/tests/core/layers/mlu/deepseek_v4_hyper_connection_test.cpp
@@ -201,7 +201,7 @@ class DeepseekV4HyperConnectionTest : public ::testing::Test {
         {"hc_fn",
          seeded("deepseek_v4_hc.pre.fn",
                 {mix_hc, hc_dim},
-                torch::kFloat32,
+                torch::kBFloat16,
                 options_.device())},
         {"hc_base",
          seeded("deepseek_v4_hc.pre.base",
@@ -260,8 +260,8 @@ TEST_F(DeepseekV4HyperConnectionTest, HCPreMatchesOfficialReference) {
   EXPECT_EQ(actual.comb.sizes(), expected.comb.sizes());
   test::verify_tensor_close(
       actual.output.cpu(), expected.output.cpu(), 1e-2, 1e-2);
-  test::verify_tensor_close(actual.post.cpu(), expected.post.cpu(), 1e-4, 1e-4);
-  test::verify_tensor_close(actual.comb.cpu(), expected.comb.cpu(), 1e-4, 1e-4);
+  test::verify_tensor_close(actual.post.cpu(), expected.post.cpu(), 1e-3, 1e-3);
+  test::verify_tensor_close(actual.comb.cpu(), expected.comb.cpu(), 1e-3, 1e-3);
 }
 
 TEST_F(DeepseekV4HyperConnectionTest, HCPostMatchesOfficialReference) {
@@ -305,6 +305,72 @@ TEST_F(DeepseekV4HyperConnectionTest, HCPostMatchesOfficialReference) {
   test::verify_tensor_close(actual.cpu(), expected.cpu(), 1e-2, 1e-2);
   test::verify_tensor_close(
       actual_rsqrt.cpu(), expected_rsqrt.cpu(), 1e-4, 1e-4);
+}
+
+TEST_F(DeepseekV4HyperConnectionTest, FusedPostPreNormMatchesComposition) {
+  const int64_t tokens = 2;
+  torch::Tensor x = seeded("deepseek_v4_hc.fused.x",
+                           {tokens, config_.dim},
+                           torch::kBFloat16,
+                           options_.device());
+  torch::Tensor residual = seeded("deepseek_v4_hc.fused.residual",
+                                  {tokens, config_.hc_mult, config_.dim},
+                                  torch::kBFloat16,
+                                  options_.device());
+  torch::Tensor post = seeded("deepseek_v4_hc.fused.post",
+                              {tokens, config_.hc_mult},
+                              torch::kFloat32,
+                              options_.device()) +
+                       0.5;
+  torch::Tensor comb =
+      torch::softmax(seeded("deepseek_v4_hc.fused.comb",
+                            {tokens, config_.hc_mult, config_.hc_mult},
+                            torch::kFloat32,
+                            options_.device()),
+                     -1);
+  torch::Tensor gamma = seeded("deepseek_v4_hc.fused.gamma",
+                               {config_.dim},
+                               torch::kBFloat16,
+                               options_.device()) +
+                        1.0;
+  std::unordered_map<std::string, torch::Tensor> weights = pre_weights();
+  DeepseekV4HCPre hc_pre(config_.hc_mult,
+                         config_.dim,
+                         config_.sinkhorn_iters,
+                         config_.hc_eps,
+                         config_.norm_eps,
+                         options_);
+  hc_pre->load_state_dict(StateDict(weights));
+  DeepseekV4HCPost hc_post(config_.norm_eps);
+
+  torch::Tensor expected_residual;
+  torch::Tensor rsqrt;
+  std::tie(expected_residual, rsqrt) =
+      hc_post->forward(x, residual, post, comb, /*compute_rms=*/true);
+  DeepseekV4HCPreOutput expected_pre =
+      hc_pre->forward(expected_residual, rsqrt);
+  torch::Tensor expected_norm =
+      expected_pre.output.to(torch::kFloat32) *
+      torch::rsqrt(
+          expected_pre.output.to(torch::kFloat32).square().mean(-1, true) +
+          config_.norm_eps) *
+      gamma.to(torch::kFloat32);
+
+  torch::Tensor actual_norm;
+  torch::Tensor actual_residual;
+  torch::Tensor actual_post;
+  torch::Tensor actual_comb;
+  std::tie(actual_norm, actual_residual, actual_post, actual_comb) =
+      hc_pre->fused_post_pre_norm(x, residual, post, comb, gamma);
+
+  test::verify_tensor_close(
+      actual_norm.cpu(), expected_norm.to(torch::kBFloat16).cpu(), 2e-2, 2e-2);
+  test::verify_tensor_close(
+      actual_residual.cpu(), expected_residual.cpu(), 2e-2, 2e-2);
+  test::verify_tensor_close(
+      actual_post.cpu(), expected_pre.post.cpu(), 2e-3, 2e-3);
+  test::verify_tensor_close(
+      actual_comb.cpu(), expected_pre.comb.cpu(), 2e-3, 2e-3);
 }
 
 TEST_F(DeepseekV4HyperConnectionTest, HCHeadMatchesOfficialReference) {

--- a/tests/core/runtime/mlu_linear_state_restore_worker_test.cpp
+++ b/tests/core/runtime/mlu_linear_state_restore_worker_test.cpp
@@ -34,7 +34,8 @@ limitations under the License.
 namespace xllm {
 namespace {
 
-constexpr int64_t kNumSlots = 6;
+constexpr int64_t kNumSlots = 7;
+constexpr int32_t kRestoreSourceSlot = 4;
 
 class LinearStateRestoreWorker final : public WorkerImpl {
  public:
@@ -206,12 +207,12 @@ TEST(MluLinearStateRestoreWorkerTest,
   LinearCacheTensors second =
       make_linear_cache(device, kSecondStride, /*sentinel=*/-202.0f);
   fill_slot(first,
-            /*slot=*/0,
+            kRestoreSourceSlot,
             kFirstStride,
             /*conv_value=*/3.0f,
             /*ssm_value=*/5.0f);
   fill_slot(second,
-            /*slot=*/0,
+            kRestoreSourceSlot,
             kSecondStride,
             /*conv_value=*/7.0f,
             /*ssm_value=*/11.0f);
@@ -245,12 +246,15 @@ TEST(MluLinearStateRestoreWorkerTest,
   LinearStateCacheOp restore;
   restore.linear_state_id = 1;
   restore.restore_requested = true;
-  restore.restore_src_slot_id = 0;
+  restore.restore_src_slot_id = kRestoreSourceSlot;
   LinearStateCacheOp continued;
   continued.linear_state_id = 2;
   LinearStateCacheOp cold;
   cold.linear_state_id = 3;
-  LinearStateCacheOp padding;
+  cold.reset_requested = true;
+  LinearStateCacheOp second_cold;
+  second_cold.linear_state_id = 5;
+  second_cold.reset_requested = true;
 
   ForwardInput input;
   input.token_ids = torch::ones(
@@ -262,7 +266,7 @@ TEST(MluLinearStateRestoreWorkerTest,
   input.input_params.attention.host.q_seq_lens = {0, 1, 2, 3, 4};
   input.input_params.attention.host.kv_cache_tokens_nums = {0, 8, 0, 0};
   input.input_params.linear_state_cache_ops = {
-      restore, continued, cold, padding};
+      restore, continued, cold, second_cold};
 
   ForwardInput processed_input;
   worker.prepare_work_before_execute(input, processed_input);
@@ -276,16 +280,18 @@ TEST(MluLinearStateRestoreWorkerTest,
             std::vector<int64_t>({1, 1, 0, 0}));
   expect_slot_matches(first,
                       /*destination=*/1,
-                      /*source=*/0,
+                      kRestoreSourceSlot,
                       kFirstStride);
   expect_slot_matches(second,
                       /*destination=*/1,
-                      /*source=*/0,
+                      kRestoreSourceSlot,
                       kSecondStride);
   expect_slot_filled(first, /*slot=*/2, kFirstStride, /*value=*/13.0f);
   expect_slot_filled(second, /*slot=*/2, kSecondStride, /*value=*/17.0f);
-  expect_slot_filled(first, /*slot=*/3, kFirstStride, /*value=*/19.0f);
-  expect_slot_filled(second, /*slot=*/3, kSecondStride, /*value=*/23.0f);
+  expect_slot_filled(first, /*slot=*/3, kFirstStride, /*value=*/0.0f);
+  expect_slot_filled(second, /*slot=*/3, kSecondStride, /*value=*/0.0f);
+  expect_slot_filled(first, /*slot=*/5, kFirstStride, /*value=*/0.0f);
+  expect_slot_filled(second, /*slot=*/5, kSecondStride, /*value=*/0.0f);
 }
 
 TEST(MluLinearStateRestoreWorkerTest,
@@ -300,6 +306,13 @@ TEST(MluLinearStateRestoreWorkerTest,
   LinearStateRestoreWorker worker(
       parallel_args, device, runtime_options, model_args);
 
+  constexpr int64_t kSsmStride = 2;
+  LinearCacheTensors cache =
+      make_linear_cache(device, kSsmStride, /*sentinel=*/-101.0f);
+  std::vector<KVCache> kv_caches;
+  kv_caches.emplace_back(LinearAttentionKVCacheTensors{cache.conv, cache.ssm});
+  worker.set_kv_caches(std::move(kv_caches));
+
   ForwardInput input;
   input.token_ids = torch::ones(
       {6}, torch::TensorOptions().dtype(torch::kInt32).device(device));
@@ -309,6 +322,12 @@ TEST(MluLinearStateRestoreWorkerTest,
   input.input_params.attention.host.q_seq_lens = {0, 1, 2, 3, 4, 5, 6};
   input.input_params.attention.host.kv_cache_tokens_nums = {0, 8};
   input.input_params.linear_state_cache_ops.resize(/*count=*/6);
+  for (int32_t row = 0; row < 6; ++row) {
+    LinearStateCacheOp& cache_op =
+        input.input_params.linear_state_cache_ops[static_cast<size_t>(row)];
+    cache_op.linear_state_id = row + 1;
+    cache_op.reset_requested = row < 3;
+  }
 
   ForwardInput processed_input;
   worker.prepare_work_before_execute(input, processed_input);
@@ -377,21 +396,24 @@ TEST(MluLinearStateRestoreWorkerTest,
   LinearStateCacheOp restore;
   restore.linear_state_id = 1;
   restore.restore_requested = true;
-  restore.restore_src_slot_id = 0;
+  restore.restore_src_slot_id = kRestoreSourceSlot;
   LinearStateCacheOp continued;
   continued.linear_state_id = 2;
   LinearStateCacheOp cold;
   cold.linear_state_id = 3;
-  LinearStateCacheOp padding;
+  cold.reset_requested = true;
+  LinearStateCacheOp second_cold;
+  second_cold.linear_state_id = 5;
+  second_cold.reset_requested = true;
 
   ForwardInput input;
   input.input_params.meta.batch_id = 43;
   input.input_params.linear_state_cache_ops = {
-      restore, continued, cold, padding};
+      restore, continued, cold, second_cold};
   input.input_params.linear_state_validity_mask = {0, 1, 0, 0};
 
-  worker.enqueue_previous_chunk_write(
-      /*source_slot=*/0, {{3.0f, 5.0f}, {7.0f, 11.0f}});
+  worker.enqueue_previous_chunk_write(kRestoreSourceSlot,
+                                      {{3.0f, 5.0f}, {7.0f, 11.0f}});
   worker.run_overlap_forward(input, /*destination_slot=*/1);
   worker.synchronize_compute_stream();
 
@@ -411,8 +433,10 @@ TEST(MluLinearStateRestoreWorkerTest,
                                            /*start=*/2 * kSecondStride,
                                            /*length=*/kSecondStride) == 23.0f)
                   .item<bool>());
-  expect_slot_filled(first, /*slot=*/3, kFirstStride, /*value=*/-101.0f);
-  expect_slot_filled(second, /*slot=*/3, kSecondStride, /*value=*/-202.0f);
+  expect_slot_filled(first, /*slot=*/3, kFirstStride, /*value=*/0.0f);
+  expect_slot_filled(second, /*slot=*/3, kSecondStride, /*value=*/0.0f);
+  expect_slot_filled(first, /*slot=*/5, kFirstStride, /*value=*/0.0f);
+  expect_slot_filled(second, /*slot=*/5, kSecondStride, /*value=*/0.0f);
 }
 
 }  // namespace

--- a/xllm/core/kernels/mlu/fused_mla_qkv.cpp
+++ b/xllm/core/kernels/mlu/fused_mla_qkv.cpp
@@ -16,6 +16,32 @@ limitations under the License.
 #include "mlu_ops_api.h"
 
 namespace xllm::kernel::mlu {
+void fused_mla_q_v2(const torch::Tensor& input,
+                    torch::Tensor& output,
+                    const std::optional<torch::Tensor>& output_norm,
+                    const torch::Tensor& gamma,
+                    const std::optional<torch::Tensor>& smooth_quant_scale,
+                    const torch::Tensor& weight_b,
+                    const std::optional<torch::Tensor>& weight_b_scale,
+                    const torch::Tensor& sin,
+                    const torch::Tensor& cos,
+                    const torch::Tensor& position_id,
+                    double eps,
+                    bool interleaved) {
+  tmo::torch_api::fused_mla_q_v2(input,
+                                 output,
+                                 output_norm,
+                                 gamma,
+                                 smooth_quant_scale,
+                                 weight_b,
+                                 weight_b_scale,
+                                 sin,
+                                 cos,
+                                 position_id,
+                                 eps,
+                                 interleaved);
+}
+
 void fused_mla_q(const torch::Tensor& input,
                  torch::Tensor& output,
                  torch::Tensor& output_scale,

--- a/xllm/core/kernels/mlu/hyper_connection.cpp
+++ b/xllm/core/kernels/mlu/hyper_connection.cpp
@@ -57,4 +57,36 @@ std::tuple<torch::Tensor, torch::Tensor> fused_mhc_post(
   return {output, output_rms};
 }
 
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+fused_mhc(const torch::Tensor& x,
+          const torch::Tensor& residual_in,
+          const torch::Tensor& hc_fn,
+          const torch::Tensor& gamma,
+          const torch::Tensor& post_in,
+          const torch::Tensor& comb_in,
+          const torch::Tensor& hc_scale,
+          const torch::Tensor& hc_base,
+          int64_t sinkhorn_iter,
+          double eps) {
+  torch::Tensor norm_out = torch::empty_like(x);
+  torch::Tensor residual_out = torch::empty_like(residual_in);
+  torch::Tensor post_out = torch::empty_like(post_in);
+  torch::Tensor comb_out = torch::empty_like(comb_in);
+  tmo::torch_api::fused_mhc(x,
+                            residual_in,
+                            hc_fn,
+                            gamma,
+                            post_in,
+                            comb_in,
+                            hc_scale,
+                            hc_base,
+                            norm_out,
+                            residual_out,
+                            post_out,
+                            comb_out,
+                            sinkhorn_iter,
+                            eps);
+  return {norm_out, residual_out, post_out, comb_out};
+}
+
 }  // namespace xllm::kernel::mlu

--- a/xllm/core/kernels/mlu/matmul.cpp
+++ b/xllm/core/kernels/mlu/matmul.cpp
@@ -42,4 +42,26 @@ torch::Tensor matmul(const torch::Tensor& a,
                                 true);
 }
 
+torch::Tensor batch_matmul(const torch::Tensor& a,
+                           const torch::Tensor& b,
+                           bool trans_a,
+                           bool trans_b) {
+  return tmo::torch_api::batch_matmul(a,
+                                      b,
+                                      /*c=*/std::nullopt,
+                                      /*bias=*/std::nullopt,
+                                      /*dtype=*/std::nullopt,
+                                      /*a_scale_tensor=*/std::nullopt,
+                                      /*b_scale_tensor=*/std::nullopt,
+                                      /*act_mode=*/"none",
+                                      /*alpha=*/1.0,
+                                      /*beta=*/0.0,
+                                      /*a_scale=*/1.0,
+                                      /*b_scale=*/1.0,
+                                      /*trans_a=*/trans_a,
+                                      /*trans_b=*/trans_b,
+                                      /*use_hp_active=*/false,
+                                      /*approximate=*/false);
+}
+
 }  // namespace xllm::kernel::mlu

--- a/xllm/core/kernels/mlu/mlu_ops_api.h
+++ b/xllm/core/kernels/mlu/mlu_ops_api.h
@@ -362,6 +362,18 @@ std::tuple<torch::Tensor, torch::Tensor> fused_mhc_post(
     bool compute_rms,
     double eps);
 
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+fused_mhc(const torch::Tensor& x,
+          const torch::Tensor& residual_in,
+          const torch::Tensor& hc_fn,
+          const torch::Tensor& gamma,
+          const torch::Tensor& post_in,
+          const torch::Tensor& comb_in,
+          const torch::Tensor& hc_scale,
+          const torch::Tensor& hc_base,
+          int64_t sinkhorn_iter,
+          double eps);
+
 void fused_mla_q(const torch::Tensor& input,
                  torch::Tensor& output,
                  torch::Tensor& output_scale,
@@ -377,6 +389,24 @@ void fused_mla_q(const torch::Tensor& input,
                  const std::string& quant_mode,
                  double eps,
                  bool interleaved);
+
+void fused_mla_q_v2(const torch::Tensor& input,
+                    torch::Tensor& output,
+                    const std::optional<torch::Tensor>& output_norm,
+                    const torch::Tensor& gamma,
+                    const std::optional<torch::Tensor>& smooth_quant_scale,
+                    const torch::Tensor& weight_b,
+                    const std::optional<torch::Tensor>& weight_b_scale,
+                    const torch::Tensor& sin,
+                    const torch::Tensor& cos,
+                    const torch::Tensor& position_id,
+                    double eps,
+                    bool interleaved);
+
+torch::Tensor batch_matmul(const torch::Tensor& a,
+                           const torch::Tensor& b,
+                           bool trans_a,
+                           bool trans_b);
 
 void fused_mla_kv(const torch::Tensor& input_kv,
                   const torch::Tensor& sin,

--- a/xllm/core/layers/mlu/deepseek_v4/deepseek_v4_attention.cpp
+++ b/xllm/core/layers/mlu/deepseek_v4/deepseek_v4_attention.cpp
@@ -293,9 +293,48 @@ void DeepseekV4AttentionImpl::apply_last_rope(
   xllm::kernel::apply_rotary(params);
 }
 
-torch::Tensor DeepseekV4AttentionImpl::project_q(torch::Tensor& q_down,
-                                                 torch::Tensor& qr) {
+torch::Tensor DeepseekV4AttentionImpl::project_q(
+    torch::Tensor& q_down,
+    torch::Tensor& qr,
+    bool use_fused_decode,
+    const torch::Tensor& sin_table,
+    const torch::Tensor& cos_table,
+    const torch::Tensor& input_positions) {
   // q_down is the segment-0 slice of the fused hidden->* projection.
+  if (use_fused_decode) {
+    torch::Tensor input = q_down.unsqueeze(1).contiguous();
+    torch::Tensor output = torch::empty(
+        {q_down.size(0), 1, n_local_heads_, head_dim_}, q_down.options());
+    torch::Tensor output_norm = torch::empty_like(input);
+    torch::Tensor weight =
+        wq_b_->weight().view({n_local_heads_, head_dim_, q_lora_rank_});
+    std::optional<torch::Tensor> weight_scale = std::nullopt;
+    std::optional<torch::Tensor> smooth = wq_b_->smooth();
+    if (weight.scalar_type() != input.scalar_type()) {
+      torch::Tensor scale = wq_b_->per_channel_scale();
+      CHECK(has_tensor(scale))
+          << "fused_mla_q_v2 requires scales for quantized wq_b";
+      weight_scale = scale.view({n_local_heads_, head_dim_});
+      if (!smooth.has_value()) {
+        smooth = torch::ones({q_lora_rank_}, scale.options());
+      }
+    }
+    xllm::kernel::mlu::fused_mla_q_v2(input,
+                                      output,
+                                      output_norm,
+                                      q_norm_->weight(),
+                                      smooth,
+                                      weight,
+                                      weight_scale,
+                                      sin_table,
+                                      cos_table,
+                                      input_positions,
+                                      eps_,
+                                      /*interleaved=*/true);
+    qr = output_norm.view_as(q_down);
+    return output.view({q_down.size(0), n_local_heads_, head_dim_});
+  }
+
   qr = std::get<0>(q_norm_->forward(q_down));
   torch::Tensor q = wq_b_->forward(qr).view({-1, n_local_heads_, head_dim_});
   torch::Tensor output = torch::empty_like(q);
@@ -331,8 +370,13 @@ torch::Tensor DeepseekV4AttentionImpl::project_output(
       attn_output.reshape({num_tokens, n_local_groups_, -1});
   torch::Tensor wo_a =
       wo_a_->weight().view({n_local_groups_, o_lora_rank_, -1});
+  torch::Tensor grouped_output =
+      xllm::kernel::mlu::batch_matmul(grouped.transpose(0, 1).contiguous(),
+                                      wo_a,
+                                      /*trans_a=*/false,
+                                      /*trans_b=*/true);
   torch::Tensor low_rank =
-      torch::einsum("tgd,grd->tgr", {grouped, wo_a}).reshape({num_tokens, -1});
+      grouped_output.transpose(0, 1).contiguous().reshape({num_tokens, -1});
   return wo_b_->forward(low_rank);
 }
 
@@ -364,10 +408,6 @@ DeepseekV4AttentionImpl::forward(const AttentionMetadata& attn_metadata,
   std::vector<torch::Tensor> parts =
       hidden_proj.split(/*split_size=*/hidden_proj_sizes_, /*dim=*/-1);
 
-  torch::Tensor qr;
-  torch::Tensor q = project_q(parts[0], qr);
-  torch::Tensor kv = project_kv(parts[1]);
-
   const bool uses_compressed_rope =
       compress_ratio_ == 4 || compress_ratio_ == 128;
   const torch::Tensor& active_sin_table =
@@ -377,11 +417,22 @@ DeepseekV4AttentionImpl::forward(const AttentionMetadata& attn_metadata,
   const torch::Tensor& active_inverse_sin_table =
       uses_compressed_rope ? dsa.compressed_inverse_sin_table
                            : dsa.inverse_sin_table;
-  apply_last_rope(q,
-                  active_sin_table,
-                  active_cos_table,
-                  dsa.input_positions,
-                  rope_head_dim_);
+  torch::Tensor qr;
+  const bool use_fused_decode = !is_prefill && !is_chunked_prefill;
+  torch::Tensor q = project_q(parts[0],
+                              qr,
+                              use_fused_decode,
+                              active_sin_table,
+                              active_cos_table,
+                              dsa.input_positions);
+  torch::Tensor kv = project_kv(parts[1]);
+  if (!use_fused_decode) {
+    apply_last_rope(q,
+                    active_sin_table,
+                    active_cos_table,
+                    dsa.input_positions,
+                    rope_head_dim_);
+  }
   apply_last_rope(kv,
                   active_sin_table,
                   active_cos_table,

--- a/xllm/core/layers/mlu/deepseek_v4/deepseek_v4_attention.h
+++ b/xllm/core/layers/mlu/deepseek_v4/deepseek_v4_attention.h
@@ -59,7 +59,12 @@ class DeepseekV4AttentionImpl final : public torch::nn::Module {
   // q_down / kv_down are the precomputed fused-projection slices for the q_a
   // and kv projections (segments 0 and 1 of hidden_proj); the attention layer
   // merges the hidden->* GEMMs into a single fused_wqa_wkv_ call and splits.
-  torch::Tensor project_q(torch::Tensor& q_down, torch::Tensor& qr);
+  torch::Tensor project_q(torch::Tensor& q_down,
+                          torch::Tensor& qr,
+                          bool use_fused_decode,
+                          const torch::Tensor& sin_table,
+                          const torch::Tensor& cos_table,
+                          const torch::Tensor& input_positions);
 
   torch::Tensor project_kv(torch::Tensor& kv_down);
 

--- a/xllm/core/layers/mlu/deepseek_v4/deepseek_v4_decoder_layer.cpp
+++ b/xllm/core/layers/mlu/deepseek_v4/deepseek_v4_decoder_layer.cpp
@@ -147,8 +147,11 @@ std::optional<torch::Tensor> DeepseekV4DecoderLayerImpl::route_input_ids(
 
   CHECK(input_ids.has_value() && input_ids.value().defined())
       << "DeepseekV4 hash routing requires input_ids.";
-  torch::Tensor flat_ids =
-      input_ids.value().reshape({-1}).to(ffn_input.device()).contiguous();
+  torch::Tensor flat_ids = input_ids.value()
+                               .reshape({-1})
+                               .to(ffn_input.device())
+                               .to(torch::kInt32)
+                               .contiguous();
   const int64_t id_count = flat_ids.size(0);
   const int64_t token_count =
       ffn_input.reshape({-1, ffn_input.size(-1)}).size(0);
@@ -171,29 +174,65 @@ torch::Tensor DeepseekV4DecoderLayerImpl::forward(
     const AttentionMetadata& attn_metadata,
     KVCache& kv_cache,
     const ModelInputParams& input_params,
-    const std::optional<torch::Tensor>& input_ids) {
+    const std::optional<torch::Tensor>& input_ids,
+    std::optional<DeepseekV4PendingMHC>* pending_mhc,
+    bool is_last_layer) {
   (void)positions;
 
   residual = std::nullopt;
+  const bool use_fused_mhc =
+      pending_mhc != nullptr && !attn_metadata.is_prefill &&
+      !attn_metadata.is_chunked_prefill && attn_hc_pre_->supports_fused_mhc() &&
+      ffn_hc_pre_->supports_fused_mhc();
 
-  torch::Tensor residual_attn = x;
-  DeepseekV4HCPreOutput attn_hc = attn_hc_pre_->forward(x);
-  torch::Tensor attn_input = attn_hc.output;
-  attn_input = std::get<0>(attn_norm_->forward(attn_input));
+  torch::Tensor residual_attn;
+  DeepseekV4HCPreOutput attn_hc;
+  torch::Tensor attn_input;
+  if (use_fused_mhc && pending_mhc->has_value()) {
+    DeepseekV4PendingMHC& pending = pending_mhc->value();
+    std::tie(attn_input, residual_attn, attn_hc.post, attn_hc.comb) =
+        attn_hc_pre_->fused_post_pre_norm(pending.x,
+                                          pending.residual,
+                                          pending.post,
+                                          pending.comb,
+                                          attn_norm_->weight());
+    pending_mhc->reset();
+  } else {
+    residual_attn = x;
+    attn_hc = attn_hc_pre_->forward(x);
+    attn_input = std::get<0>(attn_norm_->forward(attn_hc.output));
+  }
   torch::Tensor attn_output;
   std::tie(attn_output, std::ignore) =
       attention_->forward(attn_metadata, attn_input, kv_cache);
-  std::tie(x, std::ignore) =
-      hc_post_->forward(attn_output, residual_attn, attn_hc.post, attn_hc.comb);
 
-  torch::Tensor residual_ffn = x;
-  DeepseekV4HCPreOutput ffn_hc = ffn_hc_pre_->forward(x);
-  torch::Tensor ffn_input = ffn_hc.output;
-  ffn_input = std::get<0>(ffn_norm_->forward(ffn_input));
+  torch::Tensor residual_ffn;
+  DeepseekV4HCPreOutput ffn_hc;
+  torch::Tensor ffn_input;
+  if (use_fused_mhc) {
+    std::tie(ffn_input, residual_ffn, ffn_hc.post, ffn_hc.comb) =
+        ffn_hc_pre_->fused_post_pre_norm(attn_output,
+                                         residual_attn,
+                                         attn_hc.post,
+                                         attn_hc.comb,
+                                         ffn_norm_->weight());
+  } else {
+    std::tie(x, std::ignore) = hc_post_->forward(
+        attn_output, residual_attn, attn_hc.post, attn_hc.comb);
+    residual_ffn = x;
+    ffn_hc = ffn_hc_pre_->forward(x);
+    ffn_input = std::get<0>(ffn_norm_->forward(ffn_hc.output));
+  }
   std::optional<torch::Tensor> ids = route_input_ids(ffn_input, input_ids);
   FusedMoEImpl::RouteInfo route_info = sparse_moe_->prep_route(ffn_input, ids);
   torch::Tensor ffn_output = sparse_moe_->forward_selected(
       ffn_input, route_info.reduce_weight, route_info.expert_id, input_params);
+  if (use_fused_mhc && !is_last_layer) {
+    pending_mhc->emplace(DeepseekV4PendingMHC{
+        ffn_output, residual_ffn, ffn_hc.post, ffn_hc.comb});
+    x = ffn_output;
+    return x;
+  }
   std::tie(x, std::ignore) =
       hc_post_->forward(ffn_output, residual_ffn, ffn_hc.post, ffn_hc.comb);
   return x;

--- a/xllm/core/layers/mlu/deepseek_v4/deepseek_v4_decoder_layer.h
+++ b/xllm/core/layers/mlu/deepseek_v4/deepseek_v4_decoder_layer.h
@@ -33,6 +33,13 @@ limitations under the License.
 namespace xllm {
 namespace layer {
 
+struct DeepseekV4PendingMHC {
+  torch::Tensor x;
+  torch::Tensor residual;
+  torch::Tensor post;
+  torch::Tensor comb;
+};
+
 class DeepseekV4DecoderLayerImpl final : public torch::nn::Module {
  public:
   DeepseekV4DecoderLayerImpl(const ModelContext& context, int32_t layer_id);
@@ -49,7 +56,9 @@ class DeepseekV4DecoderLayerImpl final : public torch::nn::Module {
       const AttentionMetadata& attn_metadata,
       KVCache& kv_cache,
       const ModelInputParams& input_params,
-      const std::optional<torch::Tensor>& input_ids = std::nullopt);
+      const std::optional<torch::Tensor>& input_ids = std::nullopt,
+      std::optional<DeepseekV4PendingMHC>* pending_mhc = nullptr,
+      bool is_last_layer = true);
 
  private:
   std::optional<torch::Tensor> route_input_ids(

--- a/xllm/core/layers/mlu/deepseek_v4/deepseek_v4_indexer.cpp
+++ b/xllm/core/layers/mlu/deepseek_v4/deepseek_v4_indexer.cpp
@@ -146,6 +146,30 @@ torch::Tensor DeepseekV4IndexerImpl::preprocess_q(
     const torch::Tensor& compressed_sin_table,
     const torch::Tensor& compressed_cos_table) {
   const DSAMetadata& dsa = *attn_metadata.dsa_metadata;
+  if (!attn_metadata.is_prefill && !attn_metadata.is_chunked_prefill) {
+    torch::Tensor output =
+        torch::empty({qr.size(0), n_heads_, head_dim_}, qr.options());
+    torch::Tensor weight =
+        wq_b_->weight().view({n_heads_, head_dim_, q_lora_rank_});
+    CHECK_EQ(weight.scalar_type(), qr.scalar_type())
+        << "DeepSeek V4 indexer wq_b must remain unquantized";
+    xllm::kernel::FusedIndexerQParams params;
+    params.input_q = qr;
+    params.output = output;
+    params.output_scale = std::nullopt;
+    params.w_q = weight;
+    params.w_q_scale = std::nullopt;
+    params.hadamard_matrix = hadamard_matrix_;
+    params.sin = compressed_sin_table;
+    params.cos = compressed_cos_table;
+    params.position_id = dsa.input_positions;
+    params.quant_mode = "none";
+    params.interleaved = true;
+    params.rope_at_front = false;
+    xllm::kernel::fused_indexer_q(params);
+    return output;
+  }
+
   torch::Tensor q = wq_b_->forward(qr).view({qr.size(0), n_heads_, head_dim_});
   apply_last_dim_rope(q,
                       compressed_sin_table,

--- a/xllm/core/layers/mlu/deepseek_v4/hyper_connection.cpp
+++ b/xllm/core/layers/mlu/deepseek_v4/hyper_connection.cpp
@@ -63,11 +63,11 @@ DeepseekV4HCPreImpl::DeepseekV4HCPreImpl(int64_t hc_mult,
       norm_eps_(norm_eps) {
   const int64_t mix_hc = (2 + hc_mult_) * hc_mult_;
   const int64_t hc_dim = hc_mult_ * dim_;
-  torch::TensorOptions param_options =
-      options.dtype(torch::kFloat32).requires_grad(false);
+  torch::TensorOptions param_options = options.requires_grad(false);
   hc_fn_ = register_parameter("hc_fn",
                               torch::empty({mix_hc, hc_dim}, param_options),
                               /*requires_grad=*/false);
+  param_options = param_options.dtype(torch::kFloat32);
   hc_base_ = register_parameter("hc_base",
                                 torch::empty({mix_hc}, param_options),
                                 /*requires_grad=*/false);
@@ -91,8 +91,7 @@ DeepseekV4HCPreOutput DeepseekV4HCPreImpl::forward(
             .contiguous();
   }
 
-  torch::Tensor mixes =
-      torch::nn::functional::linear(x_flat.to(torch::kFloat32), hc_fn_);
+  torch::Tensor mixes = torch::nn::functional::linear(x_flat, hc_fn_);
   torch::Tensor pre;
   torch::Tensor post;
   torch::Tensor comb;
@@ -115,6 +114,28 @@ DeepseekV4HCPreOutput DeepseekV4HCPreImpl::forward(
   out_shape.emplace_back(hc_mult_);
   comb = comb.reshape(out_shape);
   return {output, post, comb};
+}
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+DeepseekV4HCPreImpl::fused_post_pre_norm(const torch::Tensor& x,
+                                         const torch::Tensor& residual,
+                                         const torch::Tensor& post,
+                                         const torch::Tensor& comb,
+                                         const torch::Tensor& gamma) {
+  CHECK(supports_fused_mhc())
+      << "fused_mhc only supports hc_mult=4 and hidden_size=4096";
+  const int64_t token_count = x.numel() / dim_;
+  return kernel::mlu::fused_mhc(
+      flat_hidden(x, dim_),
+      flat_hc(residual, hc_mult_, dim_),
+      hc_fn_,
+      gamma,
+      post.reshape({token_count, hc_mult_}).contiguous(),
+      flat_matrix(comb, hc_mult_, hc_mult_),
+      hc_scale_,
+      hc_base_,
+      sinkhorn_iters_,
+      hc_eps_);
 }
 
 void DeepseekV4HCPreImpl::load_state_dict(const StateDict& state_dict) {

--- a/xllm/core/layers/mlu/deepseek_v4/hyper_connection.h
+++ b/xllm/core/layers/mlu/deepseek_v4/hyper_connection.h
@@ -50,6 +50,15 @@ class DeepseekV4HCPreImpl final : public torch::nn::Module {
       const torch::Tensor& x,
       const std::optional<torch::Tensor>& rsqrt = std::nullopt);
 
+  std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+  fused_post_pre_norm(const torch::Tensor& x,
+                      const torch::Tensor& residual,
+                      const torch::Tensor& post,
+                      const torch::Tensor& comb,
+                      const torch::Tensor& gamma);
+
+  bool supports_fused_mhc() const { return hc_mult_ == 4 && dim_ == 4096; }
+
   void load_state_dict(const StateDict& state_dict);
 
  private:

--- a/xllm/models/llm/mlu/deepseek_v4.h
+++ b/xllm/models/llm/mlu/deepseek_v4.h
@@ -208,16 +208,15 @@ class DeepseekV4ModelImpl final
     std::optional<layer::DeepseekV4PendingMHC> pending_mhc;
     for (size_t layer_idx = 0; layer_idx < layers_.size(); ++layer_idx) {
       prepare_layer_metadata(attn_metadata, static_cast<int32_t>(layer_idx));
-      h = layers_[layer_idx]->forward(
-          h,
-          residual,
-          positions,
-          attn_metadata,
-          kv_caches[layer_idx],
-          modified_input_params,
-          tokens,
-          &pending_mhc,
-          layer_idx + 1 == layers_.size());
+      h = layers_[layer_idx]->forward(h,
+                                      residual,
+                                      positions,
+                                      attn_metadata,
+                                      kv_caches[layer_idx],
+                                      modified_input_params,
+                                      tokens,
+                                      &pending_mhc,
+                                      layer_idx + 1 == layers_.size());
       if (!modified_input_params.record_layer(static_cast<uint32_t>(layer_idx),
                                               h.device())) {
         return ModelOutput();

--- a/xllm/models/llm/mlu/deepseek_v4.h
+++ b/xllm/models/llm/mlu/deepseek_v4.h
@@ -205,15 +205,19 @@ class DeepseekV4ModelImpl final
     }
 
     std::optional<torch::Tensor> residual;
+    std::optional<layer::DeepseekV4PendingMHC> pending_mhc;
     for (size_t layer_idx = 0; layer_idx < layers_.size(); ++layer_idx) {
       prepare_layer_metadata(attn_metadata, static_cast<int32_t>(layer_idx));
-      h = layers_[layer_idx](h,
-                             residual,
-                             positions,
-                             attn_metadata,
-                             kv_caches[layer_idx],
-                             modified_input_params,
-                             tokens);
+      h = layers_[layer_idx]->forward(
+          h,
+          residual,
+          positions,
+          attn_metadata,
+          kv_caches[layer_idx],
+          modified_input_params,
+          tokens,
+          &pending_mhc,
+          layer_idx + 1 == layers_.size());
       if (!modified_input_params.record_layer(static_cast<uint32_t>(layer_idx),
                                               h.device())) {
         return ModelOutput();


### PR DESCRIPTION
## Description

  Optimize DeepSeek V4 decode execution on MLU by replacing several unfused operations with fused kernel
  paths.

  - Fuse the MLA Q projection, normalization, and RoPE application during decode.
  - Use the fused Indexer Q path and batched output projection.
  - Pipeline HyperConnection post-processing, pre-processing, and normalization across decoder layers
  through the fused MHC kernel.
  - Preserve existing prefill and chunked-prefill paths, and enable fused MHC only for the supported
  `hc_mult=4`, `hidden_size=4096` configuration.
  - Cast hash-routing input IDs to `int32` for the MLU routing path.
  - Update MLU tests for fused HyperConnection behavior and linear-state cache invariants.

  ## Related Issues

  N/A

  ## Change Type

  - [ ] Bug fix
  - [ ] New feature
  - [x] Performance improvement
  - [ ] Refactor
  - [ ] Documentation
  - [x] Test
  - [ ] Build or CI

  ## Pull Request Checklist

  ### PR Title and Commit Messages

  - [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

  ### Pre-commit Checks

  - [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
  - [x] I have installed the hooks with `pre-commit install`.
  - [x] I have run `pre-commit run --all-files` and fixed any reported issues.

  ### Self Review

  - [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-
  style.md`, especially code written or assisted by AI.
  - [x] I have rebased this PR onto the latest `main` branch.

  ### Build and Test Coverage

  - [x] Tests have been added or updated as needed.
  - [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
  - [x] NPU: `python setup.py build test` has passed on an NPU machine.
  - [x] MLU: `python setup.py build test` has passed on an MLU machine.

  ## Reviewer Notes

  Please focus on decode-only gating and numerical parity of the fused MLA Q, Indexer Q, and
  HyperConnection paths. The fused MHC path is intentionally limited to the supported DeepSeek V4
  configuration.
