### PR TITLE
perf: enable double-buffer graph decode for the VLM backend.

### DIFF
--- a/xllm/core/runtime/vlm_executor_impl.cpp
+++ b/xllm/core/runtime/vlm_executor_impl.cpp
@@ -97,4 +97,16 @@ ModelOutput VlmExecutorImpl::run(const torch::Tensor& tokens,
   return model_->forward(tokens, positions, kv_caches, params);
 }
 
+void VlmExecutorImpl::prepare_graph_input(const torch::Tensor& tokens,
+                                          const torch::Tensor& positions,
+                                          std::vector<KVCache>& kv_caches,
+                                          const ModelInputParams& params) {
+  // Decode-only double-buffer graph prewarm. Delegate to the inner graph
+  // executor built in enable_graph mode; multimodal prefill steps never reach
+  // here because the worker gates this on decode-phase input params.
+  if (llm_executor_) {
+    llm_executor_->prepare_graph_input(tokens, positions, kv_caches, params);
+  }
+}
+
 }  // namespace xllm

--- a/xllm/core/runtime/vlm_executor_impl.cpp
+++ b/xllm/core/runtime/vlm_executor_impl.cpp
@@ -60,6 +60,19 @@ ModelOutput VlmExecutorImpl::run(const torch::Tensor& tokens,
                                  const ModelInputParams& params) {
   torch::NoGradGuard no_grad;
   auto& mm_data = params.multimodal.mm_data;
+
+  // Pure decode steps carry no multimodal data, so get_input_embeddings would
+  // just do a plain token lookup. Skipping the host-side embedding here lets
+  // the graph run embed_tokens on its persistent token buffer instead, which
+  // keeps the captured graph input address stable across double-buffered slots
+  // (a host-computed embedding tensor is reallocated every step and would make
+  // graph replay read a stale/mismatched buffer).
+  const bool decode_only =
+      params.meta.batch_forward_type.is_decode() && !mm_data.valid();
+  if (decode_only && llm_executor_) {
+    return llm_executor_->run(tokens, positions, kv_caches, params);
+  }
+
   if (encoder_cache_) {
     EncoderCacheLookupVisitor lookup(encoder_cache_.get());
     mm_data.foreach (lookup);

--- a/xllm/core/runtime/vlm_executor_impl.h
+++ b/xllm/core/runtime/vlm_executor_impl.h
@@ -49,6 +49,11 @@ class VlmExecutorImpl : public ExecutorImpl {
                   std::vector<KVCache>& kv_caches,
                   const ModelInputParams& params) override;
 
+  void prepare_graph_input(const torch::Tensor& tokens,
+                           const torch::Tensor& positions,
+                           std::vector<KVCache>& kv_caches,
+                           const ModelInputParams& params) override;
+
   virtual MMDict encode(const ModelInputParams& params);
 
   // not own

--- a/xllm/core/runtime/vlm_worker_impl.cpp
+++ b/xllm/core/runtime/vlm_worker_impl.cpp
@@ -25,7 +25,9 @@ limitations under the License.
 #include <optional>
 #include <utility>
 
+#include "common/macros.h"
 #include "common/metrics.h"
+#include "core/framework/config/load_config.h"
 #include "framework/kv_cache/kv_cache.h"
 #include "framework/model/model_input_params.h"
 #include "framework/state_dict/state_dict.h"
@@ -98,6 +100,78 @@ std::optional<ForwardOutput> VLMWorkerImpl::step(const ForwardInput& input) {
   }
   auto ret = device_.synchronize_default_stream();
   return output;
+}
+
+std::optional<ForwardOutput> VLMWorkerImpl::execute_no_sync_on_stream(
+    const ForwardInput& input,
+    Stream& compute_stream,
+    bool record_ready_event) {
+  const bool empty_shard =
+      input.input_params.meta.num_sequences == 0 &&
+      (!input.token_ids.defined() || input.token_ids.numel() == 0);
+  if (empty_shard) {
+    return ForwardOutput{};
+  }
+
+  c10::StreamGuard stream_guard = compute_stream.set_stream_guard();
+#if defined(USE_NPU)
+  if (::xllm::LoadConfig::get_instance().enable_manual_loader()) {
+    SET_ATB_EXECUTE_STREAM((&compute_stream), device_, context_);
+  }
+#endif
+  CHECK(compute_stream.wait_event(input.metadata_ready_event))
+      << "failed to wait ForwardInput metadata ready event";
+
+  Timer timer;
+  auto model_output = model_executor_->forward(
+      input.token_ids, input.positions, kv_caches_, input.input_params);
+  auto& sampling_params = input.sampling_params;
+  torch::Tensor logits;
+  if (sampling_params.selected_token_idxes.defined()) {
+    logits = model_->logits(model_output.hidden_states,
+                            sampling_params.selected_token_idxes);
+  }
+
+  COUNTER_ADD(execution_latency_seconds_model, timer.elapsed_seconds());
+
+  ForwardOutput output;
+  if (sampling_params.selected_token_idxes.defined()) {
+    auto sample_output = sampler_->forward(logits, sampling_params);
+    output.logits = logits;
+    COUNTER_ADD(execution_latency_seconds_sampling, timer.elapsed_seconds());
+
+    output.sample_output = sample_output;
+    output.do_sample = sampling_params.do_sample;
+    output.logprobs = sampling_params.logprobs;
+    output.max_top_logprobs = sampling_params.max_top_logprobs;
+  }
+
+  // Keep input tensors alive until downstream consumers finish on this stream.
+  output.retained_input = std::make_shared<ForwardInput>(input);
+  if (record_ready_event) {
+    std::unique_ptr<Stream> current = device_.current_stream();
+    output.ready_event = current->record_event();
+    if (output.ready_event == nullptr) {
+      current->synchronize();
+    }
+  }
+  return output;
+}
+
+std::optional<ForwardOutput> VLMWorkerImpl::step_for_schedule_overlap(
+    const ForwardInput& input) {
+  // VLM has no linear-attention recurrent state to restore, so the LLM
+  // worker's slot-restore preamble is unnecessary here.
+  return execute_no_sync_on_stream(input, *compute_stream_);
+}
+
+ForwardInput
+VLMWorkerImpl::update_input_by_last_step_output_for_schedule_overlap(
+    ForwardInput& input) {
+  c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
+  CHECK(compute_stream_->wait_event(last_step_output_.ready_event))
+      << "failed to wait last step output ready event";
+  return update_input_by_last_step_output(input);
 }
 
 }  // namespace xllm

