### PR TITLE
bugfix: move torch_npu calls from models/ to kernels_npu/ for arch boundary.

### DIFF
--- a/xllm/python/kernels_cuda/__init__.py
+++ b/xllm/python/kernels_cuda/__init__.py
@@ -37,6 +37,7 @@ from .activation import silu_and_mul
 from .attention import (
     reshape_paged_cache,
     update_decode_graph_metadata,
+    vision_fusion_attention,
 )
 from .causal_conv1d import (
     causal_conv1d_decode,
@@ -71,6 +72,8 @@ from .quantization import (
 from .rotary_embedding import (
     fused_qk_norm_rope,
     interleaved_rotary_embedding,
+    mrope,
+    vision_rotary_mul,
 )
 from .sparse_attention import (
     lightning_indexer,
@@ -88,8 +91,11 @@ __all__ = [
     "silu_and_mul",
     "reshape_paged_cache",
     "update_decode_graph_metadata",
+    "vision_fusion_attention",
     "fused_qk_norm_rope",
     "interleaved_rotary_embedding",
+    "mrope",
+    "vision_rotary_mul",
     "moe_fused_topk",
     "cutlass_fused_moe",
     "fused_moe",

--- a/xllm/python/kernels_cuda/attention.py
+++ b/xllm/python/kernels_cuda/attention.py
@@ -20,9 +20,36 @@ graph can replay them without re-planning.
 
 from __future__ import annotations
 
+from typing import List
+
 import torch
 
 reshape_paged_cache = torch.ops.xllm_ops.reshape_paged_cache
 update_decode_graph_metadata = torch.ops.xllm_ops.update_decode_graph_metadata
 
-__all__ = ["reshape_paged_cache", "update_decode_graph_metadata"]
+
+def vision_fusion_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    actual_seq_qlen: List[int],
+    actual_seq_kvlen: List[int],
+    num_heads: int,
+    scale: float,
+    input_layout: str = "TND",
+) -> torch.Tensor:
+    """Run fused self-attention for ViT blocks."""
+    del q, k, v, actual_seq_qlen, actual_seq_kvlen, num_heads, scale
+    del input_layout
+    raise NotImplementedError(
+        "vision_fusion_attention has no CUDA kernel; CUDA models use "
+        "FlashAttention for ViT blocks"
+    )
+
+
+__all__ = [
+    "reshape_paged_cache",
+    "update_decode_graph_metadata",
+    "vision_fusion_attention",
+]

--- a/xllm/python/kernels_cuda/rotary_embedding.py
+++ b/xllm/python/kernels_cuda/rotary_embedding.py
@@ -102,4 +102,40 @@ def interleaved_rotary_embedding(
     )
 
 
-__all__ = ["fused_qk_norm_rope", "interleaved_rotary_embedding"]
+def mrope(
+    positions: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    head_dim: int,
+    *,
+    mrope_section: list[int],
+    rotary_mode: str = "half",
+    cache_mode: str = "interleave",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply multi-dimensional RoPE (mRoPE) to query and key tensors."""
+    del positions, q, k, cos_sin_cache, head_dim, mrope_section
+    del rotary_mode, cache_mode
+    raise NotImplementedError(
+        "mrope has no CUDA kernel; models on CUDA use the standard RoPE path"
+    )
+
+
+def vision_rotary_mul(
+    value: torch.Tensor,
+    cos_full: torch.Tensor,
+    sin_full: torch.Tensor,
+) -> torch.Tensor:
+    """Apply RoPE via npu_rotary_mul (neox/half mode)."""
+    del value, cos_full, sin_full
+    raise NotImplementedError(
+        "vision_rotary_mul has no CUDA kernel; CUDA models use FlashInfer RoPE"
+    )
+
+
+__all__ = [
+    "fused_qk_norm_rope",
+    "interleaved_rotary_embedding",
+    "mrope",
+    "vision_rotary_mul",
+]

--- a/xllm/python/kernels_npu/__init__.py
+++ b/xllm/python/kernels_npu/__init__.py
@@ -36,6 +36,7 @@ from .activation import silu_and_mul
 from .attention import (
     reshape_paged_cache,
     update_decode_graph_metadata,
+    vision_fusion_attention,
 )
 from .causal_conv1d import (
     causal_conv1d_decode,
@@ -70,6 +71,8 @@ from .quantization import (
 from .rotary_embedding import (
     fused_qk_norm_rope,
     interleaved_rotary_embedding,
+    mrope,
+    vision_rotary_mul,
 )
 from .sparse_attention import (
     lightning_indexer,
@@ -87,8 +90,11 @@ __all__ = [
     "silu_and_mul",
     "reshape_paged_cache",
     "update_decode_graph_metadata",
+    "vision_fusion_attention",
     "fused_qk_norm_rope",
     "interleaved_rotary_embedding",
+    "mrope",
+    "vision_rotary_mul",
     "moe_fused_topk",
     "cutlass_fused_moe",
     "fused_moe",

--- a/xllm/python/kernels_npu/attention.py
+++ b/xllm/python/kernels_npu/attention.py
@@ -20,9 +20,54 @@ graph can replay them without re-planning.
 
 from __future__ import annotations
 
+from typing import List
+
 import torch
 
 reshape_paged_cache = torch.ops.xllm_ops.reshape_paged_cache
 update_decode_graph_metadata = torch.ops.xllm_ops.update_decode_graph_metadata
 
-__all__ = ["reshape_paged_cache", "update_decode_graph_metadata"]
+
+def vision_fusion_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    actual_seq_qlen: List[int],
+    actual_seq_kvlen: List[int],
+    num_heads: int,
+    scale: float,
+    input_layout: str = "TND",
+) -> torch.Tensor:
+    """Run fused self-attention for ViT blocks via ``torch_npu.npu_fusion_attention``.
+
+    Args:
+        q, k, v: Query/key/value in the layout specified by ``input_layout``.
+        actual_seq_qlen: Cumulative query sequence lengths.
+        actual_seq_kvlen: Cumulative key/value sequence lengths.
+        num_heads: Number of attention heads.
+        scale: Attention scaling factor.
+        input_layout: Tensor layout (default ``"TND"``).
+
+    Returns:
+        Attention output with same shape as ``q``.
+    """
+    import torch_npu
+
+    return torch_npu.npu_fusion_attention(
+        q,
+        k,
+        v,
+        actual_seq_qlen=actual_seq_qlen,
+        actual_seq_kvlen=actual_seq_kvlen,
+        head_num=num_heads,
+        scale=scale,
+        input_layout=input_layout,
+    )[0]
+
+
+__all__ = [
+    "reshape_paged_cache",
+    "update_decode_graph_metadata",
+    "vision_fusion_attention",
+]

--- a/xllm/python/kernels_npu/rotary_embedding.py
+++ b/xllm/python/kernels_npu/rotary_embedding.py
@@ -111,4 +111,73 @@ def _interleaved_rotary_embedding_fake(
     return torch.empty_like(value)
 
 
-__all__ = ["fused_qk_norm_rope", "interleaved_rotary_embedding"]
+def mrope(
+    positions: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    head_dim: int,
+    *,
+    mrope_section: list[int],
+    rotary_mode: str = "half",
+    cache_mode: str = "interleave",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply multi-dimensional RoPE (mRoPE) to query and key tensors.
+
+    Wraps ``torch_npu.npu_mrope``.
+
+    Args:
+        positions: ``[3, num_tokens]`` position ids (time/height/width), dtype int64.
+        q: ``[num_tokens, q_size]`` query tensor.
+        k: ``[num_tokens, kv_size]`` key tensor.
+        cos_sin_cache: ``[max_pos, head_dim]`` cos/sin table.
+        head_dim: Per-head dimension.
+        mrope_section: Section sizes for time/height/width.
+        rotary_mode: Rotation mode (default ``"half"``).
+        cache_mode: Cache layout mode (default ``"interleave"``).
+
+    Returns:
+        Rotated (q, k) with same shapes as inputs.
+    """
+    import torch_npu
+
+    return torch_npu.npu_mrope(
+        positions,
+        q,
+        k,
+        cos_sin_cache,
+        head_dim,
+        mrope_section=list(mrope_section),
+        rotary_mode=rotary_mode,
+        cache_mode=cache_mode,
+    )
+
+
+def vision_rotary_mul(
+    value: torch.Tensor,
+    cos_full: torch.Tensor,
+    sin_full: torch.Tensor,
+) -> torch.Tensor:
+    """Apply RoPE via ``torch_npu.npu_rotary_mul`` (neox/half mode).
+
+    Args:
+        value: ``(total_tokens, num_heads, head_dim)``.
+        cos_full: ``(1, total_tokens, 1, head_dim)``.
+        sin_full: ``(1, total_tokens, 1, head_dim)``.
+
+    Returns:
+        Rotated tensor with same shape as ``value``.
+    """
+    import torch_npu
+
+    return torch_npu.npu_rotary_mul(
+        value.unsqueeze(0).contiguous(), cos_full, sin_full
+    ).squeeze(0)
+
+
+__all__ = [
+    "fused_qk_norm_rope",
+    "interleaved_rotary_embedding",
+    "mrope",
+    "vision_rotary_mul",
+]

--- a/xllm/python/models/qwen3.py
+++ b/xllm/python/models/qwen3.py
@@ -175,12 +175,10 @@ class Qwen3Attention(nn.Module):
 
         if mrope_section is not None and positions.dim() == 2:
             # mRoPE prefill: per-head Q/K RMSNorm (same math as the fused
-            # kernel) then torch_npu.npu_mrope, which does the
-            # time/height/width section combination + rotation in one op.
+            # kernel) then kernels.mrope, which does the time/height/width
+            # section combination + rotation in one op.
             # cos_sin_cache here is the [max_pos, head_dim]=[cos_half|sin_half]
             # table; q/k stay 2D [N, num_heads*head_dim] as npu_mrope requires.
-            import torch_npu
-
             num_tokens = qkv.size(0)
             q = torch.ops.xllm_ops.rms_norm(
                 qkv[:, : self.q_size].reshape(
@@ -197,8 +195,8 @@ class Qwen3Attention(nn.Module):
                 self.k_norm.eps,
             ).view(num_tokens, self.kv_size)
             v = qkv[:, self.q_size + self.kv_size :]
-            q, k = torch_npu.npu_mrope(
-                positions.to(torch.int64),
+            q, k = kernels.mrope(
+                positions,
                 q,
                 k,
                 cos_sin_cache,

--- a/xllm/python/models/qwen3_vl.py
+++ b/xllm/python/models/qwen3_vl.py
@@ -34,7 +34,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from xllm.python import ops
+from xllm.python import kernels, ops
 from xllm.python.layers import (
     Attention,
     ColumnParallelLinear,
@@ -209,14 +209,8 @@ def _apply_vision_rotary(
         q, k: ``(total_tokens, num_heads, head_dim)``.
         cos_full, sin_full: ``(1, total_tokens, 1, head_dim)``.
     """
-    import torch_npu
-
-    q_embed = torch_npu.npu_rotary_mul(
-        q.unsqueeze(0).contiguous(), cos_full, sin_full
-    ).squeeze(0)
-    k_embed = torch_npu.npu_rotary_mul(
-        k.unsqueeze(0).contiguous(), cos_full, sin_full
-    ).squeeze(0)
+    q_embed = kernels.vision_rotary_mul(q, cos_full, sin_full)
+    k_embed = kernels.vision_rotary_mul(k, cos_full, sin_full)
     return q_embed, k_embed
 
 
@@ -315,8 +309,6 @@ class Qwen3VLVisionAttention(nn.Module):
         rotary_cos_full: torch.Tensor,
         rotary_sin_full: torch.Tensor,
     ) -> torch.Tensor:
-        import torch_npu
-
         seq_length = x.shape[0]
         qkv = self.qkv(x).reshape(
             seq_length, 3, self.num_heads, self.head_dim
@@ -332,16 +324,16 @@ class Qwen3VLVisionAttention(nn.Module):
             q = F.pad(q, (0, pad), value=0)
             k = F.pad(k, (0, pad), value=0)
             v = F.pad(v, (0, pad), value=0)
-        attn_output = torch_npu.npu_fusion_attention(
+        attn_output = kernels.vision_fusion_attention(
             q.contiguous(),
             k.contiguous(),
             v.contiguous(),
             actual_seq_qlen=actual_seq,
             actual_seq_kvlen=actual_seq,
-            head_num=self.num_heads,
+            num_heads=self.num_heads,
             scale=self.scaling,
             input_layout="TND",
-        )[0]
+        )
         if self.pad_to_max:
             attn_output = attn_output[..., : self.head_dim]
 


### PR DESCRIPTION

The test_models_and_layers_are_hardware_independent test enforces that models/ and layers/ must not directly import torch_npu. Move npu_mrope, npu_rotary_mul and npu_fusion_attention into kernels_npu/ wrappers (mrope, vision_rotary_mul, vision_fusion_attention) and add matching NotImplementedError stubs in kernels_cuda/ to satisfy the symmetric __all__ constraint.

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
