### PR TITLE
bugfix: avoid linear state h2d during graph capture.

### DIFF
--- a/tests/core/layers/attention_metadata_builder_test.cpp
+++ b/tests/core/layers/attention_metadata_builder_test.cpp
@@ -83,6 +83,33 @@ TEST(AttentionMetadataBuilderTest, MaterializesChunkedPrefillMask) {
                            torch::tensor({false, true, false}, torch::kBool)));
 }
 
+TEST(AttentionMetadataBuilderTest, SkipsInitialStateMaterializationOnRequest) {
+  ModelInputParams params = make_params();
+  AttentionMetadataBuildOptions build_options;
+  build_options.materialize_linear_state_validity = false;
+
+  AttentionMetadata metadata = AttentionMetadataBuilder::build(
+      params, /*enable_mla=*/false, {}, std::nullopt, build_options);
+
+  EXPECT_FALSE(metadata.has_initial_states.defined());
+  EXPECT_EQ(params.linear_state_validity_mask,
+            LinearStateValidityMask({0, 1, 0}));
+  EXPECT_EQ(params.embedding.linear_state_ids, std::vector<int32_t>({4, 2, 9}));
+}
+
+TEST(AttentionMetadataBuilderTest,
+     SkippingInitialStateMaterializationKeepsValidation) {
+  ModelInputParams params = make_params();
+  params.linear_state_validity_mask.pop_back();
+  AttentionMetadataBuildOptions build_options;
+  build_options.materialize_linear_state_validity = false;
+
+  EXPECT_DEATH(
+      AttentionMetadataBuilder::build(
+          params, /*enable_mla=*/false, {}, std::nullopt, build_options),
+      "linear state mask row count mismatch");
+}
+
 TEST(AttentionMetadataBuilderTest, DecodeDoesNotMaterializeInitialStateMask) {
   ModelInputParams params = make_params();
   params.meta.batch_forward_type = BatchForwardType::DECODE;

--- a/xllm/core/layers/common/attention_metadata_builder.cpp
+++ b/xllm/core/layers/common/attention_metadata_builder.cpp
@@ -47,6 +47,7 @@ torch::TensorOptions int32_options_like(const torch::Tensor& preferred,
 void materialize_linear_state_validity(
     const ModelInputParams& params,
     const std::optional<torch::Device>& device,
+    const AttentionMetadataBuildOptions& build_options,
     AttentionMetadata& attn_metadata) {
   const bool needs_initial_states =
       attn_metadata.is_prefill || attn_metadata.is_chunked_prefill;
@@ -85,6 +86,10 @@ void materialize_linear_state_validity(
         << ", metadata_rows=" << metadata_rows;
   }
 
+  if (!build_options.materialize_linear_state_validity) {
+    return;
+  }
+
   torch::TensorOptions options;
   if (params.embedding.linear_state_indices.defined()) {
     options = params.embedding.linear_state_indices.options();
@@ -107,7 +112,8 @@ AttentionMetadata build_attention_metadata(
     bool enable_mla,
     const std::string& compute_dtype,
     const std::optional<torch::Device>& device,
-    const std::optional<torch::Tensor>& attn_mask) {
+    const std::optional<torch::Tensor>& attn_mask,
+    const AttentionMetadataBuildOptions& build_options) {
   // MLA mode still affects which shared tensors must be materialized for
   // attention execution, but the flag itself is no longer carried in metadata.
   AttentionMetadata attn_metadata;
@@ -308,7 +314,8 @@ AttentionMetadata build_attention_metadata(
     attn_metadata.max_seq_len = std::max<int64_t>(attn_metadata.max_seq_len, 1);
     attn_metadata.total_kv_len = 1;
   }
-  materialize_linear_state_validity(params, device, attn_metadata);
+  materialize_linear_state_validity(
+      params, device, build_options, attn_metadata);
 
   // Set is_causal: true for prefill (causal attention), false for decode
   // (non-causal) Default to true (causal) if not explicitly set
@@ -387,9 +394,10 @@ AttentionMetadata AttentionMetadataBuilder::build(
     const ModelInputParams& params,
     bool enable_mla,
     const std::optional<torch::Tensor>& attn_mask,
-    const std::optional<torch::Device>& device) {
+    const std::optional<torch::Device>& device,
+    const AttentionMetadataBuildOptions& build_options) {
   return AttentionMetadataBuilder::build(
-      params, enable_mla, "float", attn_mask, device);
+      params, enable_mla, "float", attn_mask, device, build_options);
 }
 
 AttentionMetadata AttentionMetadataBuilder::build(
@@ -397,9 +405,10 @@ AttentionMetadata AttentionMetadataBuilder::build(
     bool enable_mla,
     const std::string& compute_dtype,
     const std::optional<torch::Tensor>& attn_mask,
-    const std::optional<torch::Device>& device) {
+    const std::optional<torch::Device>& device,
+    const AttentionMetadataBuildOptions& build_options) {
   return build_attention_metadata(
-      params, enable_mla, compute_dtype, device, attn_mask);
+      params, enable_mla, compute_dtype, device, attn_mask, build_options);
 }
 
 }  // namespace xllm::layer

--- a/xllm/core/layers/common/attention_metadata_builder.h
+++ b/xllm/core/layers/common/attention_metadata_builder.h
@@ -28,6 +28,10 @@ namespace layer {
 
 struct AttentionMetadata;
 
+struct AttentionMetadataBuildOptions {
+  bool materialize_linear_state_validity = true;
+};
+
 // Builder class for AttentionMetadata to avoid circular dependency.
 // This class handles building AttentionMetadata from ModelInputParams,
 // allowing attention_metadata.h to not depend on model_input_params.h.
@@ -39,7 +43,8 @@ class AttentionMetadataBuilder {
       const ModelInputParams& params,
       bool enable_mla,
       const std::optional<torch::Tensor>& attn_mask = {},
-      const std::optional<torch::Device>& device = std::nullopt);
+      const std::optional<torch::Device>& device = std::nullopt,
+      const AttentionMetadataBuildOptions& build_options = {});
 
   // Build AttentionMetadata from ModelInputParams with specified compute_dtype.
   static AttentionMetadata build(
@@ -47,7 +52,8 @@ class AttentionMetadataBuilder {
       bool enable_mla,
       const std::string& compute_dtype,
       const std::optional<torch::Tensor>& attn_mask = {},
-      const std::optional<torch::Device>& device = std::nullopt);
+      const std::optional<torch::Device>& device = std::nullopt,
+      const AttentionMetadataBuildOptions& build_options = {});
 };
 
 }  // namespace layer

--- a/xllm/models/llm/qwen3_5_mtp_base.h
+++ b/xllm/models/llm/qwen3_5_mtp_base.h
@@ -112,12 +112,20 @@ class Qwen3_5MtpModelImplBase : public Qwen3HybridModelImplBase {
       positions = torch::tensor({0}).to(torch::kInt32).to(device_);
     }
 
+    layer::AttentionMetadataBuildOptions metadata_build_options;
+#if defined(USE_NPU)
+    // Native NPU GDN consumes the canonical host mask directly. Avoid
+    // materializing the unused device bool tensor inside ACL graph capture.
+    metadata_build_options.materialize_linear_state_validity =
+        !input_params.enable_graph;
+#endif
     layer::AttentionMetadata attn_metadata =
         layer::AttentionMetadataBuilder::build(
             input_params,
             model_args_.enable_mla(),
             build_attention_mask(input_params),
-            /*device=*/device_);
+            /*device=*/device_,
+            metadata_build_options);
     prepare_mrope(positions, attn_metadata);
 
     torch::Tensor embedding = embed_tokens_(tokens);

