### PR TITLE
bugfix: clean NPU process shutdown (bypass process-static destructors).

### DIFF
--- a/xllm/xllm.cpp
+++ b/xllm/xllm.cpp
@@ -25,7 +25,10 @@ namespace py = pybind11;
 #endif
 
 #include <csignal>
+#include <cstdio>
+#include <cstdlib>
 #include <filesystem>
+#include <iostream>
 #include <memory>
 #include <random>
 
@@ -301,6 +304,18 @@ void init_npu_python_runtime() {
   if (we_initialized_python) {
     PyEval_SaveThread();
   }
+}
+
+[[noreturn]] void exit_npu_process(int exit_code) {
+  VerboseTraceLogger::get_instance().shutdown();
+  LOG(INFO) << "NPU process shutdown complete; bypassing process-static "
+               "destructors, exit_code="
+            << exit_code;
+  google::FlushLogFiles(google::INFO);
+  std::cout.flush();
+  std::cerr.flush();
+  std::fflush(nullptr);
+  std::_Exit(exit_code);
 }
 }  // namespace
 #endif
@@ -605,5 +620,10 @@ int main(int argc, char** argv) {
   init_npu_python_runtime();
 #endif
 
-  return run();
+  const int exit_code = run();
+#if defined(USE_NPU)
+  exit_npu_process(exit_code);
+#else
+  return exit_code;
+#endif
 }


### PR DESCRIPTION
## 问题
SIGTERM 停服时,Ascend `libopp_registry.so` 的进程静态析构 + pybind GIL `dec_ref` 会在 `run()` 清理之后抛 `terminate`,导致进程非干净退出(core/terminate)。

## 方案
新增 `exit_npu_process(int)`:flush 日志/stdio 后调用 `std::_Exit`,跳过进程静态析构,干净退出。`main()` 在 `USE_NPU` 下用它替代 `return run()`。

## 说明
- 与 DCP 功能正交,独立提交(不进 DCP PR #2125)。
- 已在 Ascend 910C 上卡验证:SIGTERM 停服哨兵日志出现、无 GIL/terminate/core、HBM/fd 归零。

🤖 Generated with [Claude Code](https://claude.com/claude-code)