--- a/xllm/core/runtime/vlm_worker_impl.h
+++ b/xllm/core/runtime/vlm_worker_impl.h
@@ -42,6 +42,21 @@ class VLMWorkerImpl : public WorkerImpl {
   bool init_model(ModelContext& context) override;
 
   std::optional<ForwardOutput> step(const ForwardInput& input) override;
+
+ protected:
+  std::optional<ForwardOutput> step_for_schedule_overlap(
+      const ForwardInput& input) override;
+  ForwardInput update_input_by_last_step_output_for_schedule_overlap(
+      ForwardInput& input) override;
+
+ private:
+  // Execute forward + sampling on the given compute stream without a host-side
+  // synchronize, recording a ready event for cross-step dependency. Shared by
+  // the schedule-overlap decode fast path.
+  std::optional<ForwardOutput> execute_no_sync_on_stream(
+      const ForwardInput& input,
+      Stream& compute_stream,
+      bool record_ready_event = true);
 };
 
 }  // namespace xllm

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -621,7 +621,8 @@ bool WorkerImpl::can_prepare_npu_graph_decode_input(
   return !options_.enable_speculative_decode() &&
          ::xllm::ExecutionConfig::get_instance().enable_graph() &&
          ::xllm::ExecutionConfig::get_instance().enable_graph_double_buffer() &&
-         enable_schedule_overlap() && options_.backend() == "llm" &&
+         enable_schedule_overlap() &&
+         (options_.backend() == "llm" || options_.backend() == "vlm") &&
          input_params.meta.batch_forward_type.has_decode();
 #else
   (void)input_params;
@@ -636,7 +637,7 @@ bool WorkerImpl::can_prepare_without_compute_stream_wait(
   return !options_.enable_speculative_decode() &&
          ::xllm::ExecutionConfig::get_instance().enable_graph() &&
          ::xllm::ExecutionConfig::get_instance().enable_graph_double_buffer() &&
-         options_.backend() == "llm";
+         (options_.backend() == "llm" || options_.backend() == "vlm");
 #else
   (void)input_params;
   return false;


### PR DESCRIPTION
## Description

- VLM decode (e.g. Qwen3-VL) previously ran only in eager per-step mode and could not reuse the LLM's ACLGraph + double-buffer + schedule-overlap fast path.
- This PR relaxes the worker gates so VLM pure-decode steps reuse the LLM double-buffer graph decode path, matching text-only LLM decode performance.

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
