### PR TITLE
fix: prefer top-level config.json for backend detection.

### DIFF
--- a/xllm/core/util/utils.h
+++ b/xllm/core/util/utils.h
@@ -227,7 +227,8 @@ inline std::string get_model_repository_name(
 
 inline std::string get_model_backend(const std::filesystem::path& model_path) {
   JsonReader reader;
-  std::filesystem::path model_index_json_path = model_path / "model_index.json";
+  const std::filesystem::path model_index_json_path =
+      model_path / "model_index.json";
 
   if (std::filesystem::exists(model_index_json_path)) {
     reader.parse(model_index_json_path);
@@ -243,6 +244,21 @@ inline std::string get_model_backend(const std::filesystem::path& model_path) {
                << model_path << ", it should contain _diffusers_version key.";
   }
 
+  // Resolve from the top-level config.json first when it is present. This
+  // short-circuits DiT sub-directory discovery for LLM/VLM/REC models whose
+  // sibling folders (e.g. MTP draft weights) contain their own config.json
+  // and safetensors, which would otherwise be mis-detected as DiT components.
+  const std::filesystem::path config_json_path = model_path / "config.json";
+  if (std::filesystem::exists(config_json_path)) {
+    const std::string resolved_backend =
+        ModelRegistry::get_model_backend(get_model_type(model_path));
+    if (!resolved_backend.empty()) {
+      return resolved_backend;
+    }
+    // model_type is not registered; fall through to component discovery below
+    // to support legacy layouts that only expose component-level metadata.
+  }
+
   // Component-subdirectory layout (e.g. Cola-DLM with cola_dit/cola_vae).
   if (auto components = discover_dit_components(model_path)) {
     if (!components->empty()) {
@@ -250,6 +266,8 @@ inline std::string get_model_backend(const std::filesystem::path& model_path) {
     }
   }
 
+  // No top-level config.json and no DiT components; get_model_type will
+  // LOG(FATAL) if it cannot resolve a model_type from the path.
   return ModelRegistry::get_model_backend(get_model_type(model_path));
 }
 


### PR DESCRIPTION
## Summary

`get_model_backend()` in `xllm/core/util/utils.h` currently probes DiT sub-directory discovery before consulting the top-level `config.json`. This mis-classifies non-DiT models whose directory layout happens to contain a sibling folder holding its own `config.json` + `.safetensors` — for example DeepSeek MTP draft weights sitting next to the main weights.

This PR short-circuits DiT component discovery when the top-level `config.json` exists and its `model_type` is already registered in `ModelRegistry` (any of `llm` / `vlm` / `rec` / a registered DiT type). Only when the top-level `config.json` is absent, or its `model_type` is unregistered, do we fall back to `discover_dit_components` — preserving the Cola-DLM layout that relies on component sub-directories.

## Repro

```
/model/root/
├── config.json               (model_type: deepseek_v3)
├── *.safetensors             (main weights)
└── DeepSeek-V32-w8a8-mtp/    (draft weights, sibling folder)
    ├── config.json
    └── *.safetensors
```

Before this fix, `discover_dit_components` picks up the MTP subfolder as a DiT component, `get_model_backend` returns `"dit"`, and `master.cpp` creates a DiT master. With `cfg × tp × sp × dp = 1 × 1 × 1 × 1 = 1 ≠ world_size = 16`, `dit_mapping.cpp:84` `CHECK` fails at startup.

After this fix the top-level `config.json` is consulted first, `ModelRegistry` returns `llm` for `deepseek_v3`, and the DiT scan is skipped.

## Behavior matrix

| model layout | before | after |
|---|---|---|
| LLM/VLM/REC with sibling weight sub-dir (e.g. MTP) | dit (wrong) | llm/vlm/rec (correct) |
| Pure LLM/VLM/REC with weights only at top level | llm/vlm/rec | llm/vlm/rec |
| Diffusers DiT with `model_index.json` | dit | dit |
| Cola-DLM component layout (no top-level `config.json`) | dit | dit |
| Model whose `model_type` is unregistered | dit (via discover) | dit (via discover) |

## Test plan

- [ ] Start a DeepSeek MTP model with `--backend` unset — launches as llm, no fatal on DiT world-size check.
- [ ] Start a diffusers DiT (`model_index.json` present) — still routed as dit.
- [ ] Start a Cola-DLM style model with only component sub-dirs — still routed as dit.
- [ ] Existing plain-LLM start path unchanged.