### PR TITLE
perf: add asynchronous host kv cache transfers.

### DIFF
--- a/tests/core/framework/kv_cache_transfer/kv_transfer_completion_test.cpp
+++ b/tests/core/framework/kv_cache_transfer/kv_transfer_completion_test.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include <chrono>
 #include <future>
+#include <memory>
 
 namespace xllm {
 namespace {
@@ -80,6 +81,44 @@ TEST(KVTransferCompletionTest, RejectsPendingTransferAtDestruction) {
         completion.add(promise.getSemiFuture());
       },
       "pending KV transfers");
+}
+
+TEST(KVTransferTrackerTest, WaitsForEveryTrackedTransfer) {
+  KVTransferTracker tracker;
+  std::shared_ptr<KVTransferTracker::Completion> first = tracker.track();
+  std::shared_ptr<KVTransferTracker::Completion> second = tracker.track();
+
+  std::promise<void> waiter_started;
+  std::future<void> started = waiter_started.get_future();
+  std::future<void> result = std::async(std::launch::async, [&]() {
+    waiter_started.set_value();
+    tracker.wait();
+  });
+
+  started.wait();
+  first.reset();
+  EXPECT_EQ(result.wait_for(50ms), std::future_status::timeout);
+  second.reset();
+  EXPECT_EQ(result.wait_for(1s), std::future_status::ready);
+}
+
+TEST(KVTransferTrackerTest, DestructionWaitsForTrackedTransfer) {
+  auto tracker = std::make_unique<KVTransferTracker>();
+  std::shared_ptr<KVTransferTracker::Completion> completion = tracker->track();
+
+  std::promise<void> destruction_started;
+  std::future<void> started = destruction_started.get_future();
+  std::future<void> result = std::async(
+      std::launch::async,
+      [tracker = std::move(tracker), &destruction_started]() mutable {
+        destruction_started.set_value();
+        tracker.reset();
+      });
+
+  started.wait();
+  EXPECT_EQ(result.wait_for(50ms), std::future_status::timeout);
+  completion.reset();
+  EXPECT_EQ(result.wait_for(1s), std::future_status::ready);
 }
 
 }  // namespace

--- a/tests/core/platform/mlu/mlu_batch_memcpy_test.cpp
+++ b/tests/core/platform/mlu/mlu_batch_memcpy_test.cpp
@@ -15,11 +15,16 @@ limitations under the License.
 
 #include "core/platform/mlu/mlu_batch_memcpy.h"
 
+#include <cnrt.h>
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <future>
 #include <memory>
+#include <thread>
 #include <vector>
 
 #include "core/framework/kv_cache/kv_cache_utils.h"
