### PR TITLE
bugfix: fix qwen3.5 vlm smoothquant mlu vision path

### DIFF
--- a/tests/core/kernels/mlu/CMakeLists.txt
+++ b/tests/core/kernels/mlu/CMakeLists.txt
@@ -5,6 +5,18 @@ get_filename_component(_xllm_build_import_root
 
 cc_test(
   NAME
+    scaled_quantize_mlu_test
+  SRCS
+    scaled_quantize_test.cpp
+  DEPS
+    :mlu_kernels
+    torch
+    glog::glog
+    GTest::gtest_main
+)
+
+cc_test(
+  NAME
     triton_jit_ops_test
   SRCS
     fused_gdn_gating_test.cpp

--- a/tests/core/kernels/mlu/scaled_quantize_test.cpp
+++ b/tests/core/kernels/mlu/scaled_quantize_test.cpp
@@ -1,0 +1,62 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+
+#include <tuple>
+
+#include "kernels/mlu/mlu_ops_api.h"
+
+namespace xllm {
+namespace {
+
+TEST(ScaledQuantizeMluTest, MapsGeluPytorchTanhToGelu) {
+  torch::Device device(torch::kPrivateUse1, /*index=*/0);
+  torch::DeviceGuard guard(device);
+  torch::TensorOptions bf16_options =
+      torch::TensorOptions().dtype(torch::kBFloat16).device(device);
+  torch::TensorOptions fp32_options =
+      torch::TensorOptions().dtype(torch::kFloat32).device(device);
+  torch::Tensor x =
+      torch::arange(-128, 128, fp32_options).reshape({2, 128}).to(bf16_options);
+  torch::Tensor smooth = torch::ones({128}, fp32_options);
+
+  auto [alias_output, alias_scale] =
+      kernel::mlu::scaled_quantize(x,
+                                   smooth,
+                                   std::nullopt,
+                                   std::nullopt,
+                                   std::nullopt,
+                                   std::nullopt,
+                                   std::nullopt,
+                                   std::nullopt,
+                                   "gelu_pytorch_tanh");
+  auto [gelu_output, gelu_scale] = kernel::mlu::scaled_quantize(x,
+                                                                smooth,
+                                                                std::nullopt,
+                                                                std::nullopt,
+                                                                std::nullopt,
+                                                                std::nullopt,
+                                                                std::nullopt,
+                                                                std::nullopt,
+                                                                "gelu");
+
+  EXPECT_TRUE(torch::equal(alias_output.cpu(), gelu_output.cpu()));
+  EXPECT_TRUE(torch::equal(alias_scale.cpu(), gelu_scale.cpu()));
+}
+
+}  // namespace
+}  // namespace xllm

--- a/tests/core/kernels/mlu/scaled_quantize_test.cpp
+++ b/tests/core/kernels/mlu/scaled_quantize_test.cpp
@@ -16,26 +16,135 @@ limitations under the License.
 #include <gtest/gtest.h>
 #include <torch/torch.h>
 
+#include <optional>
+#include <string>
 #include <tuple>
+#include <vector>
 
 #include "kernels/mlu/mlu_ops_api.h"
 
 namespace xllm {
 namespace {
 
-TEST(ScaledQuantizeMluTest, MapsGeluPytorchTanhToGelu) {
-  torch::Device device(torch::kPrivateUse1, /*index=*/0);
-  torch::DeviceGuard guard(device);
-  torch::TensorOptions bf16_options =
-      torch::TensorOptions().dtype(torch::kBFloat16).device(device);
-  torch::TensorOptions fp32_options =
-      torch::TensorOptions().dtype(torch::kFloat32).device(device);
-  torch::Tensor x =
-      torch::arange(-128, 128, fp32_options).reshape({2, 128}).to(bf16_options);
-  torch::Tensor smooth = torch::ones({128}, fp32_options);
+torch::Device mlu_device() {
+  return torch::Device(torch::kPrivateUse1, /*index=*/0);
+}
 
-  auto [alias_output, alias_scale] =
-      kernel::mlu::scaled_quantize(x,
+torch::Tensor run_active(const torch::Tensor& input,
+                         const std::string& act_mode,
+                         bool is_gated = false) {
+  std::vector<int64_t> output_shape(input.sizes().begin(), input.sizes().end());
+  if (is_gated) {
+    output_shape.back() /= 2;
+  }
+  torch::Tensor output = torch::empty(output_shape, input.options());
+  kernel::mlu::active(input,
+                      output,
+                      std::nullopt,
+                      std::nullopt,
+                      act_mode,
+                      is_gated,
+                      /*start_expert_id=*/0,
+                      /*expert_size=*/0);
+  return output;
+}
+
+torch::Tensor quant_input() {
+  return torch::tensor({{1.8828125,
+                         4.03125,
+                         -3.875,
+                         -2.3125,
+                         1.59375,
+                         -3.265625,
+                         4.25,
+                         1.1640625,
+                         -1.390625,
+                         0.32421875,
+                         1.5625,
+                         -1.765625,
+                         -3.875,
+                         0.03369140625,
+                         0.09130859375,
+                         0.1005859375},
+                        {-0.73046875,
+                         3.203125,
+                         -1.3984375,
+                         -0.484375,
+                         2.0625,
+                         -3.140625,
+                         1.3359375,
+                         -1.109375,
+                         2.390625,
+                         -2.71875,
+                         0.1845703125,
+                         0.48828125,
+                         -4.03125,
+                         -3.640625,
+                         1.9140625,
+                         -1.453125}},
+                       torch::TensorOptions().dtype(torch::kFloat32))
+      .to(torch::kBFloat16);
+}
+
+torch::Tensor quant_smooth() {
+  return torch::tensor({1.4454224,
+                        0.2591031,
+                        0.6292535,
+                        0.3822536,
+                        1.2996036,
+                        0.9782565,
+                        0.8601090,
+                        0.8752215,
+                        0.4137633,
+                        1.2126962,
+                        1.0186944,
+                        0.4824153,
+                        1.2822158,
+                        0.9849257,
+                        0.2746393,
+                        1.4034402},
+                       torch::TensorOptions().dtype(torch::kFloat32));
+}
+
+TEST(ActiveMluTest, GeluModesMatchTorchApproximations) {
+  torch::Device device = mlu_device();
+  torch::DeviceGuard guard(device);
+  torch::Tensor cpu_input =
+      torch::linspace(
+          -5.0, 5.0, 321, torch::TensorOptions().dtype(torch::kFloat32))
+          .reshape({1, 321})
+          .to(torch::kBFloat16);
+  torch::Tensor input = cpu_input.to(device);
+
+  torch::Tensor tanh_output = run_active(input, "gelu_pytorch_tanh");
+  torch::Tensor exact_output = run_active(input, "gelu");
+  torch::Tensor tanh_reference = torch::gelu(cpu_input, "tanh");
+  torch::Tensor exact_reference = torch::gelu(cpu_input, "none");
+
+  EXPECT_EQ(tanh_output.sizes(), input.sizes());
+  EXPECT_EQ(tanh_output.scalar_type(), input.scalar_type());
+  EXPECT_EQ(tanh_output.device(), input.device());
+  EXPECT_TRUE(torch::allclose(tanh_output.cpu(),
+                              tanh_reference,
+                              /*rtol=*/5e-3,
+                              /*atol=*/5e-5));
+  EXPECT_TRUE(torch::allclose(exact_output.cpu(),
+                              exact_reference,
+                              /*rtol=*/5e-3,
+                              /*atol=*/5e-3));
+  EXPECT_FALSE(torch::equal(tanh_output.cpu(), exact_output.cpu()));
+}
+
+TEST(ScaledQuantizeMluTest, GeluPytorchTanhMatchesUnfusedReference) {
+  torch::Device device = mlu_device();
+  torch::DeviceGuard guard(device);
+  torch::Tensor cpu_input = quant_input();
+  torch::Tensor input = cpu_input.to(device);
+  torch::Tensor smooth = quant_smooth().to(device);
+  torch::Tensor activated = torch::gelu(cpu_input, "tanh").to(device);
+
+  auto [expected_output, expected_scale] =
+      kernel::mlu::scaled_quantize(activated,
                                    smooth,
                                    std::nullopt,
                                    std::nullopt,
@@ -43,19 +152,68 @@ TEST(ScaledQuantizeMluTest, MapsGeluPytorchTanhToGelu) {
                                    std::nullopt,
                                    std::nullopt,
                                    std::nullopt,
+                                   "none");
+  torch::Tensor output = torch::empty_like(expected_output);
+  torch::Tensor output_scale = torch::empty_like(expected_scale);
+  auto [actual_output, actual_scale] =
+      kernel::mlu::scaled_quantize(input,
+                                   smooth,
+                                   std::nullopt,
+                                   std::nullopt,
+                                   std::nullopt,
+                                   std::nullopt,
+                                   output,
+                                   output_scale,
                                    "gelu_pytorch_tanh");
-  auto [gelu_output, gelu_scale] = kernel::mlu::scaled_quantize(x,
-                                                                smooth,
-                                                                std::nullopt,
-                                                                std::nullopt,
-                                                                std::nullopt,
-                                                                std::nullopt,
-                                                                std::nullopt,
-                                                                std::nullopt,
-                                                                "gelu");
 
-  EXPECT_TRUE(torch::equal(alias_output.cpu(), gelu_output.cpu()));
-  EXPECT_TRUE(torch::equal(alias_scale.cpu(), gelu_scale.cpu()));
+  EXPECT_EQ(actual_output.data_ptr(), output.data_ptr());
+  EXPECT_EQ(actual_scale.data_ptr(), output_scale.data_ptr());
+  EXPECT_TRUE(torch::equal(actual_output.cpu(), expected_output.cpu()));
+  EXPECT_TRUE(torch::allclose(actual_scale.cpu(),
+                              expected_scale.cpu(),
+                              /*rtol=*/1e-6,
+                              /*atol=*/1e-7));
+}
+
+TEST(ScaledQuantizeMluTest, GatedGeluPytorchTanhReducesShapeOnce) {
+  torch::Device device = mlu_device();
+  torch::DeviceGuard guard(device);
+  torch::Tensor input = quant_input().to(device);
+  torch::Tensor smooth =
+      quant_smooth().slice(/*dim=*/0, /*start=*/0, /*end=*/8).to(device);
+  torch::Tensor activated = run_active(input,
+                                       "gelu_pytorch_tanh",
+                                       /*is_gated=*/true);
+  auto [expected_output, expected_scale] =
+      kernel::mlu::scaled_quantize(activated,
+                                   smooth,
+                                   std::nullopt,
+                                   std::nullopt,
+                                   std::nullopt,
+                                   std::nullopt,
+                                   std::nullopt,
+                                   std::nullopt,
+                                   "none");
+
+  auto [actual_output, actual_scale] =
+      kernel::mlu::scaled_quantize(input,
+                                   smooth,
+                                   std::nullopt,
+                                   std::nullopt,
+                                   std::nullopt,
+                                   std::nullopt,
+                                   std::nullopt,
+                                   std::nullopt,
+                                   "gelu_pytorch_tanh",
+                                   /*active_coef=*/1.0,
+                                   /*is_gated=*/true);
+
+  EXPECT_EQ(actual_output.sizes(), expected_output.sizes());
+  EXPECT_TRUE(torch::equal(actual_output.cpu(), expected_output.cpu()));
+  EXPECT_TRUE(torch::allclose(actual_scale.cpu(),
+                              expected_scale.cpu(),
+                              /*rtol=*/1e-6,
+                              /*atol=*/1e-7));
 }
 
 }  // namespace

--- a/tests/core/layers/mlu/qwen2_vision_attention_test.cpp
+++ b/tests/core/layers/mlu/qwen2_vision_attention_test.cpp
@@ -145,5 +145,71 @@ TEST_F(Qwen2VisionAttentionTest, ForwardTest) {
                               /*atol=*/1e-5));
 }
 
+TEST_F(Qwen2VisionAttentionTest, SmoothQuantQkvLoadsAndRuns) {
+  const int64_t hidden_size = 32;
+  const int64_t num_heads = 4;
+  const int64_t head_size = 8;
+  const int64_t output_size = num_heads * head_size * 3;
+  QuantArgs quant_args;
+  quant_args.quant_method() = kQuantMethodSmoothquant;
+  quant_args.bits() = 8;
+  quant_args.activation_dynamic() = true;
+  QKVParallelLinear qkv(hidden_size,
+                        num_heads,
+                        num_heads,
+                        head_size,
+                        /*num_kv_head_replicas=*/1,
+                        /*bias=*/true,
+                        /*gather_output=*/false,
+                        parallel_args_,
+                        options_,
+                        quant_args);
+
+  torch::Tensor qweight =
+      torch::randint(-8,
+                     8,
+                     {output_size, hidden_size},
+                     torch::TensorOptions().dtype(torch::kInt8))
+          .to(options_.device());
+  torch::Tensor scale = torch::linspace(
+      0.005, 0.02, output_size, options_.dtype(torch::kFloat32));
+  torch::Tensor smooth =
+      torch::linspace(0.5, 1.5, hidden_size, options_.dtype(torch::kFloat32));
+  torch::Tensor bias =
+      torch::linspace(-0.1, 0.1, output_size, options_.dtype(torch::kBFloat16));
+  std::unordered_map<std::string, torch::Tensor> weight_dict = {
+      {"qweight", qweight},
+      {"per_channel_scale", scale},
+      {"smooth", smooth},
+      {"bias", bias},
+  };
+  qkv->load_state_dict(StateDict(weight_dict, ""));
+
+  ASSERT_TRUE(qkv->is_weight_loaded());
+  EXPECT_TRUE(torch::equal(qkv->weight(), qweight));
+  EXPECT_TRUE(torch::equal(qkv->per_channel_scale(), scale));
+  ASSERT_TRUE(qkv->smooth().has_value());
+  EXPECT_TRUE(torch::equal(qkv->smooth().value(), smooth));
+
+  torch::Tensor input = test::seeded_tensor("qwen2_vision_qkv.smoothquant",
+                                            {4, hidden_size},
+                                            torch::kBFloat16,
+                                            options_.device());
+  torch::Tensor output = qkv->forward(input);
+  Device device(options_.device());
+  device.synchronize_default_stream();
+
+  EXPECT_EQ(output.sizes(), torch::IntArrayRef({4, output_size}));
+  EXPECT_TRUE(torch::isfinite(output).all().item<bool>());
+  torch::Tensor expected =
+      torch::matmul(input.to(torch::kFloat32) * smooth,
+                    (qweight.to(torch::kFloat32) * scale.unsqueeze(1)).t()) +
+      bias.to(torch::kFloat32);
+  EXPECT_TRUE(torch::allclose(output.to(torch::kFloat32),
+                              expected,
+                              /*rtol=*/3e-2,
+                              /*atol=*/3e-2));
+}
+
 }  // namespace layer
 }  // namespace xllm

--- a/xllm/core/kernels/mlu/active.cpp
+++ b/xllm/core/kernels/mlu/active.cpp
@@ -26,7 +26,6 @@ void active(const torch::Tensor& input,
             int64_t start_expert_id,
             int64_t expert_size) {
   std::string hidden_act = act_mode;
-  // TODO: act_mode gelu_pytorch_tanh not support yet.
   std::string gelu_approximate = "none";
   if (act_mode == "gelu_pytorch_tanh") {
     hidden_act = "gelu";
@@ -39,6 +38,9 @@ void active(const torch::Tensor& input,
                          hidden_act,
                          is_gated,
                          start_expert_id,
-                         expert_size);
+                         expert_size,
+                         /*active_coef=*/1.0,
+                         /*high_precision=*/false,
+                         gelu_approximate);
 }
 }  // namespace xllm::kernel::mlu

--- a/xllm/core/kernels/mlu/scaled_quantize.cpp
+++ b/xllm/core/kernels/mlu/scaled_quantize.cpp
@@ -31,6 +31,13 @@ std::tuple<torch::Tensor, torch::Tensor> scaled_quantize(
     bool is_gated /* = false */,
     at::ScalarType quant_type /* = at::kChar */
 ) {
+  // TMO fused SmoothQuant accepts "gelu", while Qwen vision configs use
+  // the Hugging Face alias "gelu_pytorch_tanh".
+  std::string mlu_act_mode = act_mode;
+  if (mlu_act_mode == "gelu_pytorch_tanh") {
+    mlu_act_mode = "gelu";
+  }
+
   // If act_mode is "none", override is_gated to false
   bool gated = is_gated;
   if (act_mode == "none") {
@@ -84,7 +91,7 @@ std::tuple<torch::Tensor, torch::Tensor> scaled_quantize(
       gather_index_start_position,
       /*scale_upper_bound*/ std::nullopt,
       /*quant_algo=*/std::string("dynamic_per_token"),
-      act_mode,
+      mlu_act_mode,
       active_coef,
       gated);
 

--- a/xllm/core/kernels/mlu/scaled_quantize.cpp
+++ b/xllm/core/kernels/mlu/scaled_quantize.cpp
@@ -31,38 +31,46 @@ std::tuple<torch::Tensor, torch::Tensor> scaled_quantize(
     bool is_gated /* = false */,
     at::ScalarType quant_type /* = at::kChar */
 ) {
-  // TMO fused SmoothQuant accepts "gelu", while Qwen vision configs use
-  // the Hugging Face alias "gelu_pytorch_tanh".
-  std::string mlu_act_mode = act_mode;
-  if (mlu_act_mode == "gelu_pytorch_tanh") {
-    mlu_act_mode = "gelu";
+  torch::Tensor quant_input = x;
+  std::string quant_act_mode = act_mode;
+  bool quant_is_gated = is_gated;
+  if (act_mode == "gelu_pytorch_tanh") {
+    std::vector<int64_t> active_shape(x.sizes().begin(), x.sizes().end());
+    if (is_gated) {
+      active_shape.back() /= 2;
+    }
+    quant_input = torch::empty(active_shape, x.options());
+    active(x,
+           quant_input,
+           std::nullopt,
+           std::nullopt,
+           act_mode,
+           is_gated,
+           /*start_expert_id=*/0,
+           /*expert_size=*/0);
+    quant_act_mode = "none";
+    quant_is_gated = false;
   }
 
-  // If act_mode is "none", override is_gated to false
-  bool gated = is_gated;
-  if (act_mode == "none") {
-    gated = false;
+  if (quant_act_mode == "none") {
+    quant_is_gated = false;
   }
 
-  // Determine output shape
-  auto x_sizes = x.sizes();
-  std::vector<int64_t> output_shape(x_sizes.begin(), x_sizes.end());
-  std::vector<int64_t> output_scale_shape(x_sizes.begin(), x_sizes.end() - 1);
+  auto input_sizes = quant_input.sizes();
+  std::vector<int64_t> output_shape(input_sizes.begin(), input_sizes.end());
+  std::vector<int64_t> output_scale_shape(input_sizes.begin(),
+                                          input_sizes.end() - 1);
 
-  // Adjust output shape based on gather_index
   if (gather_index.has_value()) {
     int64_t output_tokens = gather_index.value().size(0);
     output_shape[0] = output_tokens;
     output_scale_shape[0] = output_tokens;
   }
 
-  // Adjust output shape for gated activation
-  if (gated) {
-    // For gated, output is [..., C//2]
+  if (quant_is_gated) {
     output_shape.back() = output_shape.back() / 2;
   }
 
-  // Allocate output tensors
   torch::Tensor result_output;
   torch::Tensor result_output_scale;
 
@@ -79,9 +87,8 @@ std::tuple<torch::Tensor, torch::Tensor> scaled_quantize(
         torch::empty(output_scale_shape, x.options().dtype(at::kFloat));
   }
 
-  // Call underlying MLU kernel
   tmo::torch_api::scaled_quantize(
-      x,
+      quant_input,
       result_output,
       result_output_scale,
       smooth,
@@ -91,9 +98,9 @@ std::tuple<torch::Tensor, torch::Tensor> scaled_quantize(
       gather_index_start_position,
       /*scale_upper_bound*/ std::nullopt,
       /*quant_algo=*/std::string("dynamic_per_token"),
-      mlu_act_mode,
+      quant_act_mode,
       active_coef,
-      gated);
+      quant_is_gated);
 
   return std::make_tuple(result_output, result_output_scale);
 }

--- a/xllm/core/layers/common/linear.cpp
+++ b/xllm/core/layers/common/linear.cpp
@@ -1018,7 +1018,22 @@ QKVParallelLinearImpl::QKVParallelLinearImpl(
   (void)linear_extra_args;
   // Note: torch.nn.functional.linear performs XA^T + b and as a result
   // we allocate the transpose.
-  if (quant_args_.quant_method() == kQuantMethodFp8) {
+  if (quant_args_.quant_method() == kQuantMethodSmoothquant) {
+    qweight_ = register_parameter(
+        "qweight",
+        torch::empty({out_features_per_partition, hidden_size},
+                     options.dtype(torch::kInt8)),
+        /*requires_grad=*/false);
+    per_channel_scale_ =
+        register_parameter("per_channel_scale",
+                           torch::empty({out_features_per_partition},
+                                        options.dtype(torch::kFloat32)),
+                           /*requires_grad=*/false);
+    smooth_ = register_parameter(
+        "smooth",
+        torch::empty({hidden_size}, options.dtype(torch::kFloat32)),
+        /*requires_grad=*/false);
+  } else if (quant_args_.quant_method() == kQuantMethodFp8) {
     // FP8 W8A8 quantization - weight is stored as FP8 (float8_e4m3fn)
     weight_ = register_parameter(
         "weight",
@@ -1070,7 +1085,29 @@ torch::Tensor QKVParallelLinearImpl::forward(torch::Tensor input) {
       bias_.defined() ? std::optional<torch::Tensor>(bias_) : std::nullopt;
 
   torch::Tensor output;
-  if (quant_args_.quant_method() == kQuantMethodFp8) {
+  if (quant_args_.quant_method() == kQuantMethodSmoothquant) {
+    CHECK(qweight_.defined()) << "qweight is required for smoothquant.";
+    CHECK(per_channel_scale_.defined())
+        << "per_channel_scale is required for smoothquant.";
+    CHECK(smooth_.defined()) << "smooth is required for smoothquant.";
+
+    xllm::kernel::ScaledQuantizeParams quantize_params;
+    quantize_params.x = input;
+    quantize_params.smooth = smooth_;
+    auto [quantized_input, input_scale] =
+        xllm::kernel::scaled_quantize(quantize_params);
+
+    xllm::kernel::ScaledMatmulParams matmul_params;
+    matmul_params.a = quantized_input;
+    matmul_params.b = qweight_;
+    matmul_params.a_scale = input_scale;
+    matmul_params.b_scale = per_channel_scale_;
+    matmul_params.output_dtype = output_dtype_;
+    matmul_params.bias = bias;
+    matmul_params.beta = 0.0;
+    matmul_params.a_quant_bit_size = 8;
+    output = xllm::kernel::scaled_matmul(matmul_params);
+  } else if (quant_args_.quant_method() == kQuantMethodFp8) {
     check_fp8_activation_dynamic_supported(quant_args_);
     auto a_scale = input_scale_.defined()
                        ? std::optional<torch::Tensor>(input_scale_)
@@ -1152,7 +1189,14 @@ void QKVParallelLinearImpl::load_state_dict(
                           weight_scale_is_loaded_,
                           weight_offset_,
                           weight_offset_is_loaded_});
-  LOAD_QKV_WEIGHT(weight, 0, num_kv_head_replicas_);
+  if (quant_args_.quant_method() == kQuantMethodSmoothquant) {
+    LOAD_QKV_WEIGHT(qweight, 0, num_kv_head_replicas_);
+    LOAD_QKV_WEIGHT(per_channel_scale, 0, num_kv_head_replicas_);
+    load_shared_tensor_from_prefixes_or_fail(
+        state_dict, prefixes, "smooth", smooth_, smooth_is_loaded_);
+  } else {
+    LOAD_QKV_WEIGHT(weight, 0, num_kv_head_replicas_);
+  }
   if (bias_.defined()) {
     LOAD_QKV_WEIGHT(bias, 0, num_kv_head_replicas_);
   }
@@ -1264,7 +1308,13 @@ void QKVParallelLinearImpl::load_state_dict(const StateDict& state_dict) {
                           weight_offset_,
                           weight_offset_is_loaded_});
   CHECK_EQ(num_heads_, num_kv_heads_);
-  LOAD_MERGED_WEIGHT(weight, 0);
+  if (quant_args_.quant_method() == kQuantMethodSmoothquant) {
+    LOAD_MERGED_WEIGHT(qweight, 0);
+    LOAD_MERGED_WEIGHT(per_channel_scale, 0);
+    LOAD_WEIGHT(smooth);
+  } else {
+    LOAD_MERGED_WEIGHT(weight, 0);
+  }
 
   if (bias_.defined()) {
     LOAD_MERGED_WEIGHT(bias, 0);

--- a/xllm/core/layers/common/linear.h
+++ b/xllm/core/layers/common/linear.h
@@ -177,8 +177,26 @@ class QKVParallelLinearImpl : public torch::nn::Module {
   }
 
   // return the weight (for testing)
-  torch::Tensor weight() const { return weight_; }
-  bool is_weight_loaded() const { return weight_is_loaded_; }
+  torch::Tensor weight() const {
+    if (qweight_is_loaded_) {
+      return qweight_;
+    }
+    return weight_;
+  }
+  torch::Tensor per_channel_scale() const { return per_channel_scale_; }
+  std::optional<torch::Tensor> smooth() const {
+    if (smooth_is_loaded_) {
+      return smooth_;
+    }
+    return std::nullopt;
+  }
+  bool is_weight_loaded() const {
+    if (quant_args_.quant_method() == kQuantMethodSmoothquant) {
+      return qweight_is_loaded_ && per_channel_scale_is_loaded_ &&
+             smooth_is_loaded_;
+    }
+    return weight_is_loaded_;
+  }
 
   // Accessors for W8A8 dynamic quantization parameters.
   // Used by attention layers to reorder weight_scale/weight_offset
@@ -197,6 +215,9 @@ class QKVParallelLinearImpl : public torch::nn::Module {
   // we allocate the transpose since linear performs XA^T.
   // A^T: [out_features_per_partition, in_features]
   DEFINE_FUSED_WEIGHT(weight);
+  DEFINE_FUSED_WEIGHT(qweight);
+  DEFINE_FUSED_WEIGHT(per_channel_scale);
+  DEFINE_WEIGHT(smooth);
   DEFINE_FUSED_WEIGHT(bias);
 
   // FP8 quantization parameters

--- a/xllm/core/layers/common/qwen2_vision_attention.cpp
+++ b/xllm/core/layers/common/qwen2_vision_attention.cpp
@@ -55,7 +55,8 @@ Qwen2VisionAttentionImpl::Qwen2VisionAttentionImpl(const ModelContext& context,
                                         /*bias=*/has_bias,
                                         /*gather_output=*/false,
                                         parallel_args,
-                                        options));
+                                        options,
+                                        quant_args));
 
   proj_ = register_module("proj",
                           RowParallelLinear(hidden_size,

--- a/xllm/models/vlm/qwen3_vl.h
+++ b/xllm/models/vlm/qwen3_vl.h
@@ -160,6 +160,32 @@ class Qwen3_VisionPatchMergerImpl : public torch::nn::Module {
     norm_->weight.set_data(norm_->weight.to(options));
     norm_->bias.set_data(norm_->bias.to(options));
 
+    is_smoothquant_ = quant_args.quant_method() == kQuantMethodSmoothquant;
+    if (is_smoothquant_) {
+      quant_fc1_ =
+          register_module("linear_fc1",
+                          layer::ColumnParallelLinear(hidden_size_,
+                                                      hidden_size_,
+                                                      /*bias=*/true,
+                                                      /*gather_output=*/false,
+                                                      quant_args,
+                                                      parallel_args.tp_group_,
+                                                      options));
+      quant_fc2_ = register_module(
+          "linear_fc2",
+          layer::RowParallelLinear(
+              hidden_size_,
+              d_model,
+              /*bias=*/true,
+              /*input_is_parallelized=*/true,
+              /*enable_result_reduction=*/true,
+              quant_args,
+              parallel_args.tp_group_,
+              options,
+              layer::LinearExtraArgs("gelu", /*is_gated=*/false)));
+      return;
+    }
+
     auto fc1 = torch::nn::Linear(
         torch::nn::LinearOptions(hidden_size_, hidden_size_).bias(true));
     fc1->weight.set_data(fc1->weight.to(options));
@@ -178,6 +204,9 @@ class Qwen3_VisionPatchMergerImpl : public torch::nn::Module {
       x = norm_(x.view({-1, hidden_size_}));
     else
       x = norm_(x).view({-1, hidden_size_});
+    if (is_smoothquant_) {
+      return quant_fc2_->forward(quant_fc1_->forward(x));
+    }
     return mlp_->forward(x);
   }
 
@@ -197,6 +226,14 @@ class Qwen3_VisionPatchMergerImpl : public torch::nn::Module {
           << "bias size mismatch for " << name();
       norm_->bias.data().copy_(norm_bias);
       is_norm_bias_loaded = true;
+    }
+
+    if (is_smoothquant_) {
+      quant_fc1_->load_state_dict(
+          state_dict.get_dict_with_prefix("linear_fc1."));
+      quant_fc2_->load_state_dict(
+          state_dict.get_dict_with_prefix("linear_fc2."));
+      return;
     }
 
     const auto& fc1_dict = state_dict.get_dict_with_prefix("linear_fc1.");
@@ -233,6 +270,17 @@ class Qwen3_VisionPatchMergerImpl : public torch::nn::Module {
   }
 
   void verify_loaded_weights(const std::string& prefix) const {
+    if (is_smoothquant_) {
+      CHECK(quant_fc1_->is_weight_loaded())
+          << "quantized weights are not loaded for " << prefix + "linear_fc1";
+      CHECK(quant_fc2_->is_weight_loaded())
+          << "quantized weights are not loaded for " << prefix + "linear_fc2";
+      CHECK(is_norm_weight_loaded)
+          << "weight is not loaded for " << prefix + "norm" + ".weight";
+      CHECK(is_norm_bias_loaded)
+          << "bias is not loaded for " << prefix + "norm" + ".bias";
+      return;
+    }
     CHECK(is_fc1_weight_loaded)
         << "weight is not loaded for " << prefix + "linear_fc1" + ".weight";
     CHECK(is_fc1_bias_loaded)
@@ -252,6 +300,8 @@ class Qwen3_VisionPatchMergerImpl : public torch::nn::Module {
   bool use_postshuffle_norm_;
   torch::nn::LayerNorm norm_{nullptr};
   torch::nn::Sequential mlp_{nullptr};
+  layer::ColumnParallelLinear quant_fc1_{nullptr};
+  layer::RowParallelLinear quant_fc2_{nullptr};
   std::tuple<torch::nn::Linear, torch::nn::GELU, torch::nn::Linear> layers_ = {
       nullptr,
       nullptr,
@@ -262,6 +312,7 @@ class Qwen3_VisionPatchMergerImpl : public torch::nn::Module {
   bool is_fc2_bias_loaded = false;
   bool is_norm_weight_loaded = false;
   bool is_norm_bias_loaded = false;
+  bool is_smoothquant_ = false;
 };
 TORCH_MODULE(Qwen3_VisionPatchMerger);
 


### PR DESCRIPTION
  ## Description

  - Preserve gelu_pytorch_tanh semantics during MLU activation quantization.
  - Add SmoothQuant weight loading and execution for vision QKV and Qwen3.5 patch-merger layers.
  - Propagate quantization settings into Qwen2 vision attention.
  - Add MLU regression coverage for GELU quantization and SmoothQuant vision QKV.

  ## Testing

  - Added scaled_quantize_mlu_test coverage for tanh-GELU activation and gated quantization behavior.
  - Added SmoothQuantQkvLoadsAndRuns coverage for vision QKV loading and forward execution.
  - Tests not executed locally.



## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [x] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
