### PR TITLE
refactor: extract AuxHiddenCapture for spec draft hidden states.

### DIFF
--- a/xllm/core/framework/model/CMakeLists.txt
+++ b/xllm/core/framework/model/CMakeLists.txt
@@ -8,6 +8,7 @@ cc_library(
     rec_causal_lm.h
     causal_vlm.h
     dit_model.h
+    aux_hidden_capture.h
     model_args.h
     model_input_params.h
     mtp_topk_state.h

--- a/xllm/core/framework/model/aux_hidden_capture.h
+++ b/xllm/core/framework/model/aux_hidden_capture.h
@@ -1,0 +1,100 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <glog/logging.h>
+#include <torch/torch.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include "core/framework/model/model_args.h"
+#include "core/framework/model/model_output.h"
+
+namespace xllm {
+
+// Buffers the residual stream of selected layers into a
+// [tokens, hidden * num_captured] tensor for a spec draft (Eagle3,
+// DFlash/DSpark) to consume. A non-empty layers_to_capture is the sole capture
+// signal.
+class AuxHiddenCapture final {
+ public:
+  void init(const ModelArgs& model_args,
+            const torch::TensorOptions& options,
+            int64_t max_tokens_per_batch) {
+    if (model_args.layers_to_capture().empty()) {
+      return;
+    }
+    layers_to_capture_ = model_args.layers_to_capture();
+    const int64_t num_captured =
+        static_cast<int64_t>(layers_to_capture_.size());
+    const int64_t aux_dim = model_args.hidden_size() * num_captured;
+    buffer_ = torch::empty({max_tokens_per_batch, aux_dim}, options);
+  }
+
+  // Pass residual when the caller keeps `h` and residual as separate tensors
+  // (intralayer add-norm); pass std::nullopt when `h` already carries the sum.
+  void capture_layer(int32_t layer_idx,
+                     const torch::Tensor& h,
+                     const std::optional<torch::Tensor>& residual) {
+    if (layers_to_capture_.empty() ||
+        std::find(layers_to_capture_.begin(),
+                  layers_to_capture_.end(),
+                  layer_idx) == layers_to_capture_.end()) {
+      return;
+    }
+    const int64_t num_tokens = h.size(0);
+    const int64_t hidden_size = h.size(-1);
+    // add_out fuses the residual add into the preallocated slice, avoiding a
+    // fresh [tokens, hidden] sum tensor per captured layer.
+    torch::Tensor slot = buffer_.slice(0, 0, num_tokens)
+                             .slice(1,
+                                    capture_idx_ * hidden_size,
+                                    (capture_idx_ + 1) * hidden_size);
+    torch::Tensor h_2d = h.reshape({num_tokens, hidden_size});
+    if (residual.has_value()) {
+      torch::add_out(
+          slot, h_2d, residual.value().reshape({num_tokens, hidden_size}));
+    } else {
+      slot.copy_(h_2d);
+    }
+    capture_idx_++;
+  }
+
+  // Call before each forward's layer loop so capture_layer() refills from
+  // column 0.
+  void reset_capture_index() { capture_idx_ = 0; }
+
+  ModelOutput finalize(const torch::Tensor& hidden_states) const {
+    if (layers_to_capture_.empty()) {
+      return ModelOutput(hidden_states);
+    }
+    CHECK_EQ(capture_idx_, static_cast<int64_t>(layers_to_capture_.size()))
+        << "Captured aux hidden layer count mismatch.";
+    torch::Tensor aux = buffer_.slice(0, 0, hidden_states.size(0));
+    return ModelOutput(hidden_states, torch::Tensor(), aux);
+  }
+
+ private:
+  // Layer ids to capture; non-empty iff capture is enabled.
+  std::vector<int32_t> layers_to_capture_;
+  torch::Tensor buffer_;
+  int64_t capture_idx_ = 0;
+};
+
+}  // namespace xllm

--- a/xllm/core/framework/model/model_args.h
+++ b/xllm/core/framework/model/model_args.h
@@ -436,7 +436,7 @@ struct ModelArgs {
   // number of speculative decoding tokens
   PROPERTY(int64_t, num_speculative_tokens) = 0;
 
-  // Eagle3: layer indices (0-based) to capture aux hidden states, from config
+  // Layer indices whose residual streams feed a speculative draft.
   PROPERTY(std::vector<int32_t>, layers_to_capture) = {};
 
   // VAE related args

--- a/xllm/core/runtime/dflash_worker_impl.cpp
+++ b/xllm/core/runtime/dflash_worker_impl.cpp
@@ -367,13 +367,15 @@ bool DFlashWorkerImpl::init_model(const std::string& model_weights_path,
     CHECK_LT(mask_token_id_, draft_vocab_size)
         << "Block-diffusion mask_token_id (" << mask_token_id_
         << ") must be < draft vocab_size (" << draft_vocab_size << ").";
+    // Context hidden comes from the target.
+    const ModelArgs& target_args = impl_->context_.get_model_args();
     const int64_t num_target_layers =
-        static_cast<int64_t>(draft_args.layers_to_capture().size());
+        static_cast<int64_t>(target_args.layers_to_capture().size());
     CHECK_GT(num_target_layers, 0)
         << "Block-diffusion draft config requires target_layer_ids or "
            "dflash_config.target_layer_ids.";
     expected_context_hidden_size_ =
-        static_cast<int64_t>(draft_args.hidden_size()) * num_target_layers;
+        static_cast<int64_t>(target_args.hidden_size()) * num_target_layers;
   }
   return result;
 }

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -143,17 +143,13 @@ class ScopedAtenLoadThreads {
   bool active_ = false;
 };
 
-// DFlash draft config lists target_layer_ids as the target-model layer indices
-// (0-based) whose output the draft consumes. xLLM's capture hook fires BEFORE
-// layer i runs, so capturing layer L's output means putting L+1 in the capture
-// set (matched against layer index i in the forward loop). Returns those L+1
-// ids.
-std::vector<int32_t> read_dflash_capture_layer_ids(
+// Hooks run before a layer, so output layer L is captured at L + 1.
+std::vector<int32_t> read_capture_layer_ids(
     const std::string& model_weights_path) {
   JsonReader reader;
   const std::string config_path = model_weights_path + "/config.json";
   CHECK(reader.parse(config_path))
-      << "Failed to parse DFlash config: " << config_path;
+      << "Failed to parse block-diffusion draft config: " << config_path;
   std::vector<int32_t> capture_layer_ids;
   for (int32_t layer_id : reader.value_or<std::vector<int32_t>>(
            std::vector<std::string>{"target_layer_ids",
@@ -161,6 +157,10 @@ std::vector<int32_t> read_dflash_capture_layer_ids(
            std::vector<int32_t>{})) {
     capture_layer_ids.emplace_back(layer_id + 1);
   }
+  CHECK(!capture_layer_ids.empty())
+      << "Block-diffusion draft config requires target_layer_ids or "
+         "dflash_config.target_layer_ids: "
+      << config_path;
   return capture_layer_ids;
 }
 
@@ -1456,28 +1456,20 @@ bool WorkerImpl::init_model(const std::string& model_weights_path,
   }
   if (options_.speculative_algorithm() == "DFlash" ||
       options_.speculative_algorithm() == "DSpark") {
-    // DSpark is a DFlash variant: same target-layer capture and draft-body
-    // swap, just a different draft model_type ("DSparkDraftModel") carrying the
-    // extra Markov head. Both engines capture the same target layers, whose ids
-    // live in the draft config: the draft engine reads its own weights path,
-    // the target engine reads --draft_model. The draft engine additionally
-    // swaps in the DFlash/DSpark draft body.
     const bool is_dspark = options_.speculative_algorithm() == "DSpark";
     const char* draft_model_type =
         is_dspark ? "DSparkDraftModel" : "DFlashDraftModel";
-    std::string draft_config_path;
     if (options_.is_draft_engine()) {
       LOG(INFO) << "Overriding draft model_type from " << args.model_type()
                 << " to " << draft_model_type
                 << " for block-diffusion speculative decoding";
       args.model_type(draft_model_type);
-      draft_config_path = model_weights_path_;
     } else {
       CHECK(options_.draft_model_path().has_value())
           << "block-diffusion speculative decoding requires --draft_model.";
-      draft_config_path = options_.draft_model_path().value();
+      args.layers_to_capture(
+          read_capture_layer_ids(options_.draft_model_path().value()));
     }
-    args.layers_to_capture(read_dflash_capture_layer_ids(draft_config_path));
   } else if (options_.enable_speculative_decode() &&
              ::xllm::SpeculativeConfig::get_instance()
                  .enable_atb_spec_kernel()) {
@@ -1502,17 +1494,8 @@ bool WorkerImpl::init_model(const std::string& model_weights_path,
       args.full_attention_interval(1);
     }
   }
-  // Eagle3/DFlash targets capture intermediate-layer aux hidden from the layers
-  // in layers_to_capture, the model's sole capture signal. Fill the default
-  // {2, n/2, n-3} for an Eagle3 target whose config omits the list; DFlash
-  // already filled it from the draft config. The DFlash/DSpark draft body
-  // (DFlashDraftModel/DSparkDraftModel) consumes context-KV rather than
-  // capturing, so exclude it.
-  if (options_.enable_speculative_decode() &&
-      SpeculativeConfig::requires_aux_hidden_capture(
-          options_.speculative_algorithm()) &&
-      args.model_type() != "DFlashDraftModel" &&
-      args.model_type() != "DSparkDraftModel" &&
+  if (options_.enable_speculative_decode() && !options_.is_draft_engine() &&
+      SpeculativeConfig::requires_aux_hidden_capture(speculative_algorithm) &&
       args.layers_to_capture().empty()) {
     const int32_t num_layers = static_cast<int32_t>(args.n_layers());
     args.layers_to_capture({2, num_layers / 2, num_layers - 3});

--- a/xllm/models/llm/npu/qwen3.h
+++ b/xllm/models/llm/npu/qwen3.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include "core/common/global_flags.h"
 #include "core/framework/config/kernel_config.h"
 #include "core/framework/config/scheduler_config.h"
+#include "core/framework/model/aux_hidden_capture.h"
 #include "core/framework/model/model_output.h"
 #include "core/layers/npu/npu_qwen3_decoder_layer_impl.h"
 #include "llm_model_base.h"
@@ -80,37 +81,10 @@ class QWen3ModelImpl : public LlmModelImplBase<QWen3DecoderLayer> {
       blocks_->push_back(block);
     }
 
-    // Eagle3/DFlash/DSpark target captures intermediate-layer aux hidden states
-    // to drive the draft. The block-diffusion draft keeps layers_to_capture to
-    // size its context projection, but must not capture its own hidden states.
-    const bool is_block_diffusion_draft_model =
-        model_args.model_type() == "DFlashDraftModel" ||
-        model_args.model_type() == "DSparkDraftModel";
-    const auto& layer_ids_from_config = model_args.layers_to_capture();
-    const bool enable_aux_hidden_capture =
-        !is_block_diffusion_draft_model && !layer_ids_from_config.empty();
-    if (enable_aux_hidden_capture) {
-      set_aux_hidden_capture_layers(layer_ids_from_config);
-      // Pre-allocate aux output buffer [max_tokens_per_batch, hidden_size *
-      // num_captured]
-      const int64_t num_captured = layers_to_capture_set_.size();
-      const int64_t aux_dim = model_args.hidden_size() * num_captured;
-      aux_output_buffer_ = torch::empty(
-          {::xllm::SchedulerConfig::get_instance().max_tokens_per_batch(),
-           aux_dim},
-          options);
-    }
-  }
-
-  void set_aux_hidden_capture_layers(const std::vector<int32_t>& layer_ids) {
-    capture_aux_hidden_states_ = true;
-    layers_to_capture_set_.clear();
-    // Config uses 0-based layer indices.
-    for (int32_t val : layer_ids) {
-      layers_to_capture_set_.insert(val);
-    }
-    LOG(INFO) << "layers_to_capture_set_ size: "
-              << layers_to_capture_set_.size();
+    aux_capture_.init(
+        model_args,
+        options,
+        ::xllm::SchedulerConfig::get_instance().max_tokens_per_batch());
   }
 
   virtual ModelOutput forward(torch::Tensor tokens,
@@ -213,9 +187,7 @@ class QWen3ModelImpl : public LlmModelImplBase<QWen3DecoderLayer> {
 
     ModelInputParams& input_params_new =
         const_cast<ModelInputParams&>(input_params);
-    const int64_t num_tokens = h.size(0);
-    const int64_t hidden_size = h.size(-1);
-    int64_t capture_idx = 0;
+    aux_capture_.reset_capture_index();
     RollingLayerGuard rolling_guard(rolling_mgr_);
     for (size_t i = 0; i < layers_.size(); i++) {
       aclrtEvent* event{nullptr};
@@ -232,14 +204,8 @@ class QWen3ModelImpl : public LlmModelImplBase<QWen3DecoderLayer> {
 
       auto& layer = layers_[i];
       const int32_t layer_index = i;
-      if (capture_aux_hidden_states_ &&
-          layers_to_capture_set_.count(layer_index) != 0) {
-        aux_output_buffer_.slice(0, 0, num_tokens)
-            .slice(
-                1, capture_idx * hidden_size, (capture_idx + 1) * hidden_size)
-            .copy_(h.reshape({num_tokens, hidden_size}));
-        capture_idx++;
-      }
+      // ATB keeps `h` as the full residual stream, so no separate residual.
+      aux_capture_.capture_layer(layer_index, h, std::nullopt);
 
       if (layer_forward_interrupted_) {
         LOG(INFO) << "Forward interrupted at layer: " << i;
@@ -264,14 +230,7 @@ class QWen3ModelImpl : public LlmModelImplBase<QWen3DecoderLayer> {
       }
     }
     auto hidden_states = norm_(h, 0);
-    if (capture_aux_hidden_states_) {
-      CHECK_EQ(capture_idx, static_cast<int64_t>(layers_to_capture_set_.size()))
-          << "Captured aux hidden layer count mismatch.";
-      torch::Tensor aux_hidden_states =
-          aux_output_buffer_.slice(0, 0, num_tokens);
-      return ModelOutput(hidden_states, torch::Tensor(), aux_hidden_states);
-    }
-    return ModelOutput(hidden_states);
+    return aux_capture_.finalize(hidden_states);
   }
 
  protected:
@@ -285,9 +244,7 @@ class QWen3ModelImpl : public LlmModelImplBase<QWen3DecoderLayer> {
 
  private:
   torch::Tensor viusal_pos_mask_;
-  std::unordered_set<int32_t> layers_to_capture_set_;
-  bool capture_aux_hidden_states_ = false;
-  torch::Tensor aux_output_buffer_;
+  AuxHiddenCapture aux_capture_;
 };
 TORCH_MODULE(QWen3Model);
 
@@ -333,10 +290,6 @@ REGISTER_MODEL_ARGS_WITH_VARNAME(qwen3_atb, qwen3_atb, [&] {
 
   LOAD_ARG_OR(use_sliding_window, "use_sliding_window", false);
   LOAD_ARG_OR(max_window_layers, "max_window_layers", 28);
-
-  // Eagle3: layer ids (0-based) to capture from config, e.g.
-  // "layers_to_capture": [2, 14, 25]; defaults to empty if missing
-  LOAD_ARG_OR(layers_to_capture, "layers_to_capture", std::vector<int32_t>{});
 
   // DSpark: low-rank dim of the Markov head (top-level config key, like vLLM's
   // config.markov_rank). 0 = disabled (plain DFlash / non-DSpark models).

--- a/xllm/models/llm/npu/qwen3_dflash.h
+++ b/xllm/models/llm/npu/qwen3_dflash.h
@@ -53,8 +53,6 @@ class DFlashQwen3ModelImpl : public QWen3ModelImpl {
     head_dim_ = model_args.head_dim();
     rms_norm_eps_ = model_args.rms_norm_eps();
     CHECK_GT(head_dim_, 0) << "DFlash head_dim must be positive.";
-    CHECK_GT(model_args.layers_to_capture().size(), 0u)
-        << "DFlash requires dflash_config.target_layer_ids.";
 
     fc_ = register_module("fc", layer::NpuColumnParallelLinear(context));
     hidden_norm_ = register_module("hidden_norm", layer::NpuRMSNorm(context));

--- a/xllm/models/llm/npu/qwen3_moe.h
+++ b/xllm/models/llm/npu/qwen3_moe.h
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "core/framework/config/kernel_config.h"
 #include "core/framework/config/scheduler_config.h"
+#include "core/framework/model/aux_hidden_capture.h"
 #include "core/framework/model/model_output.h"
 #include "core/framework/model_context.h"
 #include "core/framework/parallel_state/npu_dp_ep_padding.h"
@@ -168,39 +169,10 @@ class Qwen3MoeModelImpl : public torch::nn::Module {
       indices.push_back(i);
     }
 
-    // Eagle3/DFlash target captures intermediate-layer aux hidden states to
-    // drive the draft. The worker fills layers_to_capture (from config.json for
-    // Eagle3, or the draft config for DFlash) before construction, so a
-    // non-empty list is the capture signal. The DFlash draft model itself never
-    // captures.
-    const bool is_dflash_draft_model =
-        model_args.model_type() == "DFlashDraftModel";
-    const auto& layer_ids_from_config = model_args.layers_to_capture();
-    const bool enable_aux_hidden_capture =
-        !is_dflash_draft_model && !layer_ids_from_config.empty();
-    if (enable_aux_hidden_capture) {
-      set_aux_hidden_capture_layers(layer_ids_from_config);
-      // Pre-allocate aux output buffer [max_tokens_per_batch, hidden_size *
-      // num_captured]
-      const size_t num_captured = layers_to_capture_set_.size();
-      const int64_t aux_dim =
-          model_args.hidden_size() * static_cast<int64_t>(num_captured);
-      aux_output_buffer_ = torch::empty(
-          {::xllm::SchedulerConfig::get_instance().max_tokens_per_batch(),
-           aux_dim},
-          options);
-    }
-  }
-
-  void set_aux_hidden_capture_layers(const std::vector<int32_t>& layer_ids) {
-    capture_aux_hidden_states_ = true;
-    layers_to_capture_set_.clear();
-    // Config uses 0-based layer indices.
-    for (int32_t val : layer_ids) {
-      layers_to_capture_set_.insert(val);
-    }
-    LOG(INFO) << "layers_to_capture_set_ size: "
-              << layers_to_capture_set_.size();
+    aux_capture_.init(
+        model_args,
+        options,
+        ::xllm::SchedulerConfig::get_instance().max_tokens_per_batch());
   }
 
   // tokens: [num_tokens]
@@ -309,9 +281,7 @@ class Qwen3MoeModelImpl : public torch::nn::Module {
     if (::xllm::KernelConfig::get_instance().enable_intralayer_addnorm()) {
       residual = torch::zeros_like(h);
     }
-    const int64_t num_tokens = h.size(0);
-    const int64_t hidden_size = h.size(-1);
-    size_t capture_idx = 0;
+    aux_capture_.reset_capture_index();
     for (size_t i = 0; i < layers_.size(); i++) {
       aclrtEvent* event = nullptr;
       std::atomic<bool>* event_flag = nullptr;
@@ -324,20 +294,8 @@ class Qwen3MoeModelImpl : public torch::nn::Module {
         return ModelOutput();
       }
 
-      if (capture_aux_hidden_states_ &&
-          layers_to_capture_set_.count(static_cast<int32_t>(i)) != 0) {
-        // auto aux_h = h;
-        auto aux_h =
-            (::xllm::KernelConfig::get_instance().enable_intralayer_addnorm())
-                ? h + residual.value()
-                : h;
-        aux_output_buffer_.slice(0, 0, num_tokens)
-            .slice(1,
-                   static_cast<int64_t>(capture_idx) * hidden_size,
-                   static_cast<int64_t>(capture_idx + 1) * hidden_size)
-            .copy_(aux_h.reshape({num_tokens, hidden_size}));
-        capture_idx++;
-      }
+      // Intralayer add-norm splits the stream, so pass residual for the add.
+      aux_capture_.capture_layer(static_cast<int32_t>(i), h, residual);
 
       auto& layer = layers_[i];
       const int32_t layer_index = i;
@@ -361,14 +319,7 @@ class Qwen3MoeModelImpl : public torch::nn::Module {
     if (::xllm::KernelConfig::get_instance().enable_intralayer_addnorm())
       h = h + residual.value();
     auto hidden_states = norm_(h, 0);
-    if (capture_aux_hidden_states_) {
-      CHECK_EQ(capture_idx, layers_to_capture_set_.size())
-          << "Captured aux hidden layer count mismatch.";
-      torch::Tensor aux_hidden_states =
-          aux_output_buffer_.slice(0, 0, num_tokens);
-      return ModelOutput(hidden_states, torch::Tensor(), aux_hidden_states);
-    }
-    return ModelOutput(hidden_states);
+    return aux_capture_.finalize(hidden_states);
   }
 
   // load the weight from the checkpoint
@@ -484,10 +435,7 @@ class Qwen3MoeModelImpl : public torch::nn::Module {
   std::vector<int64_t> mrope_section_;
   RollingLoadManager* rolling_mgr_ = nullptr;
 
-  // egale3
-  std::unordered_set<int32_t> layers_to_capture_set_;
-  bool capture_aux_hidden_states_ = false;
-  torch::Tensor aux_output_buffer_;
+  AuxHiddenCapture aux_capture_;
 };
 TORCH_MODULE(Qwen3MoeModel);
 
@@ -538,10 +486,6 @@ REGISTER_MODEL_ARGS_WITH_VARNAME(qwen3_moe_atb, qwen3_moe_atb, [&] {
   LOAD_ARG_OR(tie_word_embeddings, "tie_word_embeddings", false);
   LOAD_ARG_OR(vocab_size, "vocab_size", 151936);
   LOAD_ARG_OR(mlp_only_layers, "mlp_only_layers", std::vector<int>());
-
-  // Eagle3: layer ids (0-based) to capture from config, e.g.
-  // "layers_to_capture": [2, 14, 25]; defaults to empty if missing
-  LOAD_ARG_OR(layers_to_capture, "layers_to_capture", std::vector<int32_t>{});
 
   SET_ARG(stop_token_ids, std::unordered_set<int32_t>({args->eos_token_id()}));
 });


### PR DESCRIPTION
## Description

Extract the duplicated Qwen3 and Qwen3-MoE auxiliary-hidden capture logic into a shared `AuxHiddenCapture` value object.

The refactor:

- centralizes preallocated aux-hidden buffering, selected-layer capture, capture-count verification, and `ModelOutput` construction;
- uses a non-empty `ModelArgs::layers_to_capture` list as the sole model-side capture signal;
- keeps capture policy in `WorkerImpl`: Eagle3 targets receive the supported default layer list, while DFlash/DSpark targets load `target_layer_ids` from the draft model configuration;
- prevents every speculative draft worker from producing its own aux hidden by gating default capture setup on `!options_.is_draft_engine()`;
- derives DFlash context-hidden width from the target model that produces the tensor, rather than from the draft model that consumes it;
- writes intralayer-addnorm residual sums directly into the preallocated capture slice with `torch::add_out`.

Capture-layer IDs are an internal model/runtime contract: they are valid and unique. Target model configs do not own an independent `layers_to_capture` override; the worker is the single source of capture policy.

Prepared with AI-assisted review; the final diff and branch history were verified locally.

## Related Issues

None.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Test Plan / Result

- `git diff --check upstream/main...HEAD` — passed.
- `pre-commit run --files <all 8 changed files>` — passed (`clang-format`).
- Build and runtime tests were not run.

## Pull Request Checklist

### PR Title and Commit Messages

- [x] The PR title and commit message follow the xLLM commit format: `<type>: <subject>`.

### Pre-commit Checks

- [x] All changed files passed the configured clang-format hook.
- [ ] `pre-commit run --all-files` was not run.

### Self Review

- [x] I self-reviewed the change according to the project-specific code style.
- [x] The branch is rebased onto the latest upstream `main` (`cd167a6a`).

### Build and Test Coverage

- [ ] Tests were added or updated; this refactor preserves the existing capture contract.
- [ ] CUDA build/test was not run.
- [ ] NPU build/test was not run.
- [ ] MLU build/test was not run.

## Reviewer Notes

Please focus on the target/draft ownership boundary:

- only target workers populate `layers_to_capture` and produce aux hidden;
- DFlash/DSpark draft workers consume target-produced context hidden and do not capture their own layers;
- `expected_context_hidden_size_` is therefore derived from target hidden size and target capture-layer count.

Out of scope: accepting arbitrary target-config overrides or silently deduplicating invalid capture-layer lists.