@@ -123,6 +128,48 @@ TEST_F(MLUBatchMemcpyTest, RoundTripSupportsDifferentTensorSizes) {
   for (size_t index = 0; index < widths.size(); ++index) {
     EXPECT_TRUE(torch::equal(sources[index], restored[index]));
   }
+}
+
+TEST_F(MLUBatchMemcpyTest, SubmitH2DReturnsBeforeCopyStreamCompletes) {
+  torch::Tensor host;
+  HostPageAlignedRegion host_region;
+  create_host_page_aligned_tensor({16}, torch::kUInt8, &host, &host_region);
+  host.fill_(23);
+  const torch::Tensor device_tensor = torch::zeros(
+      {16},
+      torch::TensorOptions().dtype(torch::kUInt8).device(device_->unwrap()));
+  ASSERT_EQ(device_->synchronize_default_stream(), 0);
+
+  std::atomic<bool> gate_open{false};
+  ASSERT_EQ(cnrtInvokeHostFunc(
+                stream_->get_stream()->stream(),
+                [](void* user_data) {
+                  std::atomic<bool>* gate =
+                      static_cast<std::atomic<bool>*>(user_data);
+                  while (!gate->load(std::memory_order_acquire)) {
+                    std::this_thread::yield();
+                  }
+                },
+                &gate_open),
+            cnrtSuccess);
+
+  std::future<bool> submit_result =
+      std::async(std::launch::async, [this, &host, &device_tensor]() {
+        device_->set_device();
+        device_->init_device_context();
+        return batch_memcpy_->submit_h2d(
+            {host}, {device_tensor}, stream_.get());
+      });
+  const std::future_status submit_status =
+      submit_result.wait_for(std::chrono::milliseconds(250));
+  gate_open.store(true, std::memory_order_release);
+
+  ASSERT_EQ(submit_result.wait_for(std::chrono::seconds(2)),
+            std::future_status::ready);
+  ASSERT_TRUE(submit_result.get());
+  ASSERT_EQ(stream_->synchronize(), 0);
+  EXPECT_EQ(submit_status, std::future_status::ready);
+  EXPECT_TRUE(torch::all(device_tensor.cpu() == 23).item<bool>());
 }
 
 TEST_F(MLUBatchMemcpyTest, RejectsInvalidInputs) {

--- a/xllm/core/framework/block/CMakeLists.txt
+++ b/xllm/core/framework/block/CMakeLists.txt
@@ -43,6 +43,7 @@ cc_library(
     :request
     :common
     :prefix_cache
+    :kv_transfer_completion
     glog::glog
     Boost::serialization
     SMHasherSupport

--- a/xllm/core/framework/block/hierarchy_block_manager_pool.cpp
+++ b/xllm/core/framework/block/hierarchy_block_manager_pool.cpp
@@ -15,6 +15,8 @@ limitations under the License.
 
 #include "hierarchy_block_manager_pool.h"
 
+#include <folly/executors/InlineExecutor.h>
+
 #include <algorithm>
 #include <iterator>
 #include <limits>
@@ -30,6 +32,31 @@ namespace xllm {
 namespace {
 
 using ProbeResult = CompositeBlockManager::ProbeResult;
+using HostLeafSnapshot = std::unordered_map<BlockType, BlockManager*>;
+
+void finalize_host_blocks(bool publish,
+                          std::vector<Block> host_blocks,
+                          const std::vector<BlockType>& block_types,
+                          const HostLeafSnapshot& host_leaves) {
+  CHECK_EQ(host_blocks.size(), block_types.size());
+  std::unordered_map<BlockType, std::vector<Block>> blocks_by_type;
+  for (size_t i = 0; i < host_blocks.size(); ++i) {
+    blocks_by_type[block_types[i]].emplace_back(std::move(host_blocks[i]));
+  }
+
+  for (auto& [type, blocks] : blocks_by_type) {
+    auto leaf = host_leaves.find(type);
+    if (leaf == host_leaves.end()) {
+      LOG(ERROR) << "Missing Host block manager for block type "
+                 << static_cast<int32_t>(type);
+      continue;
+    }
+    if (publish) {
+      leaf->second->cache(blocks);
+    }
+    leaf->second->deallocate(blocks);
+  }
+}
 
 // Wrap a leaf in the concurrency adapter when the D2H offload callback frees
 // blocks off-thread. Host-offload leaves always need this wrap.
@@ -776,18 +803,21 @@ void HierarchyBlockManagerPool::transfer_offload_blocks() {
     if (!transfer_infos.empty()) {
       // Capture per-leaf host manager pointers so the completion callback can
       // route each block to the correct host leaf on publish.
-      std::unordered_map<BlockType, BlockManager*> host_leaves_snapshot;
+      HostLeafSnapshot host_leaves_snapshot;
       for (const auto& [type, entry] : host_block_managers_[i]) {
         host_leaves_snapshot.emplace(type, entry.leaf.get());
       }
+      std::shared_ptr<KVTransferTracker::Completion> completion =
+          offload_transfers_.track();
       folly::collectAll(
           std::move(engine_->transfer_kv_blocks(i, std::move(transfer_infos))))
-          .via(folly::getGlobalCPUExecutor())
+          .via(&folly::InlineExecutor::instance())
           .thenValue([device_blocks = std::move(src_blocks),
                       host_blocks = std::move(dst_blocks),
                       block_types_vec = std::move(block_types),
                       device_block_mgr_ptr = block_managers_[i].get(),
-                      host_leaves = std::move(host_leaves_snapshot)](
+                      host_leaves = std::move(host_leaves_snapshot),
+                      completion = std::move(completion)](
                          std::vector<folly::Try<uint32_t>>&& results) mutable {
             bool copy_ok = true;
             for (auto&& result : results) {
@@ -808,50 +838,13 @@ void HierarchyBlockManagerPool::transfer_offload_blocks() {
             device_block_mgr_ptr->deallocate(device_blocks);
             device_blocks.clear();
 
-            if (copy_ok) {
-              // Group host blocks by type and cache/free them on the matching
-              // host leaf. Publishing per-type keeps a partial success from
-              // corrupting sibling leaves.
-              std::unordered_map<BlockType, std::vector<Block>> by_type;
-              for (size_t k = 0; k < host_blocks.size(); ++k) {
-                by_type[block_types_vec[k]].emplace_back(
-                    std::move(host_blocks[k]));
-              }
-              for (auto& [type, blocks] : by_type) {
-                auto it = host_leaves.find(type);
-                if (it == host_leaves.end()) {
-                  LOG(ERROR) << "Missing Host block manager for block type "
-                             << static_cast<int32_t>(type);
-                  blocks.clear();
-                  continue;
-                }
-                it->second->cache(blocks);
-                it->second->deallocate(blocks);
-                blocks.clear();
-              }
-              host_blocks.clear();
-            } else {
-              // Publish nothing on failure. Return all host ids to their
-              // owning leaf so no host slot leaks.
-              std::unordered_map<BlockType, std::vector<Block>> by_type;
-              for (size_t k = 0; k < host_blocks.size(); ++k) {
-                by_type[block_types_vec[k]].emplace_back(
-                    std::move(host_blocks[k]));
-              }
-              for (auto& [type, blocks] : by_type) {
-                auto it = host_leaves.find(type);
-                if (it == host_leaves.end()) {
-                  LOG(ERROR) << "Missing Host block manager for block type "
-                             << static_cast<int32_t>(type);
-                  blocks.clear();
-                  continue;
-                }
-                it->second->deallocate(blocks);
-                blocks.clear();
-              }
-              host_blocks.clear();
-            }
+            // Successful copies become visible in the Host prefix cache.
+            // Failures publish nothing, but both paths release every reserved
+            // Host id through the same type-aware ownership path.
+            finalize_host_blocks(
+                copy_ok, std::move(host_blocks), block_types_vec, host_leaves);
 
+            completion.reset();
             return 0;
           });
     }

--- a/xllm/core/framework/block/hierarchy_block_manager_pool.h
+++ b/xllm/core/framework/block/hierarchy_block_manager_pool.h
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include "block_manager_pool.h"
 #include "composite_block_manager.h"
+#include "core/framework/kv_cache_transfer/kv_transfer_completion.h"
 #include "distributed_runtime/engine.h"
 #include "util/blockingconcurrentqueue.h"
 
@@ -84,6 +85,10 @@ class HierarchyBlockManagerPool : public BlockManagerPool {
   // owned only by the Sequence's Host/device cache states.
   std::vector<std::vector<BlockTransferInfo>> load_block_transfer_infos_;
   std::vector<OffloadBlockPairQueue> offload_block_pair_queues_;
+
+  // Declared last so destruction waits for callbacks before any manager or
+  // block storage captured by those callbacks is released.
+  KVTransferTracker offload_transfers_;
 };
 
 }  // namespace xllm

--- a/xllm/core/framework/kv_cache_transfer/hierarchy_kv_cache_transfer.cpp
+++ b/xllm/core/framework/kv_cache_transfer/hierarchy_kv_cache_transfer.cpp
@@ -182,6 +182,25 @@ HierarchyKVCacheTransfer::HierarchyKVCacheTransfer(
   }
 }
 
+HierarchyKVCacheTransfer::~HierarchyKVCacheTransfer() {
+  // Joining the load pool first guarantees no producer can enqueue more work
+  // while the copy streams and host cache storage are being released.
+  load_threadpool_.reset();
+
+  device_.set_device();
+  std::unique_ptr<Stream> stream;
+  while (copy_stream_.try_dequeue(stream)) {
+    if (stream == nullptr) {
+      continue;
+    }
+    CHECK_EQ(stream->synchronize(), 0)
+        << "Failed to drain hierarchy KV copy stream during shutdown.";
+  }
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  layer_wise_load_synchronizer_.clear();
+}
+
 void HierarchyKVCacheTransfer::build_device_block_type_map() {
   device_kv_caches_.clear();
   device_block_type_layer_ids_.clear();
@@ -458,7 +477,7 @@ bool HierarchyKVCacheTransfer::load_from_host(
       }
       continue;
     }
-    if (!batch_memcpy_->copy_h2d(
+    if (!batch_memcpy_->submit_h2d(
             plan.src_tensors, plan.dst_tensors, stream.get())) {
       success = false;
       break;

--- a/xllm/core/framework/kv_cache_transfer/hierarchy_kv_cache_transfer.h
+++ b/xllm/core/framework/kv_cache_transfer/hierarchy_kv_cache_transfer.h
@@ -75,7 +75,7 @@ class HierarchyKVCacheTransfer {
                            std::vector<xllm::KVCache>* kv_caches_ptr,
                            const KVCacheShape& kv_cache_shape,
                            const KVCacheCreateOptions& create_options);
-  ~HierarchyKVCacheTransfer() = default;
+  ~HierarchyKVCacheTransfer();
 
   uint32_t transfer_kv_blocks(
       const uint64_t batch_id,

--- a/xllm/core/framework/kv_cache_transfer/kv_transfer_completion.cpp
+++ b/xllm/core/framework/kv_cache_transfer/kv_transfer_completion.cpp
@@ -19,6 +19,9 @@ limitations under the License.
 
 #include <algorithm>
 #include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <mutex>
 #include <utility>
 
 namespace xllm {
@@ -59,5 +62,50 @@ bool KVTransferCompletion::wait() {
         return result.hasValue() && result.value();
       });
 }
+
+class KVTransferTracker::State final {
+ public:
+  void start() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++pending_transfers_;
+  }
+
+  void finish() {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      CHECK_GT(pending_transfers_, 0u);
+      --pending_transfers_;
+    }
+    completion_cv_.notify_all();
+  }
+
+  void wait() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    completion_cv_.wait(lock, [this]() { return pending_transfers_ == 0; });
+  }
+
+ private:
+  std::mutex mutex_;
+  std::condition_variable completion_cv_;
+  size_t pending_transfers_ = 0;
+};
+
+KVTransferTracker::Completion::Completion(std::shared_ptr<State> state)
+    : state_(std::move(state)) {
+  CHECK(state_ != nullptr);
+  state_->start();
+}
+
+KVTransferTracker::Completion::~Completion() { state_->finish(); }
+
+KVTransferTracker::KVTransferTracker() : state_(std::make_shared<State>()) {}
+
+KVTransferTracker::~KVTransferTracker() { wait(); }
+
+std::shared_ptr<KVTransferTracker::Completion> KVTransferTracker::track() {
+  return std::shared_ptr<Completion>(new Completion(state_));
+}
+
+void KVTransferTracker::wait() { state_->wait(); }
 
 }  // namespace xllm

--- a/xllm/core/framework/kv_cache_transfer/kv_transfer_completion.h
+++ b/xllm/core/framework/kv_cache_transfer/kv_transfer_completion.h
@@ -18,6 +18,7 @@ limitations under the License.
 #include <folly/futures/Future.h>
 
 #include <chrono>
+#include <memory>
 #include <vector>
 
 namespace xllm {
@@ -44,6 +45,47 @@ class KVTransferCompletion final {
  private:
   std::chrono::milliseconds wait_timeout_;
   std::vector<folly::SemiFuture<bool>> futures_;
+};
+
+// Tracks callbacks that retain KV block managers or blocks. A Completion
+// token keeps one callback pending; releasing the last token unblocks wait().
+// Destruction waits so owners can declare this as their last member and make
+// callback lifetime a construction invariant instead of custom teardown code.
+class KVTransferTracker final {
+ private:
+  class State;
+
+ public:
+  class Completion final {
+   public:
+    ~Completion();
+
+    Completion(const Completion&) = delete;
+    Completion& operator=(const Completion&) = delete;
+    Completion(Completion&&) = delete;
+    Completion& operator=(Completion&&) = delete;
+
+   private:
+    friend class KVTransferTracker;
+
+    explicit Completion(std::shared_ptr<State> state);
+
+    std::shared_ptr<State> state_;
+  };
+
+  KVTransferTracker();
+  ~KVTransferTracker();
+
+  KVTransferTracker(const KVTransferTracker&) = delete;
+  KVTransferTracker& operator=(const KVTransferTracker&) = delete;
+  KVTransferTracker(KVTransferTracker&&) = delete;
+  KVTransferTracker& operator=(KVTransferTracker&&) = delete;
+
+  std::shared_ptr<Completion> track();
+  void wait();
+
+ private:
+  std::shared_ptr<State> state_;
 };
 
 }  // namespace xllm

--- a/xllm/core/platform/batch_memcpy.h
+++ b/xllm/core/platform/batch_memcpy.h
@@ -37,6 +37,14 @@ class BatchMemcpy {
                         const std::vector<torch::Tensor>& dst_tensors,
                         Stream* stream) = 0;
 
+  // Submits H2D copies without waiting for stream completion. Backends that
+  // do not support non-blocking submission keep the synchronous contract.
+  virtual bool submit_h2d(const std::vector<torch::Tensor>& src_tensors,
+                          const std::vector<torch::Tensor>& dst_tensors,
+                          Stream* stream) {
+    return copy_h2d(src_tensors, dst_tensors, stream);
+  }
+
   virtual bool copy_d2h(const std::vector<torch::Tensor>& src_tensors,
                         const std::vector<torch::Tensor>& dst_tensors,
                         Stream* stream) = 0;

--- a/xllm/core/platform/mlu/mlu_batch_memcpy.cpp
+++ b/xllm/core/platform/mlu/mlu_batch_memcpy.cpp
@@ -52,13 +52,31 @@ void MLUBatchMemcpy::init(int32_t device_id) {
 bool MLUBatchMemcpy::copy_h2d(const std::vector<torch::Tensor>& src_tensors,
                               const std::vector<torch::Tensor>& dst_tensors,
                               Stream* stream) {
-  return copy(src_tensors, dst_tensors, stream, Direction::H2D);
+  return copy(src_tensors,
+              dst_tensors,
+              stream,
+              Direction::H2D,
+              CompletionMode::SYNCHRONIZE);
+}
+
+bool MLUBatchMemcpy::submit_h2d(const std::vector<torch::Tensor>& src_tensors,
+                                const std::vector<torch::Tensor>& dst_tensors,
+                                Stream* stream) {
+  return copy(src_tensors,
+              dst_tensors,
+              stream,
+              Direction::H2D,
+              CompletionMode::SUBMIT_ONLY);
 }
 
 bool MLUBatchMemcpy::copy_d2h(const std::vector<torch::Tensor>& src_tensors,
                               const std::vector<torch::Tensor>& dst_tensors,
                               Stream* stream) {
-  return copy(src_tensors, dst_tensors, stream, Direction::D2H);
+  return copy(src_tensors,
+              dst_tensors,
+              stream,
+              Direction::D2H,
+              CompletionMode::SYNCHRONIZE);
 }
 
 bool MLUBatchMemcpy::valid_inputs(const std::vector<torch::Tensor>& src_tensors,
@@ -129,7 +147,8 @@ bool MLUBatchMemcpy::valid_inputs(const std::vector<torch::Tensor>& src_tensors,
 bool MLUBatchMemcpy::copy(const std::vector<torch::Tensor>& src_tensors,
                           const std::vector<torch::Tensor>& dst_tensors,
                           Stream* stream,
-                          Direction direction) {
+                          Direction direction,
+                          CompletionMode completion_mode) {
   try {
     if (!valid_inputs(src_tensors, dst_tensors, stream, direction)) {
       return false;
@@ -186,7 +205,6 @@ bool MLUBatchMemcpy::copy(const std::vector<torch::Tensor>& src_tensors,
       }
     }
 
-    const CNresult sync_result = cnQueueSync(queue);
     if (!submitted) {
       LOG(ERROR) << "MLU batch memcpy " << direction_name(h2d)
                  << " submission failed: chunk_offset=" << failed_offset
@@ -194,13 +212,18 @@ bool MLUBatchMemcpy::copy(const std::vector<torch::Tensor>& src_tensors,
                  << ", result=" << static_cast<int32_t>(submit_result)
                  << ", error=" << cn_error_text(submit_result);
     }
+    if (!submitted || completion_mode == CompletionMode::SUBMIT_ONLY) {
+      return submitted;
+    }
+
+    const CNresult sync_result = cnQueueSync(queue);
     if (sync_result != CN_SUCCESS) {
       LOG(ERROR) << "MLU batch memcpy " << direction_name(h2d)
                  << " queue sync failed: chunk_offset=0, chunk_count=" << count
                  << ", result=" << static_cast<int32_t>(sync_result)
                  << ", error=" << cn_error_text(sync_result);
     }
-    return submitted && sync_result == CN_SUCCESS;
+    return sync_result == CN_SUCCESS;
   } catch (const std::exception& error) {
     LOG(ERROR) << "MLU batch memcpy "
                << direction_name(direction == Direction::H2D)

--- a/xllm/core/platform/mlu/mlu_batch_memcpy.h
+++ b/xllm/core/platform/mlu/mlu_batch_memcpy.h
@@ -37,19 +37,25 @@ class MLUBatchMemcpy final : public BatchMemcpy {
                 const std::vector<torch::Tensor>& dst_tensors,
                 Stream* stream) override;
 
+  bool submit_h2d(const std::vector<torch::Tensor>& src_tensors,
+                  const std::vector<torch::Tensor>& dst_tensors,
+                  Stream* stream) override;
+
   bool copy_d2h(const std::vector<torch::Tensor>& src_tensors,
                 const std::vector<torch::Tensor>& dst_tensors,
                 Stream* stream) override;
 
  private:
   enum class Direction : int8_t { H2D = 0, D2H = 1 };
+  enum class CompletionMode : int8_t { SYNCHRONIZE = 0, SUBMIT_ONLY = 1 };
 
   static constexpr size_t kMaxBatchCopyCount = 4096;
 
   bool copy(const std::vector<torch::Tensor>& src_tensors,
             const std::vector<torch::Tensor>& dst_tensors,
             Stream* stream,
-            Direction direction);
+            Direction direction,
+            CompletionMode completion_mode);
   bool valid_inputs(const std::vector<torch::Tensor>& src_tensors,
                     const std::vector<torch::Tensor>& dst_tensors,
                     const Stream* stream,


### PR DESCRIPTION
- submit MLU H2D copies without stream-wide synchronization
- preserve layer-ready ordering and drain copy streams at shutdown
- track asynchronous offload callbacks with reusable RAII lifetime state

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