--- a/xllm/models/llm/qwen3_next_hybrid_base.h
+++ b/xllm/models/llm/qwen3_next_hybrid_base.h
@@ -105,12 +105,20 @@ class Qwen3HybridModelImplBase : public Qwen3HybridModelModule {
       }
     }
 
+    layer::AttentionMetadataBuildOptions metadata_build_options;
+#if defined(USE_NPU)
+    // Native NPU GDN consumes the canonical host mask directly. Avoid
+    // materializing the unused device bool tensor inside ACL graph capture.
+    metadata_build_options.materialize_linear_state_validity =
+        !input_params.enable_graph;
+#endif
     layer::AttentionMetadata attn_metadata =
         layer::AttentionMetadataBuilder::build(
             input_params,
             model_args_.enable_mla(),
             build_attention_mask(input_params),
-            /*device=*/device_);
+            /*device=*/device_,
+            metadata_build_options);
     const int32_t num_tokens = static_cast<int32_t>(tokens.size(0));
     const auto& batch_forward_type = input_params.meta.batch_forward_type;
     const bool is_prefill_side = batch_forward_type.no_decode();


### PR DESCRIPTION
## Description

Fix the NPU ACLGraph capture failure in Qwen3.5 hybrid and MTP execution.

During graph capture, `AttentionMetadataBuilder` materialized the CPU `linear_state_validity_mask` as an NPU bool tensor. This triggered a synchronous H2D `aclrtMemcpy` on the captured stream, which the Ascend runtime rejects and caused every graph bucket to fall back to eager execution.

This PR:

- adds a named builder option that controls device materialization of `has_initial_states`, while preserving the existing default behavior for other consumers;
- disables the unused device tensor only for native NPU Qwen hybrid/MTP graph execution;
- keeps the restore/reset-adjusted host `linear_state_validity_mask` as the canonical source of truth consumed by native NPU GDN kernels;
- preserves canonical mask validation even when device materialization is disabled;
- does not derive linear-state validity from `kv_cache_token_nums`, because KV-cache occupancy and recurrent-state validity are not equivalent.

## Related Issues

N/A.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

Validation performed:

- NPU build and CTest passed: `1161/1161` tests.
- Added regression coverage for skipping materialization while preserving the canonical mask and its validation.
- Two-card Qwen3.5-27B + MTP E2E passed with HCCL, chunked prefill, schedule overlap, and ACLGraph enabled.
- Graph buckets `64`, `32`, `16`, `8`, and `4` were captured successfully on both ranks.
- Two fixed requests completed with HTTP 200; the logs contained no captured-stream `aclrtMemcpy`, graph-capture exception, or eager fallback.
