### PR TITLE
bugfix: reject prompts exceeding decode kv capacity.

### DIFF
--- a/tests/core/scheduler/disagg_pd_scheduler_test.cpp
+++ b/tests/core/scheduler/disagg_pd_scheduler_test.cpp
@@ -67,16 +67,14 @@ class FakeEngine final : public Engine {
  public:
   FakeEngine(int32_t num_blocks,
              int32_t block_size,
-             int32_t num_speculative_tokens = 0,
-             bool enable_host_offload = false) {
+             int32_t num_speculative_tokens = 0) {
     BlockManagerPool::Options options;
     options.num_blocks(num_blocks)
         .block_size(block_size)
         .enable_prefix_cache(true)
         .enable_disagg_pd(true)
         .num_speculative_tokens(num_speculative_tokens)
-        .num_embedding_blocks(num_blocks)
-        .enable_host_offload(enable_host_offload);
+        .num_embedding_blocks(num_blocks);
     tokenizer_ = std::make_unique<FakeTokenizer>();
     block_manager_ = std::make_unique<BlockManagerPool>(options, /*dp_size=*/1);
   }
@@ -477,19 +475,6 @@ TEST(DisaggPDSchedulerTest, OversizedDecodePromptIsPermanent) {
   EXPECT_TRUE(scheduler.prompt_exceeds_block_capacity(sequence));
 
   block_manager->deallocate(request.get());
-}
-
-TEST(DisaggPDSchedulerTest, HostOffloadedPrefillPromptIsNotAborted) {
-  FakeEngine engine(
-      /*num_blocks=*/4,
-      /*block_size=*/2,
-      /*num_speculative_tokens=*/0,
-      /*enable_host_offload=*/true);
-  TestDisaggPDScheduler scheduler(&engine, make_options());
-  std::shared_ptr<Request> request = make_request({1, 2, 3, 4, 5, 6, 7});
-
-  EXPECT_FALSE(
-      scheduler.prompt_exceeds_block_capacity(request->sequences()[0].get()));
 }
 
 TEST(DisaggPDSchedulerTest, InvalidPrefillCachedTokensFallBackToZero) {

--- a/tests/core/scheduler/disagg_pd_scheduler_test.cpp
+++ b/tests/core/scheduler/disagg_pd_scheduler_test.cpp
@@ -433,19 +433,19 @@ TEST(DisaggPDSchedulerTest, PreservesPrefillCachedTokensOnDecodeRequest) {
 }
 
 TEST(DisaggPDSchedulerTest, PromptAtDecodeBlockCapacityIsNotPermanent) {
-  EXPECT_FALSE(pd_prompt_exceeds_block_capacity(
+  EXPECT_FALSE(pd_prompt_exceeds_decode_block_capacity(
       /*num_prompt_tokens=*/6, /*block_size=*/2, /*num_blocks=*/4));
 }
 
 TEST(DisaggPDSchedulerTest, OnlyOversizedDecodeResponseIsTerminal) {
-  EXPECT_FALSE(decode_add_new_failure_is_terminal(/*status_code=*/404));
-  EXPECT_TRUE(
-      decode_add_new_failure_is_terminal(kDecodeAddNewPromptTooLongStatusCode));
-  EXPECT_FALSE(decode_add_new_failure_is_terminal(/*status_code=*/500));
+  EXPECT_FALSE(is_decode_add_request_failure_terminal(/*status_code=*/404));
+  EXPECT_TRUE(is_decode_add_request_failure_terminal(
+      kDecodeAddNewPromptTooLongStatusCode));
+  EXPECT_FALSE(is_decode_add_request_failure_terminal(/*status_code=*/500));
 }
 
 TEST(DisaggPDSchedulerTest, PromptBeyondDecodeBlockCapacityIsPermanent) {
-  EXPECT_TRUE(pd_prompt_exceeds_block_capacity(
+  EXPECT_TRUE(pd_prompt_exceeds_decode_block_capacity(
       /*num_prompt_tokens=*/7, /*block_size=*/2, /*num_blocks=*/4));
 }
 
@@ -459,7 +459,7 @@ TEST(DisaggPDSchedulerTest, TemporaryDecodeBlockPressureIsNotPermanent) {
   Sequence* sequence = request->sequences()[0].get();
 
   EXPECT_FALSE(scheduler.try_allocate(sequence));
-  EXPECT_FALSE(scheduler.prompt_exceeds_block_capacity(sequence));
+  EXPECT_FALSE(scheduler.prompt_exceeds_decode_block_capacity(sequence));
 
   block_manager->deallocate(holder.get());
 }
@@ -472,7 +472,7 @@ TEST(DisaggPDSchedulerTest, OversizedDecodePromptIsPermanent) {
   Sequence* sequence = request->sequences()[0].get();
 
   EXPECT_FALSE(scheduler.try_allocate(sequence));
-  EXPECT_TRUE(scheduler.prompt_exceeds_block_capacity(sequence));
+  EXPECT_TRUE(scheduler.prompt_exceeds_decode_block_capacity(sequence));
 
   block_manager->deallocate(request.get());
 }

--- a/tests/core/scheduler/disagg_pd_scheduler_test.cpp
+++ b/tests/core/scheduler/disagg_pd_scheduler_test.cpp
@@ -433,19 +433,18 @@ TEST(DisaggPDSchedulerTest, PreservesPrefillCachedTokensOnDecodeRequest) {
 }
 
 TEST(DisaggPDSchedulerTest, PromptAtDecodeBlockCapacityIsNotPermanent) {
-  EXPECT_FALSE(pd_prompt_exceeds_decode_block_capacity(
+  EXPECT_FALSE(exceeds_decode_capacity(
       /*num_prompt_tokens=*/6, /*block_size=*/2, /*num_blocks=*/4));
 }
 
 TEST(DisaggPDSchedulerTest, OnlyOversizedDecodeResponseIsTerminal) {
-  EXPECT_FALSE(is_decode_add_request_failure_terminal(/*status_code=*/404));
-  EXPECT_TRUE(is_decode_add_request_failure_terminal(
-      kDecodeAddNewPromptTooLongStatusCode));
-  EXPECT_FALSE(is_decode_add_request_failure_terminal(/*status_code=*/500));
+  EXPECT_FALSE(is_permanent_rejection(/*status_code=*/404));
+  EXPECT_TRUE(is_permanent_rejection(kDecodeAddNewPromptTooLongStatusCode));
+  EXPECT_FALSE(is_permanent_rejection(/*status_code=*/500));
 }
 
 TEST(DisaggPDSchedulerTest, PromptBeyondDecodeBlockCapacityIsPermanent) {
-  EXPECT_TRUE(pd_prompt_exceeds_decode_block_capacity(
+  EXPECT_TRUE(exceeds_decode_capacity(
       /*num_prompt_tokens=*/7, /*block_size=*/2, /*num_blocks=*/4));
 }
 
@@ -459,7 +458,7 @@ TEST(DisaggPDSchedulerTest, TemporaryDecodeBlockPressureIsNotPermanent) {
   Sequence* sequence = request->sequences()[0].get();
 
   EXPECT_FALSE(scheduler.try_allocate(sequence));
-  EXPECT_FALSE(scheduler.prompt_exceeds_decode_block_capacity(sequence));
+  EXPECT_FALSE(scheduler.exceeds_decode_capacity(sequence));
 
   block_manager->deallocate(holder.get());
 }
@@ -472,7 +471,7 @@ TEST(DisaggPDSchedulerTest, OversizedDecodePromptIsPermanent) {
   Sequence* sequence = request->sequences()[0].get();
 
   EXPECT_FALSE(scheduler.try_allocate(sequence));
-  EXPECT_TRUE(scheduler.prompt_exceeds_decode_block_capacity(sequence));
+  EXPECT_TRUE(scheduler.exceeds_decode_capacity(sequence));
 
   block_manager->deallocate(request.get());
 }

--- a/tests/core/scheduler/disagg_pd_scheduler_test.cpp
+++ b/tests/core/scheduler/disagg_pd_scheduler_test.cpp
@@ -67,14 +67,16 @@ class FakeEngine final : public Engine {
  public:
   FakeEngine(int32_t num_blocks,
              int32_t block_size,
-             int32_t num_speculative_tokens = 0) {
+             int32_t num_speculative_tokens = 0,
+             bool enable_host_offload = false) {
     BlockManagerPool::Options options;
     options.num_blocks(num_blocks)
         .block_size(block_size)
         .enable_prefix_cache(true)
         .enable_disagg_pd(true)
         .num_speculative_tokens(num_speculative_tokens)
-        .num_embedding_blocks(num_blocks);
+        .num_embedding_blocks(num_blocks)
+        .enable_host_offload(enable_host_offload);
     tokenizer_ = std::make_unique<FakeTokenizer>();
     block_manager_ = std::make_unique<BlockManagerPool>(options, /*dp_size=*/1);
   }
@@ -430,6 +432,64 @@ TEST(DisaggPDSchedulerTest, PreservesPrefillCachedTokensOnDecodeRequest) {
   std::shared_ptr<Request> queued;
   ASSERT_TRUE(scheduler.pop_decode_request_for_test(&queued));
   EXPECT_EQ(queued->num_prefix_cache_tokens(), 2u);
+}
+
+TEST(DisaggPDSchedulerTest, PromptAtDecodeBlockCapacityIsNotPermanent) {
+  EXPECT_FALSE(pd_prompt_exceeds_block_capacity(
+      /*num_prompt_tokens=*/6, /*block_size=*/2, /*num_blocks=*/4));
+}
+
+TEST(DisaggPDSchedulerTest, OnlyOversizedDecodeResponseIsTerminal) {
+  EXPECT_FALSE(decode_add_new_failure_is_terminal(/*status_code=*/404));
+  EXPECT_TRUE(
+      decode_add_new_failure_is_terminal(kDecodeAddNewPromptTooLongStatusCode));
+  EXPECT_FALSE(decode_add_new_failure_is_terminal(/*status_code=*/500));
+}
+
+TEST(DisaggPDSchedulerTest, PromptBeyondDecodeBlockCapacityIsPermanent) {
+  EXPECT_TRUE(pd_prompt_exceeds_block_capacity(
+      /*num_prompt_tokens=*/7, /*block_size=*/2, /*num_blocks=*/4));
+}
+
+TEST(DisaggPDSchedulerTest, TemporaryDecodeBlockPressureIsNotPermanent) {
+  FakeEngine engine(/*num_blocks=*/4, /*block_size=*/2);
+  TestDisaggPDScheduler scheduler(&engine, make_options());
+  BlockManagerPool* block_manager = engine.block_manager_pool();
+  std::shared_ptr<Request> holder = make_request({1, 2, 3, 4, 5, 6});
+  ASSERT_TRUE(block_manager->try_allocate(holder->sequences()[0].get()));
+  std::shared_ptr<Request> request = make_request({7, 8});
+  Sequence* sequence = request->sequences()[0].get();
+
+  EXPECT_FALSE(scheduler.try_allocate(sequence));
+  EXPECT_FALSE(scheduler.prompt_exceeds_block_capacity(sequence));
+
+  block_manager->deallocate(holder.get());
+}
+
+TEST(DisaggPDSchedulerTest, OversizedDecodePromptIsPermanent) {
+  FakeEngine engine(/*num_blocks=*/4, /*block_size=*/2);
+  TestDisaggPDScheduler scheduler(&engine, make_options());
+  BlockManagerPool* block_manager = engine.block_manager_pool();
+  std::shared_ptr<Request> request = make_request({1, 2, 3, 4, 5, 6, 7});
+  Sequence* sequence = request->sequences()[0].get();
+
+  EXPECT_FALSE(scheduler.try_allocate(sequence));
+  EXPECT_TRUE(scheduler.prompt_exceeds_block_capacity(sequence));
+
+  block_manager->deallocate(request.get());
+}
+
+TEST(DisaggPDSchedulerTest, HostOffloadedPrefillPromptIsNotAborted) {
+  FakeEngine engine(
+      /*num_blocks=*/4,
+      /*block_size=*/2,
+      /*num_speculative_tokens=*/0,
+      /*enable_host_offload=*/true);
+  TestDisaggPDScheduler scheduler(&engine, make_options());
+  std::shared_ptr<Request> request = make_request({1, 2, 3, 4, 5, 6, 7});
+
+  EXPECT_FALSE(
+      scheduler.prompt_exceeds_block_capacity(request->sequences()[0].get()));
 }
 
 TEST(DisaggPDSchedulerTest, InvalidPrefillCachedTokensFallBackToZero) {

--- a/xllm/core/distributed_runtime/disagg_pd_service_impl.cpp
+++ b/xllm/core/distributed_runtime/disagg_pd_service_impl.cpp
@@ -160,7 +160,7 @@ void DisaggPDServiceImpl::decode_recv_new_requests(
     Sequence* sequence = sequences[0].get();
 
     if (!scheduler_->try_allocate(sequence)) {
-      if (scheduler_->prompt_exceeds_decode_block_capacity(sequence)) {
+      if (scheduler_->exceeds_decode_capacity(sequence)) {
         LOG(ERROR) << "Decode cannot fit request prompt at any load, "
                    << "request_id=" << req.req_id()
                    << ", prompt_tokens=" << sequence->num_prompt_tokens();

--- a/xllm/core/distributed_runtime/disagg_pd_service_impl.cpp
+++ b/xllm/core/distributed_runtime/disagg_pd_service_impl.cpp
@@ -160,8 +160,15 @@ void DisaggPDServiceImpl::decode_recv_new_requests(
     Sequence* sequence = sequences[0].get();
 
     if (!scheduler_->try_allocate(sequence)) {
-      // FIXME: set status code
-      resp->set_status_code(404);
+      if (scheduler_->prompt_exceeds_block_capacity(sequence)) {
+        LOG(ERROR) << "Decode cannot fit request prompt at any load, "
+                   << "request_id=" << req.req_id()
+                   << ", prompt_tokens=" << sequence->num_prompt_tokens();
+        resp->set_status_code(kDecodeAddNewPromptTooLongStatusCode);
+      } else {
+        // Current cache pressure can be relieved, so Prefill may retry.
+        resp->set_status_code(404);
+      }
     } else {
       // push the request to scheduler request buffer
       bool success =

--- a/xllm/core/distributed_runtime/disagg_pd_service_impl.cpp
+++ b/xllm/core/distributed_runtime/disagg_pd_service_impl.cpp
@@ -160,7 +160,7 @@ void DisaggPDServiceImpl::decode_recv_new_requests(
     Sequence* sequence = sequences[0].get();
 
     if (!scheduler_->try_allocate(sequence)) {
-      if (scheduler_->prompt_exceeds_block_capacity(sequence)) {
+      if (scheduler_->prompt_exceeds_decode_block_capacity(sequence)) {
         LOG(ERROR) << "Decode cannot fit request prompt at any load, "
                    << "request_id=" << req.req_id()
                    << ", prompt_tokens=" << sequence->num_prompt_tokens();

--- a/xllm/core/scheduler/disagg_pd_scheduler.cpp
+++ b/xllm/core/scheduler/disagg_pd_scheduler.cpp
@@ -48,13 +48,13 @@ limitations under the License.
 
 namespace xllm {
 
-bool decode_add_new_failure_is_terminal(int32_t status_code) {
+bool is_decode_add_request_failure_terminal(int32_t status_code) {
   return status_code == kDecodeAddNewPromptTooLongStatusCode;
 }
 
-bool pd_prompt_exceeds_block_capacity(size_t num_prompt_tokens,
-                                      size_t block_size,
-                                      size_t num_blocks) {
+bool pd_prompt_exceeds_decode_block_capacity(size_t num_prompt_tokens,
+                                             size_t block_size,
+                                             size_t num_blocks) {
   if (block_size == 0) {
     return true;
   }
@@ -544,13 +544,13 @@ void DisaggPDScheduler::dispatch_requests() {
     }
     for (size_t i = 0; i < requests.size(); ++i) {
       if (resps.resps()[i].status_code() != 200) {
-        if (decode_add_new_failure_is_terminal(
+        if (is_decode_add_request_failure_terminal(
                 resps.resps()[i].status_code())) {
           LOG(ERROR) << "Decode rejected an oversized prompt, request_id="
                      << requests[i]->request_id() << ", prompt_tokens="
                      << requests[i]->state().prompt_tokens.size()
                      << ", selected_instance=" << selected_instance;
-          fail_request_exceeding_decode_capacity(requests[i]);
+          fail_request_rejected_by_decode_capacity(requests[i]);
           continue;
         }
         // push back to prefill_request_queue_
@@ -1095,7 +1095,7 @@ bool DisaggPDScheduler::try_allocate(Sequence* sequence) {
   }
 }
 
-bool DisaggPDScheduler::prompt_exceeds_block_capacity(
+bool DisaggPDScheduler::prompt_exceeds_decode_block_capacity(
     Sequence* sequence) const {
   CHECK(sequence != nullptr);
   const BlockManagerPool* block_manager = engine_->block_manager_pool();
@@ -1107,13 +1107,13 @@ bool DisaggPDScheduler::prompt_exceeds_block_capacity(
        options_.instance_role() != InstanceRole::DECODE)) {
     return false;
   }
-  return pd_prompt_exceeds_block_capacity(
+  return pd_prompt_exceeds_decode_block_capacity(
       sequence->num_prompt_tokens(),
       static_cast<size_t>(block_manager->block_size()),
       static_cast<size_t>(block_manager->num_blocks()));
 }
 
-void DisaggPDScheduler::fail_request_exceeding_decode_capacity(
+void DisaggPDScheduler::fail_request_rejected_by_decode_capacity(
     const std::shared_ptr<Request>& request) {
   CHECK(request != nullptr);
   response_processor_->process_failed_request(

--- a/xllm/core/scheduler/disagg_pd_scheduler.cpp
+++ b/xllm/core/scheduler/disagg_pd_scheduler.cpp
@@ -1105,7 +1105,7 @@ bool DisaggPDScheduler::exceeds_decode_capacity(Sequence* sequence) const {
        options_.instance_role() != InstanceRole::DECODE)) {
     return false;
   }
-  return exceeds_decode_capacity(
+  return ::xllm::exceeds_decode_capacity(
       sequence->num_prompt_tokens(),
       static_cast<size_t>(block_manager->block_size()),
       static_cast<size_t>(block_manager->num_blocks()));

--- a/xllm/core/scheduler/disagg_pd_scheduler.cpp
+++ b/xllm/core/scheduler/disagg_pd_scheduler.cpp
@@ -48,13 +48,13 @@ limitations under the License.
 
 namespace xllm {
 
-bool is_decode_add_request_failure_terminal(int32_t status_code) {
+bool is_permanent_rejection(int32_t status_code) {
   return status_code == kDecodeAddNewPromptTooLongStatusCode;
 }
 
-bool pd_prompt_exceeds_decode_block_capacity(size_t num_prompt_tokens,
-                                             size_t block_size,
-                                             size_t num_blocks) {
+bool exceeds_decode_capacity(size_t num_prompt_tokens,
+                             size_t block_size,
+                             size_t num_blocks) {
   if (block_size == 0) {
     return true;
   }
@@ -544,13 +544,12 @@ void DisaggPDScheduler::dispatch_requests() {
     }
     for (size_t i = 0; i < requests.size(); ++i) {
       if (resps.resps()[i].status_code() != 200) {
-        if (is_decode_add_request_failure_terminal(
-                resps.resps()[i].status_code())) {
+        if (is_permanent_rejection(resps.resps()[i].status_code())) {
           LOG(ERROR) << "Decode rejected an oversized prompt, request_id="
                      << requests[i]->request_id() << ", prompt_tokens="
                      << requests[i]->state().prompt_tokens.size()
                      << ", selected_instance=" << selected_instance;
-          fail_request_rejected_by_decode_capacity(requests[i]);
+          do_permanent_rejection(requests[i]);
           continue;
         }
         // push back to prefill_request_queue_
@@ -1095,8 +1094,7 @@ bool DisaggPDScheduler::try_allocate(Sequence* sequence) {
   }
 }
 
-bool DisaggPDScheduler::prompt_exceeds_decode_block_capacity(
-    Sequence* sequence) const {
+bool DisaggPDScheduler::exceeds_decode_capacity(Sequence* sequence) const {
   CHECK(sequence != nullptr);
   const BlockManagerPool* block_manager = engine_->block_manager_pool();
   CHECK(block_manager != nullptr);
@@ -1107,13 +1105,13 @@ bool DisaggPDScheduler::prompt_exceeds_decode_block_capacity(
        options_.instance_role() != InstanceRole::DECODE)) {
     return false;
   }
-  return pd_prompt_exceeds_decode_block_capacity(
+  return exceeds_decode_capacity(
       sequence->num_prompt_tokens(),
       static_cast<size_t>(block_manager->block_size()),
       static_cast<size_t>(block_manager->num_blocks()));
 }
 
-void DisaggPDScheduler::fail_request_rejected_by_decode_capacity(
+void DisaggPDScheduler::do_permanent_rejection(
     const std::shared_ptr<Request>& request) {
   CHECK(request != nullptr);
   response_processor_->process_failed_request(

--- a/xllm/core/scheduler/disagg_pd_scheduler.cpp
+++ b/xllm/core/scheduler/disagg_pd_scheduler.cpp
@@ -34,6 +34,7 @@ limitations under the License.
 #include "disagg_pd_scheduler.h"
 #include "distributed_runtime/engine.h"
 #include "framework/batch/batch_factory.h"
+#include "framework/block/block_manager_pool.h"
 #include "framework/kv_cache_transfer/pd_topology_guard.h"
 #include "framework/request/request.h"
 #include "framework/request/request_state.h"
@@ -46,6 +47,21 @@ limitations under the License.
 #include "util/utils.h"
 
 namespace xllm {
+
+bool decode_add_new_failure_is_terminal(int32_t status_code) {
+  return status_code == kDecodeAddNewPromptTooLongStatusCode;
+}
+
+bool pd_prompt_exceeds_block_capacity(size_t num_prompt_tokens,
+                                      size_t block_size,
+                                      size_t num_blocks) {
+  if (block_size == 0) {
+    return true;
+  }
+  const size_t needed_blocks = util::ceil_div(num_prompt_tokens, block_size);
+  const size_t usable_blocks = num_blocks == 0 ? 0 : num_blocks - 1;
+  return needed_blocks > usable_blocks;
+}
 
 DisaggPDScheduler::DisaggPDScheduler(Engine* engine, const Options& options)
     : ContinuousScheduler(engine, options), server_name_("DisaggPDServer") {
@@ -528,6 +544,15 @@ void DisaggPDScheduler::dispatch_requests() {
     }
     for (size_t i = 0; i < requests.size(); ++i) {
       if (resps.resps()[i].status_code() != 200) {
+        if (decode_add_new_failure_is_terminal(
+                resps.resps()[i].status_code())) {
+          LOG(ERROR) << "Decode rejected an oversized prompt, request_id="
+                     << requests[i]->request_id() << ", prompt_tokens="
+                     << requests[i]->state().prompt_tokens.size()
+                     << ", selected_instance=" << selected_instance;
+          fail_request_exceeding_decode_capacity(requests[i]);
+          continue;
+        }
         // push back to prefill_request_queue_
         if (requests[i]->offline()) {
           prefill_request_queue_offline_.enqueue(requests[i]);
@@ -1068,6 +1093,36 @@ bool DisaggPDScheduler::try_allocate(Sequence* sequence) {
   } else {
     return false;
   }
+}
+
+bool DisaggPDScheduler::prompt_exceeds_block_capacity(
+    Sequence* sequence) const {
+  CHECK(sequence != nullptr);
+  const BlockManagerPool* block_manager = engine_->block_manager_pool();
+  CHECK(block_manager != nullptr);
+  const BlockManagerPool::Options& block_options = block_manager->options();
+  if (block_options.enable_xtensor() ||
+      !block_options.manager_types().empty() ||
+      (block_options.enable_host_offload() &&
+       options_.instance_role() != InstanceRole::DECODE)) {
+    return false;
+  }
+  return pd_prompt_exceeds_block_capacity(
+      sequence->num_prompt_tokens(),
+      static_cast<size_t>(block_manager->block_size()),
+      static_cast<size_t>(block_manager->num_blocks()));
+}
+
+void DisaggPDScheduler::fail_request_exceeding_decode_capacity(
+    const std::shared_ptr<Request>& request) {
+  CHECK(request != nullptr);
+  response_processor_->process_failed_request(
+      request,
+      {StatusCode::RESOURCE_EXHAUSTED,
+       "Request prompt exceeds decode KV cache capacity"});
+  kv_cache_manager_->deallocate(request.get());
+  std::lock_guard<std::mutex> lock(req_to_channel_map_mutex_);
+  req_to_channel_map_.erase(request->request_id());
 }
 
 void DisaggPDScheduler::update_token_latency_metrics(

--- a/xllm/core/scheduler/disagg_pd_scheduler.h
+++ b/xllm/core/scheduler/disagg_pd_scheduler.h
@@ -17,6 +17,8 @@ limitations under the License.
 
 #include <brpc/channel.h>
 
+#include <cstddef>
+#include <cstdint>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -33,6 +35,17 @@ limitations under the License.
 #include "util/threadpool.h"
 
 namespace xllm {
+
+inline constexpr int32_t kDecodeAddNewPromptTooLongStatusCode = 413;
+
+bool decode_add_new_failure_is_terminal(int32_t status_code);
+
+// Flat KV managers reserve block 0 for padding, so only num_blocks - 1 blocks
+// can belong to a request. Returns true only when the prompt can never fit,
+// independent of current cache pressure.
+bool pd_prompt_exceeds_block_capacity(size_t num_prompt_tokens,
+                                      size_t block_size,
+                                      size_t num_blocks);
 
 class DisaggPDScheduler : public ContinuousScheduler {
  public:
@@ -78,6 +91,11 @@ class DisaggPDScheduler : public ContinuousScheduler {
   // decode allocate blocks with prefix cache.
   bool try_allocate(Sequence* sequence);
 
+  // Classifies a failed allocation as permanently oversized.
+  // DSV4 multi-manager and XTensor layouts conservatively return false because
+  // their effective token capacity cannot be derived from the flat KV count.
+  bool prompt_exceeds_block_capacity(Sequence* sequence) const;
+
   bool enable_schedule_overlap() { return options_.enable_schedule_overlap(); };
 
   void get_latency_metrics(std::vector<int64_t>& ttft,
@@ -98,6 +116,9 @@ class DisaggPDScheduler : public ContinuousScheduler {
                        const int32_t src_kv_split_size);
 
  protected:
+  void fail_request_exceeding_decode_capacity(
+      const std::shared_ptr<Request>& request);
+
   // Pre-execute prefill requests of different lengths at startup and obtain the
   // corresponding TTFT for calculating the estimated TTFT of requests.
   void profile_ttft();

--- a/xllm/core/scheduler/disagg_pd_scheduler.h
+++ b/xllm/core/scheduler/disagg_pd_scheduler.h
@@ -38,14 +38,14 @@ namespace xllm {
 
 inline constexpr int32_t kDecodeAddNewPromptTooLongStatusCode = 413;
 
-bool is_decode_add_request_failure_terminal(int32_t status_code);
+bool is_permanent_rejection(int32_t status_code);
 
 // Flat KV managers reserve block 0 for padding, so only num_blocks - 1 blocks
 // can belong to a request. Returns true only when the prompt can never fit,
 // independent of current cache pressure.
-bool pd_prompt_exceeds_decode_block_capacity(size_t num_prompt_tokens,
-                                             size_t block_size,
-                                             size_t num_blocks);
+bool exceeds_decode_capacity(size_t num_prompt_tokens,
+                             size_t block_size,
+                             size_t num_blocks);
 
 class DisaggPDScheduler : public ContinuousScheduler {
  public:
@@ -94,7 +94,7 @@ class DisaggPDScheduler : public ContinuousScheduler {
   // Classifies a failed allocation as permanently oversized.
   // DSV4 multi-manager and XTensor layouts conservatively return false because
   // their effective token capacity cannot be derived from the flat KV count.
-  bool prompt_exceeds_decode_block_capacity(Sequence* sequence) const;
+  bool exceeds_decode_capacity(Sequence* sequence) const;
 
   bool enable_schedule_overlap() { return options_.enable_schedule_overlap(); };
 
@@ -116,8 +116,7 @@ class DisaggPDScheduler : public ContinuousScheduler {
                        const int32_t src_kv_split_size);
 
  protected:
-  void fail_request_rejected_by_decode_capacity(
-      const std::shared_ptr<Request>& request);
+  void do_permanent_rejection(const std::shared_ptr<Request>& request);
 
   // Pre-execute prefill requests of different lengths at startup and obtain the
   // corresponding TTFT for calculating the estimated TTFT of requests.

--- a/xllm/core/scheduler/disagg_pd_scheduler.h
+++ b/xllm/core/scheduler/disagg_pd_scheduler.h
@@ -38,14 +38,14 @@ namespace xllm {
 
 inline constexpr int32_t kDecodeAddNewPromptTooLongStatusCode = 413;
 
-bool decode_add_new_failure_is_terminal(int32_t status_code);
+bool is_decode_add_request_failure_terminal(int32_t status_code);
 
 // Flat KV managers reserve block 0 for padding, so only num_blocks - 1 blocks
 // can belong to a request. Returns true only when the prompt can never fit,
 // independent of current cache pressure.
-bool pd_prompt_exceeds_block_capacity(size_t num_prompt_tokens,
-                                      size_t block_size,
-                                      size_t num_blocks);
+bool pd_prompt_exceeds_decode_block_capacity(size_t num_prompt_tokens,
+                                             size_t block_size,
+                                             size_t num_blocks);
 
 class DisaggPDScheduler : public ContinuousScheduler {
  public:
@@ -94,7 +94,7 @@ class DisaggPDScheduler : public ContinuousScheduler {
   // Classifies a failed allocation as permanently oversized.
   // DSV4 multi-manager and XTensor layouts conservatively return false because
   // their effective token capacity cannot be derived from the flat KV count.
-  bool prompt_exceeds_block_capacity(Sequence* sequence) const;
+  bool prompt_exceeds_decode_block_capacity(Sequence* sequence) const;
 
   bool enable_schedule_overlap() { return options_.enable_schedule_overlap(); };
 
@@ -116,7 +116,7 @@ class DisaggPDScheduler : public ContinuousScheduler {
                        const int32_t src_kv_split_size);
 
  protected:
-  void fail_request_exceeding_decode_capacity(
+  void fail_request_rejected_by_decode_capacity(
       const std::shared_ptr<Request>& request);
 
   // Pre-execute prefill requests of different lengths at startup and obtain the

--- a/xllm/core/scheduler/pd_ooc_scheduler.cpp
+++ b/xllm/core/scheduler/pd_ooc_scheduler.cpp
@@ -1471,13 +1471,12 @@ void PDOOCScheduler::dispatch_requests() {
     for (size_t i = 0; i < requests.size(); ++i) {
       CHECK(!requests[i]->offline());
       if (resps.resps()[i].status_code() != 200) {
-        if (is_decode_add_request_failure_terminal(
-                resps.resps()[i].status_code())) {
+        if (is_permanent_rejection(resps.resps()[i].status_code())) {
           LOG(ERROR) << "Decode rejected an oversized prompt, request_id="
                      << requests[i]->request_id() << ", prompt_tokens="
                      << requests[i]->state().prompt_tokens.size()
                      << ", selected_instance=" << selected_instance;
-          fail_request_rejected_by_decode_capacity(requests[i]);
+          do_permanent_rejection(requests[i]);
           continue;
         }
         // push back to prefill_request_queue_
@@ -1958,13 +1957,13 @@ void PDOOCScheduler::dispatch_offline_requests() {
     // Check response and handle accordingly
     const bool prompt_too_long =
         !cntl.Failed() && !resps.resps().empty() &&
-        is_decode_add_request_failure_terminal(resps.resps()[0].status_code());
+        is_permanent_rejection(resps.resps()[0].status_code());
     if (prompt_too_long) {
       LOG(ERROR) << "Decode rejected an oversized offline prompt, request_id="
                  << request->request_id()
                  << ", prompt_tokens=" << request->state().prompt_tokens.size()
                  << ", target_instance=" << target_instance;
-      fail_request_rejected_by_decode_capacity(request);
+      do_permanent_rejection(request);
       continue;
     }
     if (cntl.Failed() || resps.resps().empty() ||

--- a/xllm/core/scheduler/pd_ooc_scheduler.cpp
+++ b/xllm/core/scheduler/pd_ooc_scheduler.cpp
@@ -1471,6 +1471,15 @@ void PDOOCScheduler::dispatch_requests() {
     for (size_t i = 0; i < requests.size(); ++i) {
       CHECK(!requests[i]->offline());
       if (resps.resps()[i].status_code() != 200) {
+        if (decode_add_new_failure_is_terminal(
+                resps.resps()[i].status_code())) {
+          LOG(ERROR) << "Decode rejected an oversized prompt, request_id="
+                     << requests[i]->request_id() << ", prompt_tokens="
+                     << requests[i]->state().prompt_tokens.size()
+                     << ", selected_instance=" << selected_instance;
+          fail_request_exceeding_decode_capacity(requests[i]);
+          continue;
+        }
         // push back to prefill_request_queue_
         if (requests[i]->offline()) {
           prefill_request_queue_offline_.enqueue(requests[i]);
@@ -1947,6 +1956,17 @@ void PDOOCScheduler::dispatch_offline_requests() {
     stub->AddNewRequests(&cntl, &reqs, &resps, nullptr);
 
     // Check response and handle accordingly
+    const bool prompt_too_long =
+        !cntl.Failed() && !resps.resps().empty() &&
+        decode_add_new_failure_is_terminal(resps.resps()[0].status_code());
+    if (prompt_too_long) {
+      LOG(ERROR) << "Decode rejected an oversized offline prompt, request_id="
+                 << request->request_id()
+                 << ", prompt_tokens=" << request->state().prompt_tokens.size()
+                 << ", target_instance=" << target_instance;
+      fail_request_exceeding_decode_capacity(request);
+      continue;
+    }
     if (cntl.Failed() || resps.resps().empty() ||
         resps.resps()[0].status_code() != 200) {
       LOG(ERROR) << "Failed to dispatch offline request "

--- a/xllm/core/scheduler/pd_ooc_scheduler.cpp
+++ b/xllm/core/scheduler/pd_ooc_scheduler.cpp
@@ -1471,13 +1471,13 @@ void PDOOCScheduler::dispatch_requests() {
     for (size_t i = 0; i < requests.size(); ++i) {
       CHECK(!requests[i]->offline());
       if (resps.resps()[i].status_code() != 200) {
-        if (decode_add_new_failure_is_terminal(
+        if (is_decode_add_request_failure_terminal(
                 resps.resps()[i].status_code())) {
           LOG(ERROR) << "Decode rejected an oversized prompt, request_id="
                      << requests[i]->request_id() << ", prompt_tokens="
                      << requests[i]->state().prompt_tokens.size()
                      << ", selected_instance=" << selected_instance;
-          fail_request_exceeding_decode_capacity(requests[i]);
+          fail_request_rejected_by_decode_capacity(requests[i]);
           continue;
         }
         // push back to prefill_request_queue_
@@ -1958,13 +1958,13 @@ void PDOOCScheduler::dispatch_offline_requests() {
     // Check response and handle accordingly
     const bool prompt_too_long =
         !cntl.Failed() && !resps.resps().empty() &&
-        decode_add_new_failure_is_terminal(resps.resps()[0].status_code());
+        is_decode_add_request_failure_terminal(resps.resps()[0].status_code());
     if (prompt_too_long) {
       LOG(ERROR) << "Decode rejected an oversized offline prompt, request_id="
                  << request->request_id()
                  << ", prompt_tokens=" << request->state().prompt_tokens.size()
                  << ", target_instance=" << target_instance;
-      fail_request_exceeding_decode_capacity(request);
+      fail_request_rejected_by_decode_capacity(request);
       continue;
     }
     if (cntl.Failed() || resps.resps().empty() ||


### PR DESCRIPTION
- Mark only permanently oversized Decode allocations as terminal.
- Propagate the terminal result to Prefill and OOC while preserving transient retries.
- Cover the capacity boundary and host-offload cases.

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
