### PR TITLE
perf: adapt Qwen W8A8 quantization for FlashComm.

### DIFF
--- a/tests/core/layers/npu_torch/linear_w8a8_dynamic_tests.cpp
+++ b/tests/core/layers/npu_torch/linear_w8a8_dynamic_tests.cpp
@@ -23,10 +23,12 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
+#include "common/flash_comm1_context.h"
 #include "framework/parallel_state/parallel_args.h"
 #include "framework/quant_args.h"
 #include "framework/state_dict/state_dict.h"
 #include "kernels/ops_api.h"
+#include "layers/common/dense_mlp.h"
 #include "layers/common/linear.h"
 #include "platform/device.h"
 #include "platform/platform.h"
@@ -261,6 +263,90 @@ TEST_F(NpuLinearW8A8DynamicTest, ColumnParallelLinearLoadAndForward) {
   Device(options_.device()).synchronize_default_stream();
 
   auto expected = make_reference_output(input, weight, weight_scale, bias);
+  ASSERT_TRUE(output.sizes() == expected.sizes());
+  expect_output_close(output, expected);
+}
+
+TEST_F(NpuLinearW8A8DynamicTest, DenseMlpGathersQuantizedActivation) {
+  const int32_t num_tokens = 4;
+  const int64_t hidden_size = 16;
+  const int64_t intermediate_size = 20;
+  const std::string prefix = "npu.mlp.quantized_gather";
+  add_quant_desc(prefix + ".gate_proj");
+  add_quant_desc(prefix + ".up_proj");
+  add_quant_desc(prefix + ".down_proj");
+
+  mock_process_group_ = std::make_unique<test::MockProcessGroup>(
+      options_.device(), /*rank=*/0, /*world_size=*/2);
+  test::MockProcessGroup* mock_group =
+      static_cast<test::MockProcessGroup*>(mock_process_group_.get());
+  auto mlp = DenseMLP(DenseMLPImpl(hidden_size,
+                                   intermediate_size,
+                                   /*is_gated=*/true,
+                                   /*has_bias=*/false,
+                                   /*hidden_act=*/"silu",
+                                   /*enable_result_reduction=*/true,
+                                   quant_args_,
+                                   mock_group,
+                                   options_,
+                                   prefix));
+
+  std::unordered_map<std::string, torch::Tensor> weight_dict = {
+      {"gate_proj.weight",
+       make_qweight("npu.mlp.quantized_gather.gate.weight",
+                    intermediate_size,
+                    hidden_size)},
+      {"gate_proj.weight_scale",
+       make_weight_scale("npu.mlp.quantized_gather.gate.scale",
+                         intermediate_size)},
+      {"gate_proj.weight_offset",
+       torch::zeros({intermediate_size}, options_.dtype(torch::kFloat32))},
+      {"up_proj.weight",
+       make_qweight("npu.mlp.quantized_gather.up.weight",
+                    intermediate_size,
+                    hidden_size)},
+      {"up_proj.weight_scale",
+       make_weight_scale("npu.mlp.quantized_gather.up.scale",
+                         intermediate_size)},
+      {"up_proj.weight_offset",
+       torch::zeros({intermediate_size}, options_.dtype(torch::kFloat32))},
+      {"down_proj.weight",
+       make_qweight("npu.mlp.quantized_gather.down.weight",
+                    hidden_size,
+                    intermediate_size)},
+      {"down_proj.weight_scale",
+       make_weight_scale("npu.mlp.quantized_gather.down.scale", hidden_size)},
+      {"down_proj.weight_offset",
+       torch::zeros({hidden_size}, options_.dtype(torch::kFloat32))},
+  };
+  mlp->load_state_dict(StateDict(std::move(weight_dict), prefix + "."));
+
+  torch::Tensor local_input =
+      make_input("npu.mlp.quantized_gather.input", num_tokens / 2, hidden_size);
+  torch::Tensor expected = mlp->forward(local_input);
+  Device(options_.device()).synchronize_default_stream();
+
+  FlashComm1Context context;
+  context.enabled = true;
+  context.tp_rank = 0;
+  context.tp_world_size = 2;
+  context.original_num_tokens = num_tokens;
+  context.padded_num_tokens = num_tokens;
+  context.padded_local_num_tokens = num_tokens / context.tp_world_size;
+  context.tp_group = mock_group;
+  mock_group->clear_allgather_input_dtypes();
+  torch::Tensor output;
+  {
+    FlashComm1ContextScope context_scope(&context);
+    output = mlp->forward(local_input);
+  }
+  Device(options_.device()).synchronize_default_stream();
+
+  const std::vector<torch::ScalarType>& gathered_dtypes =
+      mock_group->allgather_input_dtypes();
+  ASSERT_EQ(gathered_dtypes.size(), 2);
+  EXPECT_EQ(gathered_dtypes[0], torch::kInt8);
+  EXPECT_EQ(gathered_dtypes[1], torch::kFloat32);
   ASSERT_TRUE(output.sizes() == expected.sizes());
   expect_output_close(output, expected);
 }

