### PR TITLE
refactor: reuse stream record-or-sync helper.

### DIFF
--- a/xllm/core/runtime/dflash_worker_impl.cpp
+++ b/xllm/core/runtime/dflash_worker_impl.cpp
@@ -124,11 +124,7 @@ void clear_all_output_embeddings(ForwardOutput& output) {
 }
 
 void record_metadata_ready_event(Stream& stream, ForwardInput& input) {
-  StreamEventPtr event = stream.record_event();
-  if (event == nullptr) {
-    stream.synchronize();
-  }
-  input.metadata_ready_event = event;
+  input.metadata_ready_event = stream.record_event_or_sync();
 }
 
 void wait_metadata_ready_event(const ForwardInput& input, Stream& stream) {
@@ -1160,12 +1156,11 @@ void DFlashWorkerImpl::write_target_context_to_cache(
   // enforce cross-stream ordering: the write_context_kv scatter could launch
   // before index_select finishes, producing corrupt KV cache. The prefill
   // caller runs its producer on compute_stream_, so no event is needed there.
-  StreamEventPtr context_hidden_ready_event = prepare_stream_->record_event();
+  StreamEventPtr context_hidden_ready_event =
+      prepare_stream_->record_event_or_sync();
   if (context_hidden_ready_event != nullptr) {
     CHECK(compute_stream_->wait_event(context_hidden_ready_event))
         << "failed to wait DFlash context hidden ready event";
-  } else {
-    prepare_stream_->synchronize();
   }
   write_context_kv(
       input, context_hidden, positions_device, new_cache_slots_device);

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -173,11 +173,7 @@ KVCacheEstimateOptions make_kv_cache_estimate_options(
 }
 
 void record_metadata_ready_event(Stream& stream, ForwardInput& input) {
-  StreamEventPtr event = stream.record_event();
-  if (event == nullptr) {
-    stream.synchronize();
-  }
-  input.metadata_ready_event = event;
+  input.metadata_ready_event = stream.record_event_or_sync();
 }
 
 void finish_metadata_prepare(Stream& stream, ForwardInput& input) {


### PR DESCRIPTION
## Description

Reuse `Stream::record_event_or_sync()` in three speculative-runtime handoff paths:

- DFlash metadata readiness;
- MTP metadata readiness;
- DFlash context-hidden prepare-stream to compute-stream handoff.

These call sites previously duplicated the same sequence: attempt to record a stream event, synchronize the producing stream when event creation is unavailable, and retain the resulting event pointer. The shared helper implements that exact fallback, so this removes duplicate control flow without changing metadata ordering or cross-stream synchronization behavior.

A repository-wide audit of `record_event()` call sites found two remaining MTP fallback paths. They intentionally remain unchanged because they check the integer return value from `synchronize()` and attach operation-specific failure messages; replacing them with the current helper would weaken error handling. MLU layer synchronization also remains unchanged because it requires a real event and aborts when event recording fails.

Prepared with AI-assisted review; the final diff, repository-wide call-site audit, and branch history were verified locally.

## Related Issues

None.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Test Plan / Result

- `git diff --check upstream/main...HEAD` — passed.
- `pre-commit run --files xllm/core/runtime/dflash_worker_impl.cpp xllm/core/runtime/mtp_worker_impl.cpp` — passed (`clang-format`).
- Repository-wide `record_event()` / null-event / `synchronize()` pattern audit — completed; only the helper implementation and the two return-code-checking MTP exceptions remain.
- Build and runtime tests were not run; this is a three-call-site mechanical replacement with the existing helper.

## Pull Request Checklist

### PR Title and Commit Messages

- [x] The PR title and commit message follow the xLLM commit format: `<type>: <subject>`.

### Pre-commit Checks

- [x] The changed C++ files passed the configured pre-commit clang-format hook.
- [ ] `pre-commit run --all-files` was not run for this isolated mechanical refactor.

### Self Review

- [x] I self-reviewed every repository `record_event()` call site against the helper contract.
- [x] The branch is rebased onto upstream `main` at `71dd0acc`.

### Build and Test Coverage

- [ ] Tests were added or updated; no new behavior is introduced.
- [ ] CUDA build/test was not run.
- [ ] NPU build/test was not run.
- [ ] MLU build/test was not run.

## Reviewer Notes

Please verify the helper contract at the three changed call sites: a failed `record_event()` synchronizes the producer stream and returns a null event pointer; the downstream wait paths already treat a null event as a completed synchronous fallback.

Out of scope: changing `record_event_or_sync()` to expose or enforce the `synchronize()` return code. The two MTP paths that currently check that return value remain explicit.
