### PR TITLE
perf: drop multimodal mrope handling on npu decode path.

### DIFF
--- a/xllm/core/runtime/acl_graph_persistent_param.cpp
+++ b/xllm/core/runtime/acl_graph_persistent_param.cpp
@@ -205,9 +205,6 @@ GraphPersistentParam::GraphPersistentParam(const ModelArgs& args,
        !util::is_deepseek_v4_model_type(args.model_type()) &&
        args.model_type() != "glm_moe_dsa" && !supports_mla_graph_kv_bucketing_);
 
-  // Check if mRoPE is used (for VLM models like qwen2-vl)
-  use_mrope_ = !args.rope_scaling_mrope_section().empty();
-
   const int64_t max_tokens_per_batch = options.max_tokens_per_batch();
   // Graph-mode token capacity is narrower than max_tokens_per_batch: ACL graph
   // only serves decode / spec-verify batches, so the relevant row upper bound
@@ -224,14 +221,8 @@ GraphPersistentParam::GraphPersistentParam(const ModelArgs& args,
   // Create persistent tensors with max_tokens_per_batch as first dimension
   persistent_tokens_ = torch::zeros({max_tokens_per_batch},
                                     torch::dtype(torch::kInt).device(device));
-  if (args.rope_scaling_mrope_section().empty()) {
-    persistent_positions_ = torch::zeros(
-        {max_tokens_per_batch}, torch::dtype(torch::kInt).device(device));
-  } else {
-    persistent_positions_ = torch::zeros(
-        {3, max_tokens_per_batch}, torch::dtype(torch::kInt).device(device));
-    use_mrope_ = true;
-  }
+  persistent_positions_ = torch::zeros(
+      {max_tokens_per_batch}, torch::dtype(torch::kInt).device(device));
   persistent_new_cache_slots_ = torch::zeros(
       {max_tokens_per_batch}, torch::dtype(torch::kInt).device(device));
   persistent_new_cache_slots_default_ = torch::zeros(
@@ -802,15 +793,7 @@ void GraphPersistentParam::update_spec_verify_inputs(
   CHECK_LE(block_table_len, persistent_block_tables_.size(1));
   CHECK_LE(expanded_block_table_len, persistent_expanded_block_tables_.size(1));
 
-  if (use_mrope_) {
-    // Hybrid mRoPE models store graph positions as [3, max_tokens]. The MTP
-    // worker supplies the compact [num_tokens] position vector, matching the
-    // normal persistent update path where copy_ broadcasts it across the mRoPE
-    // rows.
-    persistent_positions_.narrow(1, 0, total_tokens).copy_(positions, true);
-  } else {
-    persistent_positions_.narrow(0, 0, total_tokens).copy_(positions, true);
-  }
+  persistent_positions_.narrow(0, 0, total_tokens).copy_(positions, true);
   q_seq_lens_.narrow(0, 0, batch_size)
       .copy_(attention.q_seq_lens.narrow(0, 0, batch_size), true);
   kv_seq_lens_.narrow(0, 0, batch_size)
@@ -889,23 +872,16 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
   if (!skip_token_update) {
     update_tokens(tokens, params, actual_num_tokens, padded_num_tokens);
   }
-  // mRoPE positions have shape [3, num_tokens], slice on dim 1
   if (actual_num_tokens > 0) {
-    if (use_mrope_) {
-      persistent_positions_
-          .slice(/*dim=*/1, /*start=*/0, /*end=*/actual_num_tokens)
-          .copy_(positions, /*non_blocking=*/true);
-    } else {
-      persistent_positions_
-          .slice(/*dim=*/0, /*start=*/0, /*end=*/actual_num_tokens)
-          .copy_(positions, /*non_blocking=*/true);
-    }
+    persistent_positions_
+        .slice(/*dim=*/0, /*start=*/0, /*end=*/actual_num_tokens)
+        .copy_(positions, /*non_blocking=*/true);
   }
   if (padded_num_tokens > actual_num_tokens) {
     zero_tensor_tail(persistent_positions_,
                      actual_num_tokens,
                      static_cast<int64_t>(padded_num_tokens),
-                     use_mrope_ ? 1 : 0);
+                     /*dim=*/0);
   }
   update_eplb_decode_token_mask(params, padded_num_tokens);
   if (q_seq_lens_default_.defined() &&

--- a/xllm/core/runtime/acl_graph_persistent_param.h
+++ b/xllm/core/runtime/acl_graph_persistent_param.h
@@ -112,11 +112,8 @@ class GraphPersistentParam final {
   }
   torch::Tensor persistent_positions(uint32_t actual_tokens = 0) const {
     if (actual_tokens > 0) {
-      int32_t slice_dim = use_mrope_ ? 1 : 0;
-      return persistent_positions_
-          .slice(
-              /*dim=*/slice_dim, /*start=*/0, /*end=*/actual_tokens)
-          .contiguous();
+      return persistent_positions_.slice(
+          /*dim=*/0, /*start=*/0, /*end=*/actual_tokens);
     }
     return persistent_positions_;
   }
@@ -305,9 +302,7 @@ class GraphPersistentParam final {
   torch::Tensor persistent_linear_state_indices_;
   torch::Tensor persistent_num_accepted_tokens_;
 
-  // for mrope (multimodal rotary position embedding)
-  bool use_mrope_ = false;
-
+  // ModelOutput fields
   torch::Tensor aux_hidden_states_;
 
   // ATB context and operation for paged attention plan

--- a/xllm/core/runtime/vlm_executor_impl.cpp
+++ b/xllm/core/runtime/vlm_executor_impl.cpp
@@ -90,11 +90,18 @@ ModelOutput VlmExecutorImpl::run(const torch::Tensor& tokens,
   params.embedding.input_embedding =
       model_->get_input_embeddings(tokens, params);
 
-  if (llm_executor_) {
-    return llm_executor_->run(tokens, positions, kv_caches, params);
+  // Decode mRoPE positions degenerate to identical rows; collapse to 1-D so
+  // decode runs ordinary rope. Prefill keeps the real [3, num_tokens] rows.
+  torch::Tensor fwd_positions = positions;
+  if (params.meta.batch_forward_type.is_decode()) {
+    fwd_positions = positions[0].contiguous();
   }
 
-  return model_->forward(tokens, positions, kv_caches, params);
+  if (llm_executor_) {
+    return llm_executor_->run(tokens, fwd_positions, kv_caches, params);
+  }
+
+  return model_->forward(tokens, fwd_positions, kv_caches, params);
 }
 
 }  // namespace xllm


### PR DESCRIPTION
## Description

drop multimodal mrope handling on npu decode path.

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
