### PR TITLE
bugfix: revert "fix A5 TileLang build and mRoPE correctness" (#2171).

### DIFF
--- a/xllm/compiler/tilelang/targets/ascend/kernels/spec_verify_attention_tiling_update.py
+++ b/xllm/compiler/tilelang/targets/ascend/kernels/spec_verify_attention_tiling_update.py
@@ -55,7 +55,7 @@ class SpecVerifyAttentionTilingUpdateKernel(TilelangKernel):
     ]
     SPECIALIZATIONS = [
         {
-            "variant_key": f"attn_tiling_w{spec_width}",
+            "variant_key": f"w{spec_width}",
             "spec_width": spec_width,
         }
         for spec_width in SUPPORTED_SPEC_VERIFY_WIDTHS

--- a/xllm/compiler/tilelang/targets/ascend/kernels/spec_verify_token_update.py
+++ b/xllm/compiler/tilelang/targets/ascend/kernels/spec_verify_token_update.py
@@ -91,7 +91,7 @@ def build_spec_verify_token_update_kernel(spec_width: int):
 class SpecVerifyTokenUpdateKernel(TilelangKernel):
     DISPATCH_SCHEMA = [DispatchField("spec_width", "int32")]
     SPECIALIZATIONS = [
-        {"variant_key": f"token_w{spec_width}", "spec_width": spec_width}
+        {"variant_key": f"w{spec_width}", "spec_width": spec_width}
         for spec_width in SUPPORTED_SPEC_VERIFY_WIDTHS
     ]
 

--- a/xllm/compiler/tilelang/targets/ascend/kernels/split_qkv_rmsnorm_mrope.py
+++ b/xllm/compiler/tilelang/targets/ascend/kernels/split_qkv_rmsnorm_mrope.py
@@ -380,6 +380,7 @@ def build_split_qkv_rmsnorm_mrope_kernel(
 
                 # Init: load gather pattern, weights.
                 T.copy(gather_pattern, gather_offset_ub)
+                T.tile.fill(axes_ub, 0.0)
                 T.copy(q_weight[0, 0], q_weight_half_ub[0, :])
                 T.copy(k_weight[0, 0], k_weight_half_ub[0, :])
                 mte2_notify_v(E.INIT_WEIGHTS)

--- a/xllm/compiler/tilelang/targets/ascend/toolchain.py
+++ b/xllm/compiler/tilelang/targets/ascend/toolchain.py
@@ -138,7 +138,6 @@ def bisheng_include_dirs() -> list[str]:
         f"{npu_home_path}/include",
         f"{npu_home_path}/include/experiment/runtime",
         f"{npu_home_path}/include/experiment/msprof",
-        f"{npu_home_path}/pkg_inc",
         f"{npu_home_path}/compiler/tikcpp",
         f"{npu_home_path}/compiler/tikcpp/tikcfw",
         f"{npu_home_path}/compiler/tikcpp/tikcfw/impl",


### PR DESCRIPTION
The torch_npu_ops submodule bump (9fb3a6c → a6cbf78) introduced an aicore kernel crash (error 507015) in TritonChunkGatedDeltaRuleTest on CANN 9. Revert the full PR to unblock CI until a corrected submodule revision is available.

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