--- a/tests/core/layers/npu_torch/tests_utils.h
+++ b/tests/core/layers/npu_torch/tests_utils.h
@@ -166,6 +166,7 @@ class MockProcessGroup : public xllm::ProcessGroup {
 
   void allgather(const torch::Tensor& input,
                  std::vector<torch::Tensor>& outputs) override {
+    allgather_input_dtypes_.emplace_back(input.scalar_type());
     outputs.resize(this->world_size());
     if (!allgather_outputs_.empty()) {
       CHECK_EQ(allgather_outputs_.size(), outputs.size())
@@ -192,6 +193,7 @@ class MockProcessGroup : public xllm::ProcessGroup {
   c10::intrusive_ptr<c10d::Work> allgather_base_async(
       const torch::Tensor& input,
       torch::Tensor& output) override {
+    allgather_input_dtypes_.emplace_back(input.scalar_type());
     CHECK(output.defined()) << "mock allgather_base_async requires output";
     CHECK_EQ(output.size(0), this->world_size())
         << "mock allgather_base_async world_size mismatch";
@@ -223,8 +225,15 @@ class MockProcessGroup : public xllm::ProcessGroup {
     allgather_outputs_ = std::move(outputs);
   }
 
+  const std::vector<torch::ScalarType>& allgather_input_dtypes() const {
+    return allgather_input_dtypes_;
+  }
+
+  void clear_allgather_input_dtypes() { allgather_input_dtypes_.clear(); }
+
  private:
   std::vector<torch::Tensor> allgather_outputs_;
+  std::vector<torch::ScalarType> allgather_input_dtypes_;
 };
 
 // Helper function to create custom input tensor for precision testing

--- a/xllm/core/common/flash_comm1_context.cpp
+++ b/xllm/core/common/flash_comm1_context.cpp
@@ -18,6 +18,13 @@ limitations under the License.
 #include <glog/logging.h>
 
 #include <algorithm>
+#include <array>
+#include <cstddef>
+#include <vector>
+
+#if defined(USE_NPU)
+#include <torch_npu/torch_npu.h>
+#endif
 
 #include "framework/parallel_state/parallel_state.h"
 
@@ -26,7 +33,21 @@ namespace xllm {
 namespace {
 
 constexpr int32_t kFc1LocalTokenAlignment = 16;
+constexpr size_t kQuantizedMmrsRetainedBytesLimit = 512 * 1024 * 1024;
 thread_local const FlashComm1Context* current_flash_comm1_context = nullptr;
+thread_local std::vector<torch::Tensor> quantized_mmrs_launch_tensors;
+thread_local size_t quantized_mmrs_retained_bytes = 0;
+
+void synchronize_quantized_mmrs_launches() {
+  if (quantized_mmrs_launch_tensors.empty()) {
+    return;
+  }
+#if defined(USE_NPU)
+  torch::npu::synchronize();
+#endif
+  quantized_mmrs_launch_tensors.clear();
+  quantized_mmrs_retained_bytes = 0;
+}
 
 int32_t round_up_to_multiple(int32_t value, int32_t multiple) {
   CHECK_GT(multiple, 0);
@@ -105,11 +126,30 @@ FlashComm1ContextScope::FlashComm1ContextScope(const FlashComm1Context* ctx)
 }
 
 FlashComm1ContextScope::~FlashComm1ContextScope() {
+  if (previous_ == nullptr) {
+    synchronize_quantized_mmrs_launches();
+  }
   current_flash_comm1_context = previous_;
 }
 
 const FlashComm1Context* get_current_flash_comm1_context() {
   return current_flash_comm1_context;
+}
+
+void retain_quantized_mmrs_launch_tensors(const torch::Tensor& activation,
+                                          const torch::Tensor& activation_scale,
+                                          const torch::Tensor& weight_scale) {
+  const std::array<torch::Tensor, 3> tensors = {
+      activation, activation_scale, weight_scale};
+  for (const torch::Tensor& tensor : tensors) {
+    if (tensor.defined()) {
+      quantized_mmrs_retained_bytes += tensor.nbytes();
+      quantized_mmrs_launch_tensors.emplace_back(tensor);
+    }
+  }
+  if (quantized_mmrs_retained_bytes >= kQuantizedMmrsRetainedBytesLimit) {
+    synchronize_quantized_mmrs_launches();
+  }
 }
 
 bool is_sequence_sharded(const FlashComm1Context& ctx) {

--- a/xllm/core/common/flash_comm1_context.h
+++ b/xllm/core/common/flash_comm1_context.h
@@ -99,6 +99,10 @@ class FlashComm1ContextScope {
 
 const FlashComm1Context* get_current_flash_comm1_context();
 
+void retain_quantized_mmrs_launch_tensors(const torch::Tensor& activation,
+                                          const torch::Tensor& activation_scale,
+                                          const torch::Tensor& weight_scale);
+
 bool is_sequence_sharded(const FlashComm1Context& ctx);
 
 torch::Tensor pad_rows_by_copy(const torch::Tensor& input, int64_t padded_rows);

--- a/xllm/core/layers/common/dense_mlp.cpp
+++ b/xllm/core/layers/common/dense_mlp.cpp
@@ -24,6 +24,31 @@ limitations under the License.
 namespace xllm {
 namespace layer {
 
+namespace {
+
+#if defined(USE_NPU)
+W8A8DynamicInput quantize_and_gather_w8a8_dynamic_input(
+    const torch::Tensor& input,
+    const FlashComm1Context& fc1_ctx) {
+  xllm::kernel::NpuQuantizeParams quantize_params;
+  quantize_params.input = input;
+
+  torch::Tensor quantized_input;
+  std::optional<torch::Tensor> per_token_scale;
+  std::tie(quantized_input, per_token_scale) =
+      xllm::kernel::dynamic_quant(quantize_params);
+  CHECK(per_token_scale.has_value() && per_token_scale->defined())
+      << "dynamic_quant must return per-token scale before AllGather.";
+
+  torch::Tensor gathered_input = gather_sequence(quantized_input, fc1_ctx);
+  torch::Tensor gathered_scale =
+      gather_sequence(per_token_scale->reshape({-1, 1}), fc1_ctx).reshape({-1});
+  return W8A8DynamicInput{gathered_input, gathered_scale};
+}
+#endif
+
+}  // namespace
+
 DenseMLPImpl::DenseMLPImpl(int64_t hidden_size,
                            int64_t intermediate_size,
                            bool is_gated,
@@ -100,13 +125,24 @@ torch::Tensor DenseMLPImpl::forward(const torch::Tensor& hidden_states) {
   const FlashComm1Context* fc1_ctx = get_current_flash_comm1_context();
   const bool use_fc1_sequence_parallel =
       apply_fc1_sequence_parallel_ && fc1_ctx && is_sequence_sharded(*fc1_ctx);
-  torch::Tensor h = hidden_states;
-
-  if (use_fc1_sequence_parallel) {
-    h = gather_sequence(hidden_states, *fc1_ctx);
+  torch::Tensor gate_up;
+#if defined(USE_NPU)
+  const bool use_quantized_allgather = use_fc1_sequence_parallel &&
+                                       hidden_states.dim() == 2 &&
+                                       gate_up_proj_->uses_w8a8_dynamic_quant();
+  if (use_quantized_allgather) {
+    const W8A8DynamicInput quantized_input =
+        quantize_and_gather_w8a8_dynamic_input(hidden_states, *fc1_ctx);
+    gate_up = gate_up_proj_->forward_quantized(quantized_input);
   }
-
-  auto gate_up = gate_up_proj_->forward(h);
+#endif
+  if (!gate_up.defined()) {
+    torch::Tensor h = hidden_states;
+    if (use_fc1_sequence_parallel) {
+      h = gather_sequence(hidden_states, *fc1_ctx);
+    }
+    gate_up = gate_up_proj_->forward(h);
+  }
 
   if (is_smoothquant_) {
     if (use_fc1_sequence_parallel) {

--- a/xllm/core/layers/common/linear.cpp
+++ b/xllm/core/layers/common/linear.cpp
@@ -715,6 +715,37 @@ torch::Tensor ColumnParallelLinearImpl::forward(torch::Tensor input) {
   return output;
 }
 
+torch::Tensor ColumnParallelLinearImpl::forward_quantized(
+    const W8A8DynamicInput& input) {
+  CHECK(uses_w8a8_dynamic_quant())
+      << "forward_quantized requires w8a8_dynamic quant method.";
+  CHECK(input.activation.defined())
+      << "forward_quantized requires a quantized activation.";
+  CHECK(input.per_token_scale.defined())
+      << "forward_quantized requires a per-token scale.";
+  CHECK_EQ(input.activation.dim(), 2)
+      << "forward_quantized requires a 2D activation.";
+  CHECK_EQ(input.activation.size(0), input.per_token_scale.numel())
+      << "forward_quantized requires one scale per activation row.";
+
+#if defined(USE_NPU)
+  torch::Tensor output = npu_w8a8_dynamic_quantized_linear_forward(
+      input.activation.to(device_),
+      input.per_token_scale.to(device_),
+      weight_,
+      w8a8_dynamic_weight_scale(),
+      bias(),
+      output_dtype_);
+  if (world_size_ > 1 && gather_output_) {
+    output = xllm::parallel_state::gather(output, process_group_);
+  }
+  return output;
+#else
+  LOG(FATAL) << "forward_quantized is only supported on NPU.";
+  return torch::Tensor();
+#endif
+}
+
 bool ColumnParallelLinearImpl::uses_w8a8_dynamic_quant() const {
   return is_w8a8_dynamic_quant(resolved_weight_quant_method_);
 }
@@ -1776,6 +1807,9 @@ torch::Tensor RowParallelLinearImpl::forward_impl(
         }
         if (output.defined() &&
             output.sizes() == torch::IntArrayRef(output_shape)) {
+          retain_quantized_mmrs_launch_tensors(q_input,
+                                               mmrs_params.x1_scale.value(),
+                                               mmrs_params.x2_scale.value());
           return output;
         }
         if (output.defined()) {

--- a/xllm/core/layers/common/linear.h
+++ b/xllm/core/layers/common/linear.h
@@ -39,6 +39,11 @@ struct LinearExtraArgs {
       : act_mode(act_mode_), is_gated(is_gated_) {}
 };
 
+struct W8A8DynamicInput {
+  torch::Tensor activation;
+  torch::Tensor per_token_scale;
+};
+
 // Linear layer with column parallelism.
 // The linear layer is defined as Y = XA + b. A is parallelized along
 // its second dimension as A = [A_1, ..., A_p].
@@ -58,6 +63,8 @@ class ColumnParallelLinearImpl : public torch::nn::Module {
   ColumnParallelLinearImpl(const ModelContext& context);
 
   torch::Tensor forward(torch::Tensor input);
+
+  torch::Tensor forward_quantized(const W8A8DynamicInput& input);
 
   // load the weight from the checkpoint
   void load_state_dict(const StateDict& state_dict);

--- a/xllm/core/layers/common/quant_utils.h
+++ b/xllm/core/layers/common/quant_utils.h
@@ -76,6 +76,37 @@ inline void resolve_weight_quant_method_for_linear_load(
   resolved_weight_quant_method = std::nullopt;
 }
 
+inline torch::Tensor npu_w8a8_dynamic_quantized_linear_forward(
+    const torch::Tensor& quantized_input,
+    const torch::Tensor& per_token_scale,
+    const torch::Tensor& weight,
+    const torch::Tensor& weight_scale,
+    const std::optional<torch::Tensor>& bias,
+    at::ScalarType output_dtype,
+    const std::optional<torch::Tensor>& weight_offset = std::nullopt) {
+  CHECK_EQ(quantized_input.scalar_type(), torch::kInt8)
+      << "w8a8_dynamic quantized input must be int8.";
+  CHECK(per_token_scale.defined())
+      << "w8a8_dynamic per-token scale must be defined.";
+  CHECK_EQ(per_token_scale.scalar_type(), torch::kFloat32)
+      << "w8a8_dynamic per-token scale must be float32.";
+
+  kernel::QuantMatmulParams quant_matmul_params;
+  quant_matmul_params.x1 = quantized_input;
+  quant_matmul_params.x2 = weight;
+  quant_matmul_params.transpose2 = true;
+  quant_matmul_params.scale = weight_scale;
+  quant_matmul_params.pertoken_scale = per_token_scale.reshape({-1});
+  quant_matmul_params.output_dtype = output_dtype;
+  if (weight_offset.has_value() && weight_offset->defined()) {
+    quant_matmul_params.offset = weight_offset;
+  }
+  if (bias.has_value() && bias->defined()) {
+    quant_matmul_params.bias = bias;
+  }
+  return kernel::quant_matmul(quant_matmul_params);
+}
+
 inline torch::Tensor npu_w8a8_dynamic_linear_forward(
     const torch::Tensor& input,
     const torch::Tensor& weight,
@@ -85,30 +116,21 @@ inline torch::Tensor npu_w8a8_dynamic_linear_forward(
     const std::optional<torch::Tensor>& weight_offset = std::nullopt) {
   kernel::NpuQuantizeParams quant_params;
   quant_params.input = input;
-  // quant_params.dst_type = at::kChar;
 
   torch::Tensor quantized_input;
-  std::optional<torch::Tensor> pertoken_scale;
-  std::tie(quantized_input, pertoken_scale) =
+  std::optional<torch::Tensor> per_token_scale;
+  std::tie(quantized_input, per_token_scale) =
       kernel::dynamic_quant(quant_params);
-  CHECK(pertoken_scale.has_value() && pertoken_scale->defined())
+  CHECK(per_token_scale.has_value() && per_token_scale->defined())
       << "dynamic_quant must return per-token scale for w8a8_dynamic.";
 
-  kernel::QuantMatmulParams quant_matmul_params;
-  quant_matmul_params.x1 = quantized_input;
-  quant_matmul_params.x2 = weight;
-  quant_matmul_params.transpose2 = true;
-  quant_matmul_params.scale = weight_scale;
-  quant_matmul_params.pertoken_scale = pertoken_scale->reshape({-1});
-  quant_matmul_params.output_dtype = output_dtype;
-  if (weight_offset.has_value() && weight_offset->defined()) {
-    quant_matmul_params.offset = weight_offset;
-  }
-  if (bias.has_value() && bias->defined()) {
-    quant_matmul_params.bias = bias;
-  }
-  auto output = kernel::quant_matmul(quant_matmul_params);
-  return output;
+  return npu_w8a8_dynamic_quantized_linear_forward(quantized_input,
+                                                   per_token_scale.value(),
+                                                   weight,
+                                                   weight_scale,
+                                                   bias,
+                                                   output_dtype,
+                                                   weight_offset);
 }
 
 }  // namespace layer


### PR DESCRIPTION
## Description

### 背景

本 PR 优化 FlashComm 序列并行执行中的 W8A8 动态量化路径，减少 prefill 阶段 AllGather 的激活通信量，并复用量化 MMRS 执行路径。

包含两项相关改动：

1. 量化 MMRS 执行：FlashComm 行并行层复用 W8A8 动态量化 matmul/MMRS 路径。量化激活、逐 token 激活 scale、权重 scale、输出数据类型以及发射所需 tensor 会保留到异步通信和矩阵乘发射完成。
2. AllGather 前激活量化：在序列并行 AllGather 前，将本地 BF16 激活量化为 INT8。INT8 激活与 FP32 逐 token scale 分别执行 AllGather，随后传给现有 W8A8 量化矩阵乘路径。

对于形状为 `[T, H]` 的激活，通信量从：

- BF16 激活：`2 * T * H` 字节
- INT8 激活 + FP32 逐 token scale：`T * H + 4 * T` 字节

对于 `H=5120` 的 Qwen3.5-27B，激活通信量约降至 BF16 方案的 50%。新的 AllGather 前量化路径仅用于受支持的 NPU W8A8 动态量化、二维激活和序列并行场景。其他量化方法和非 NPU 路径保持原有行为。

### 实现细节

- 新增量化输入载体，包含 INT8 激活和 FP32 逐 token激活 scale。
- 为 W8A8 动态量化列并行线性层新增 `forward_quantized()`。
- 在 `DenseMLP` 中，于序列 AllGather 前量化本地激活。
- 分别聚合 INT8 激活和逐 token scale。
- 在 FlashComm 异步执行期间保留量化 MMRS 发射所需 tensor。
- 在 FlashComm 作用域边界或达到配置的保留阈值后清理所保留的 tensor。
- 增加 mock process group 测试，验证 AllGather 依次接收 INT8 激活和 FP32 scale。
- 对不受支持的量化路径保留现有回退行为。

### 功能开关

本优化**默认关闭**，需要显式设置：

```bash
--enable_flashcomm1=true \
--enable_mmrs_fusion=true \
--mmrs_comm_mode=aiv
```

- `enable_flashcomm1` 默认值为 `false`。
- `enable_mmrs_fusion` 默认值为 `false`，仅在 `enable_flashcomm1=true` 时生效。
- `mmrs_comm_mode` 默认值为 `aiv`。
- AllGather 前 W8A8 激活量化仅在受支持的 NPU W8A8 dynamic FlashComm 路径中使用；不受支持的场景保持现有回退行为。

### 性能验证

测试负载：

- 模型：Qwen3.5-27B W8A8 dynamic
- TP：4
- Graph 模式：开启
- 输入/输出：`8192 / 1024` tokens
- Prefix cache：关闭
- MTP：关闭
- 并发：`1 / 2 / 4 / 8 / 16`
- Warmup：每个测试单元 2 个请求
- 正式请求：每个测试单元 20 个请求
- 轮次：4
- 主矩阵 `max_tokens_per_batch`：`8192`
- CPU 绑核和 host load 窗口：未控制

对比配置：

- Baseline A：`enable_flashcomm1=false`、`enable_mmrs_fusion=false`
- Candidate B：`enable_flashcomm1=true`、`enable_mmrs_fusion=true`、`mmrs_comm_mode=aiv`，并启用 AllGather 前 W8A8 激活量化

| 并发 | Baseline TTFT avg (ms) | Candidate TTFT avg (ms) | TTFT 收益 | p50 收益 | p90 收益 | p99 收益 |
|---:|---:|---:|---:|---:|---:|---:|
| 1  | 545.90 | 494.15 | 9.48% | 8.90% | 7.52% | 7.72% |
| 2  | 847.12 | 788.94 | 6.87% | 4.06% | 5.28% | 9.24% |
| 4  | 1621.01 | 1596.29 | 1.52% | -6.02% | 1.45% | 2.33% |
| 8  | 2510.26 | 2476.40 | 1.35% | 1.37% | 3.03% | 3.10% |
| 16 | 5188.02 | 5016.08 | 3.31% | 3.65% | 2.79% | 2.83% |

所有已完成测试单元均达到 20/20 请求成功。

#### 并发 4 对 batch token 上限的敏感性

并发 4 时，将 `max_tokens_per_batch` 从 `8192` 提高到 `16384`，四轮平均 TTFT 收益从 **1.52%** 提高到 **5.80%**。输入长度为 8192 tokens 时，8192 的 batch token 预算一次只能容纳一个完整 prefill；16384 的预算可以容纳两个，使融合 FlashComm/MMRS 路径节省的通信时间在整体耗时中占比更高。

| max_tokens_per_batch | Baseline TTFT avg (ms) | Candidate TTFT avg (ms) | TTFT 收益 | p50 收益 | p90 收益 | p99 收益 |
|---:|---:|---:|---:|---:|---:|---:|
| 8192 | 1621.01 | 1596.29 | 1.52% | -6.02% | 1.45% | 2.33% |
| 16384 | 1583.31 | 1491.31 | 5.80% | 3.66% | 6.18% | 5.39% |

8192 数据来自原始矩阵，16384 数据来自之后进行的四轮受控重测，因此跨 batch token 预算的两组数据并非同一时间采集。每个预算内部的 B/C 使用相同测试条件，纳入统计的每个测试单元均完成 20/20 请求。

### 验证结果

- 修改文件的 `clang-format` 检查通过。
- `git diff --check` 通过。
- W8A8 dynamic NPU 定向测试通过：5/5。
- xLLM 主二进制编译和链接成功。
- 已完成的矩阵测试单元中未发现 graph status 27 或 HCCL 失败。

上述构建、测试和性能结果对应功能提交 `3a63101c`。PR 分支已合入最新 `main@a7630f3c`，合入后的 head 为 `368f6031`；最新 head 尚未重新执行 NPU build/test，因此下方 NPU build/test checkbox 保持未勾选。

## Related Issues

Related to #2022.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [x] Test
- [ ] Build or CI

## Pull Request Checklist

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

### Pre-commit Checks

- [ ] I have installed pre-commit by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have merged the latest `main` branch into this PR.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine after the latest main update.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

请重点检查以下内容：

1. FlashComm 异步执行期间，量化 MMRS 发射 tensor 的生命周期约束。
2. W8A8 dynamic 与 static W8A8、SmoothQuant、FP8、W4A8 和 MoE 路径的兼容边界。
3. INT8 激活与 FP32 scale 分别执行 AllGather 的行为。
4. 通信量降低与额外 scale AllGather 之间的性能权衡。

The validated NPU binary and performance results correspond to `3a63101c`. The PR branch has since merged `main@a7630f3c` into `368f6031`; the updated head has not been rebuilt or rerun on NPU, so the NPU build/test checkbox remains unchecked.
