### PR TITLE
feat: support kda fla_npu operator build and execute_linear integration.

### DIFF
--- a/xllm/python/attention/backend.py
+++ b/xllm/python/attention/backend.py
@@ -164,6 +164,17 @@ class AttentionBackend(ABC):
             f"{type(self).__name__} does not support MLA"
         )
 
+    def execute_linear(
+        self,
+        mixed_qkv: torch.Tensor,
+        gate: torch.Tensor,
+        beta: torch.Tensor,
+        layer: "Attention",
+    ) -> torch.Tensor:
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support linear attention (KDA)"
+        )
+
     def mla_index_context(self, layer: "Attention") -> MlaIndexContext:
         """Public hook for an optional LightningIndexer.
 

--- a/xllm/python/attention/npu_paged_attention.py
+++ b/xllm/python/attention/npu_paged_attention.py
@@ -122,6 +122,149 @@ class NpuPagedAttentionBackend(AttentionBackend):
     def bind_kv_caches(self, kv_caches: list[LayerCache]) -> None:
         self._kv_caches = kv_caches
 
+    def execute_linear(
+        self,
+        mixed_qkv: torch.Tensor,
+        gate: torch.Tensor,
+        beta: torch.Tensor,
+        layer: "Attention",
+    ) -> torch.Tensor:
+        from xllm.python.kernels_npu.kda import (
+            _causal_conv1d_fn,
+            _causal_conv1d_update,
+        )
+
+        metadata = self._metadata
+        assert metadata is not None, "execute_linear called before prepare()"
+        layer_cache = self._kv_caches[layer.layer_id]
+        conv_cache = layer_cache.conv
+        ssm_cache = layer_cache.ssm
+        assert conv_cache is not None and ssm_cache is not None, (
+            "execute_linear requires a linear-attention layer cache (conv/ssm)")
+
+        seq_len = mixed_qkv.shape[-1]
+        conv_kernel_size = layer.conv_kernel_size
+        conv_state_len = conv_kernel_size - 1
+        head_dim = layer.head_dim
+        qkv_dim = layer.qkv_dim
+        is_prefill = metadata.is_prefill or metadata.is_chunked_prefill
+
+        idx = metadata.linear_state_indices
+        assert idx is not None, "execute_linear requires metadata.linear_state_indices"
+        num_seqs = idx.shape[0]
+        if idx.dtype != torch.int64:
+            idx = idx.to(torch.int64)
+        conv_state = conv_cache.index_select(0, idx)
+        conv_state = conv_state.transpose(1, 2).contiguous()
+        ssm_state = ssm_cache.index_select(0, idx)
+        # Pooled slots may hold a prior request's stale state; zero cold slots
+        # on prefill (decode continues its own warm slot).
+        if is_prefill:
+            his = metadata.has_initial_state
+            assert his is not None, (
+                "execute_linear requires metadata.has_initial_state for prefill")
+            if not isinstance(his, torch.Tensor):
+                his = torch.tensor(
+                    his, dtype=torch.int64, device=conv_state.device
+                )
+            if his.shape[0] != num_seqs:
+                raise ValueError(
+                    f"has_initial_state length {his.shape[0]} != num_seqs "
+                    f"{num_seqs}")
+            # mask = [num_seqs, 1, ...] broadcasting to each state's dims; bool
+            # mul zeroes cold slots without a zeros_like allocation.
+            warm = his.to(torch.bool)
+            conv_state = conv_state * warm.view(num_seqs, *([1] * (conv_state.ndim - 1)))
+            ssm_state = ssm_state * warm.view(num_seqs, *([1] * (ssm_state.ndim - 1)))
+
+        conv_weight = layer.conv1d.weight.squeeze(1)
+        activation = layer.activation
+        q_cu = metadata.q_cu_seq_lens
+        if q_cu is None:
+            q_cu = torch.tensor(
+                [0, seq_len], dtype=torch.int64, device=mixed_qkv.device)
+        else:
+            q_cu = q_cu.to(torch.int64)
+        q_cu_list = q_cu.tolist()
+        outs = []
+        for s in range(num_seqs):
+            t0, t1 = q_cu_list[s], q_cu_list[s + 1]
+            seg = mixed_qkv[:, :, t0:t1]   # [1, conv_dim, seg_len]
+            cs = conv_state[s:s + 1]       # [1, conv_dim, state_len]
+            seg_len = t1 - t0
+            if seg_len == 1:
+                outs.append(_causal_conv1d_update(
+                    seg, cs, conv_weight, activation
+                ))
+            else:
+                cin = torch.cat([cs, seg], dim=-1)
+                outs.append(_causal_conv1d_fn(
+                    cin, conv_weight, activation
+                )[:, :, -seg_len:])
+                conv_state[s] = cin[0, :, -conv_state_len:]
+        mixed_qkv = torch.cat(outs, dim=-1)
+        hidden_shape = (1, seq_len, -1, head_dim)
+
+        query, key, value = torch.split(
+            mixed_qkv.transpose(1, 2), [qkv_dim] * 3, dim=-1
+        )
+        query = query.view(hidden_shape)
+        key = key.view(hidden_shape)
+        value = value.view(hidden_shape)
+
+        # Delta-rule on fla_npu fused ops (one varlen call for all sequences).
+        core_attn_out, final_state = self._kda_fla_npu_varlen(
+            query, key, value, gate, beta, ssm_state, head_dim, q_cu,
+            is_prefill=is_prefill,
+        )
+
+        conv_cache.index_copy_(
+            0, idx, conv_state.transpose(1, 2).contiguous()
+        )
+        ssm_cache.index_copy_(
+            0, idx, final_state.float().contiguous()
+        )
+        return core_attn_out
+
+    def _kda_fla_npu_varlen(
+        self, query: torch.Tensor, key: torch.Tensor, value: torch.Tensor,
+        gate: torch.Tensor, beta: torch.Tensor, ssm_state: torch.Tensor,
+        head_dim: int, cu_seqlens: torch.Tensor, *, is_prefill: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        from fla_npu.ops.ascendc import chunk_kda_fwd, recurrent_kda
+        from xllm.python.kernels_npu.kda import _l2norm
+
+        scale = 1.0 / (head_dim ** 0.5)
+
+        if not is_prefill:
+            out, final_state = recurrent_kda(
+                query, key, value, gate, beta,
+                initial_state=ssm_state,
+                cu_seqlens=cu_seqlens,
+                layout="BSND", scale=scale,
+                output_final_state=True, inplace_final_state=False,
+                use_qk_l2norm_in_kernel=True,
+                use_gate_in_kernel=False,
+                use_beta_sigmoid_in_kernel=False,
+            )
+            return out.to(query.dtype), final_state
+
+        q_in = _l2norm(query.float(), dim=-1, eps=1e-6).to(torch.bfloat16).contiguous()
+        k_in = _l2norm(key.float(), dim=-1, eps=1e-6).to(torch.bfloat16).contiguous()
+        v_in = value.to(torch.bfloat16).contiguous()
+        result = chunk_kda_fwd(
+            q_in, k_in, v_in, gate, beta, scale,
+            chunk_size=64, layout="BSND",
+            initial_state=ssm_state,
+            output_final_state=True,
+            cu_seqlens=cu_seqlens,
+            use_gate_in_kernel=False,
+            return_intermediate_states=False,
+        )
+        core_attn_out = result[0].to(query.dtype)
+        final_state = result[1]
+        return core_attn_out, final_state
+
     @staticmethod
     def _query_sequence_ends(
         q_cu_seq_lens: torch.Tensor | None,

--- a/xllm/python/kernels_npu/kda.py
+++ b/xllm/python/kernels_npu/kda.py
@@ -1,0 +1,74 @@
+# Copyright 2026 The xLLM Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://github.com/jd-opensource/xllm/blob/main/LICENSE
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure-torch conv1d helpers for KDA (Kimi Delta Attention) layers.
+
+The delta-rule runs on fla_npu fused ops (``chunk_kda_fwd`` / ``recurrent_kda``);
+only conv1d stays pure-torch here. No model coupling and no fla_npu runtime
+dependency — import-safe everywhere.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+
+def _l2norm(x: torch.Tensor, dim: int = -1, eps: float = 1e-6) -> torch.Tensor:
+    """FLA-style l2norm: divide by sqrt(sum(x^2)+eps) (NOT F.normalize)."""
+    norm = torch.sqrt((x * x).sum(dim=dim, keepdim=True) + eps)
+    return x / norm
+
+
+def _causal_conv1d_fn(
+    mixed_qkv: torch.Tensor, weight: torch.Tensor,
+    activation: str = "silu",
+) -> torch.Tensor:
+    """Depthwise causal conv1d (left-pad K-1) + activation, fp32 weight."""
+    # mixed_qkv: [B, conv_dim, S]; weight: [conv_dim, K] (squeezed)
+    padding = weight.shape[-1] - 1
+    out = F.conv1d(
+        mixed_qkv.to(weight.dtype),
+        weight=weight.unsqueeze(1),
+        bias=None,
+        padding=padding,
+        groups=mixed_qkv.shape[1],
+    )[:, :, : mixed_qkv.shape[-1]]
+    if activation == "silu":
+        out = F.silu(out)
+    return out.to(mixed_qkv.dtype)
+
+
+def _causal_conv1d_update(
+    mixed_qkv: torch.Tensor, conv_state: torch.Tensor,
+    weight: torch.Tensor, activation: str = "silu",
+) -> torch.Tensor:
+    """Incremental depthwise causal conv1d + activation (single-token decode).
+
+    Prepend ``conv_state`` (last K-1 conv inputs), run a width-0-pad conv, slice
+    the tail, and update ``conv_state`` in place. ``mixed_qkv`` is
+    ``[B, conv_dim, S]`` (S == 1 for decode); ``conv_state`` is
+    ``[B, conv_dim, K-1]``; ``weight`` is ``[conv_dim, K]`` (squeezed).
+    """
+    _, hidden_size, seq_len = mixed_qkv.shape
+    state_len = conv_state.shape[-1]
+    hidden_states_new = torch.cat([conv_state, mixed_qkv], dim=-1).to(weight.dtype)
+    conv_state.copy_(hidden_states_new[:, :, -state_len:])
+    out = F.conv1d(
+        hidden_states_new, weight=weight.unsqueeze(1), bias=None, padding=0,
+        groups=hidden_size,
+    )[:, :, -seq_len:]
+    if activation == "silu":
+        out = F.silu(out)
+    return out.to(mixed_qkv.dtype)


### PR DESCRIPTION
## 概述

为 NPU 后端接入 KDA(Kimi Delta Attention)的 `execute_linear`:conv1d 保持纯 torch,delta-rule 调用 `fla_npu` 融合算子(`chunk_kda_fwd` for prefill,`recurrent_kda` for decode,含 MTP 多 token-per-seq varlen)。重新对齐 upstream 的 `LayerCache` dataclass,conv/ssm 状态读自框架池。

> `fla_npu` 是外部依赖,不在此 PR 编译安装;运行 KDA 层前需自行安装 fla_npu(暴露 `chunk_kda_fwd` / `recurrent_kda`)。

## 改动内容

### 1. `execute_linear` 接入

- **`xllm/python/attention/backend.py`**:新增 `AttentionBackend.execute_linear` 抽象入口(conv1d + delta-rule,操作框架 conv/ssm 状态),契约与 `execute_mla` 对称。
- **`xllm/python/attention/npu_paged_attention.py`**:
  - `NpuPagedAttentionBackend.execute_linear`:多并发走 **batched varlen**(引擎 flatten 多序列为 `[1,T,H,D]`,delta-rule 用 `cu_seqlens` **单次调用** fla_npu,非逐序列循环);单序列统一走 varlen(`cu_seqlens=[0,S]` 特例)。
  - `_kda_fla_npu_varlen`:decode→`recurrent_kda`(varlen),prefill→`chunk_kda_fwd`(varlen),无纯 torch fallback。
  - conv/ssm 直读 `_kv_caches`(单一真相源,无 projection list);状态契约用 assert 钉死(`linear_state_indices`/`conv`/`ssm`/`has_initial_state` 必须已设,引擎预分配池并每序列一槽)。

### 2. conv1d 辅助函数

- **`xllm/python/kernels_npu/kda.py`**(新增):纯 torch conv1d 辅助函数 —— `_l2norm`、`_causal_conv1d_fn`、`_causal_conv1d_update`。无模型耦合,任何环境均可安全 import。

## 验证

### 单算子对等(fla_npu vs 纯 torch 参考)

`fla_npu` 算子 vs 纯 torch 参考(`chunk_kimi_delta_attention`/`recurrent_kimi_delta_attention`),同一组输入,NPU 容器实跑,`B=1 / H=16 / K=V=128`,prefill `S=64`、decode `S=1`。

| 路径 | out maxdiff | state maxdiff |
|------|------------|---------------|
| prefill(`chunk_kda_fwd` vs `chunk_kimi`) | 3.9e-3(~0.4%) | 2.65e-2(~0.07%) |
| decode(`recurrent_kda` vs `recurrent_kimi`) | 6.1e-5 | 4.8e-7 |

> 相对量级:prefill out absmax 0.918、state absmax 37;decode 近乎精确。均在 bf16 精度内。