### PR TITLE
bugfix: retain no-sync inputs until validation completes.

### DIFF
--- a/xllm/core/runtime/dflash_worker_impl.cpp
+++ b/xllm/core/runtime/dflash_worker_impl.cpp
@@ -703,9 +703,7 @@ DFlashWorkerImpl::DraftBlock DFlashWorkerImpl::run_decode_draft(
       {batch_size, num_speculative_tokens});
   draft_block.probs = draft_output.sample_output.probs.view(
       {batch_size, num_speculative_tokens});
-  // Keep the draft's no-sync input alive past run_validate's compute-stream
-  // sync (see DraftBlock::draft_retained_input).
-  draft_block.draft_retained_input = std::move(draft_output.retained_input);
+  draft_block.retained_inputs = take_retained_inputs(draft_output);
   return draft_block;
 }
 

--- a/xllm/core/runtime/dflash_worker_impl.h
+++ b/xllm/core/runtime/dflash_worker_impl.h
@@ -64,12 +64,8 @@ class DFlashWorkerImpl : public SpeculativeWorkerImpl {
   struct DraftBlock {
     torch::Tensor token_ids;
     torch::Tensor probs;
-    // The draft runs no-sync, so execute_no_sync_on_stream stashes its still
-    // in-flight input in ForwardOutput::retained_input. Anchor it here so the
-    // draft input outlives run_validate's unconditional compute-stream sync;
-    // otherwise the buffer frees when run_decode_draft returns and the validate
-    // stage could reuse memory the draft kernel is still reading.
-    std::shared_ptr<ForwardInput> draft_retained_input;
+    // No-sync draft inputs must outlive validation's stream sync.
+    std::vector<std::shared_ptr<ForwardInput>> retained_inputs;
   };
 
   // virtual: DSpark overrides the draft sampling (parallel block sample ->

--- a/xllm/core/runtime/dspark_worker_impl.cpp
+++ b/xllm/core/runtime/dspark_worker_impl.cpp
@@ -98,7 +98,7 @@ DSparkWorkerImpl::DraftBlock DSparkWorkerImpl::run_decode_draft(
   DraftBlock draft_block;
   draft_block.token_ids = std::move(sample_output.token_ids);
   draft_block.probs = std::move(sample_output.probs);
-  draft_block.draft_retained_input = std::move(draft_output->retained_input);
+  draft_block.retained_inputs = take_retained_inputs(*draft_output);
 
   COUNTER_ADD(speculative_execution_latency_seconds_draft,
               timer.elapsed_seconds());

--- a/xllm/core/runtime/forward_params.h
+++ b/xllm/core/runtime/forward_params.h
@@ -631,11 +631,9 @@ struct ForwardOutput {
   int64_t max_top_logprobs = 0;
   SampleOutput sample_output;
   // Keep no-sync input tensor handles alive until downstream consumers finish
-  // using outputs on the same compute stream.
-  std::shared_ptr<ForwardInput> retained_input;
-  // Composite workers retain nested no-sync inputs until their final output is
-  // synchronized or its ready event is consumed.
-  std::vector<std::shared_ptr<ForwardInput>> retained_input_dependencies;
+  // using outputs on the same compute stream. Composite workers append child
+  // outputs' retained inputs here. Local runtime handles; not in proto/shm.
+  std::vector<std::shared_ptr<ForwardInput>> retained_inputs;
   // Device-side readiness dependency for no-sync outputs. This local runtime
   // handle is intentionally not included in proto or shared-memory transport.
   StreamEventPtr ready_event;
@@ -655,6 +653,29 @@ struct ForwardOutput {
   // dit output data
   DiTForwardOutput dit_forward_output;
 };
+
+inline void copy_retained_inputs(ForwardOutput& destination,
+                                 const ForwardOutput& source) {
+  destination.retained_inputs.insert(destination.retained_inputs.end(),
+                                     source.retained_inputs.begin(),
+                                     source.retained_inputs.end());
+}
+
+inline void transfer_retained_inputs(ForwardOutput& destination,
+                                     ForwardOutput& source) {
+  CHECK_NE(&destination, &source)
+      << "transfer_retained_inputs cannot alias source and destination";
+  destination.retained_inputs.insert(
+      destination.retained_inputs.end(),
+      std::make_move_iterator(source.retained_inputs.begin()),
+      std::make_move_iterator(source.retained_inputs.end()));
+  source.retained_inputs.clear();
+}
+
+inline std::vector<std::shared_ptr<ForwardInput>> take_retained_inputs(
+    ForwardOutput& source) {
+  return std::exchange(source.retained_inputs, {});
+}
 
 struct RawSampleOutput {
   std::vector<RawToken> tokens;  // num tokens

--- a/xllm/core/runtime/llm_worker_impl.cpp
+++ b/xllm/core/runtime/llm_worker_impl.cpp
@@ -408,7 +408,7 @@ std::optional<ForwardOutput> LLMWorkerImpl::step_internal(
 #endif
   if (sync_policy == ForwardSyncPolicy::NO_SYNC) {
     wait_kv_push();
-    output.retained_input = std::make_shared<ForwardInput>(input);
+    output.retained_inputs.emplace_back(std::make_shared<ForwardInput>(input));
     if (enable_schedule_overlap() && record_ready_event) {
       output.ready_event = record_current_stream_event(device_);
     }

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -211,30 +211,6 @@ void record_output_ready_event(ForwardOutput& output, Stream& stream) {
   output.ready_event = event;
 }
 
-void transfer_retained_inputs(ForwardOutput& destination,
-                              ForwardOutput& source) {
-  const size_t retained_input_count =
-      source.retained_input_dependencies.size() +
-      (source.retained_input != nullptr ? 1 : 0);
-  destination.retained_input_dependencies.reserve(
-      destination.retained_input_dependencies.size() + retained_input_count);
-  if (source.retained_input != nullptr) {
-    destination.retained_input_dependencies.emplace_back(
-        std::move(source.retained_input));
-  }
-  for (std::shared_ptr<ForwardInput>& retained_input :
-       source.retained_input_dependencies) {
-    destination.retained_input_dependencies.emplace_back(
-        std::move(retained_input));
-  }
-  source.retained_input_dependencies.clear();
-}
-
-void release_retained_inputs(ForwardOutput& output) {
-  output.retained_input.reset();
-  output.retained_input_dependencies.clear();
-}
-
 void finalize_output_on_stream(ForwardOutput& output,
                                Stream& stream,
                                bool allow_async) {
@@ -244,7 +220,7 @@ void finalize_output_on_stream(ForwardOutput& output,
   }
   const int32_t ret = stream.synchronize();
   CHECK_EQ(ret, 0) << "failed to synchronize MTP compute stream, ret=" << ret;
-  release_retained_inputs(output);
+  output.retained_inputs.clear();
 }
 
 #if defined(USE_NPU)
@@ -2066,7 +2042,7 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
 
     const int32_t ret = compute_stream_->synchronize();
     CHECK_EQ(ret, 0) << "failed to synchronize MTP compute stream, ret=" << ret;
-    release_retained_inputs(target_output);
+    target_output.retained_inputs.clear();
     val_output.next_tokens = val_output.next_tokens.to(torch::kCPU);
     // Record adaptive-prune-aware draft/accept counts on the already-CPU
     // next_tokens. Static path lets worker_service count on the async-handoff
@@ -2146,22 +2122,16 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
   }
   target_output.ready_event = target_context_ready_event;
 
-  // Target validation consumes all draft outputs on the same compute stream.
-  // Keep their prepared inputs alive until the target-context event completes.
+  // Target validation consumes all draft outputs on the same compute stream;
+  // keep their prepared inputs alive on target_output until the target-context
+  // event completes. Copy (not move): draft_outputs live beyond this loop.
   for (const ForwardOutput& draft_output : draft_outputs) {
-    if (draft_output.retained_input != nullptr) {
-      target_output.retained_input_dependencies.emplace_back(
-          draft_output.retained_input);
-    }
-    target_output.retained_input_dependencies.insert(
-        target_output.retained_input_dependencies.end(),
-        draft_output.retained_input_dependencies.begin(),
-        draft_output.retained_input_dependencies.end());
+    copy_retained_inputs(target_output, draft_output);
   }
 
   if (!enable_schedule_overlap()) {
     flush_pending_target_context();
-    release_retained_inputs(target_output);
+    target_output.retained_inputs.clear();
     target_output.ready_event.reset();
     val_output.next_tokens = std::move(accepted_tokens_cpu_result);
   }

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -1195,9 +1195,7 @@ folly::SemiFuture<std::optional<ForwardOutput>> WorkerImpl::step_async(
       const auto output = this->step_for_schedule_overlap(input);
 #if defined(USE_NPU)
       if (output.has_value() && !output->sample_output.next_tokens.defined() &&
-          output->ready_event != nullptr &&
-          (output->retained_input != nullptr ||
-           !output->retained_input_dependencies.empty())) {
+          output->ready_event != nullptr && !output->retained_inputs.empty()) {
         CHECK(output->ready_event->synchronize())
             << "failed to retire asynchronous output without tokens";
       }


### PR DESCRIPTION
## Summary

DFlash and DSpark keep the `DraftBlock` alive across `run_validate`'s compute-stream sync, while the no-sync draft kernel is still reading the `ForwardInput` tensor buffers on device. Without anchoring those handles, the buffers freed when `run_decode_draft` returned and validation could reuse memory the draft kernel had not finished with.

- Unify `ForwardOutput::retained_input` (single) and `retained_input_dependencies` (vector) into a single `retained_inputs` vector.
- Colocate `copy_retained_inputs` / `transfer_retained_inputs` / `take_retained_inputs` helpers with `ForwardOutput` in `forward_params.h`.
- Reuse them from MTP, DFlash, and DSpark so every producer follows the same lifetime rule.

## Files changed

- `xllm/core/runtime/forward_params.h` — unified field + 3 inline helpers
- `xllm/core/runtime/llm_worker_impl.cpp` — write side updated
- `xllm/core/runtime/mtp_worker_impl.cpp` — file-local `transfer_retained_inputs`/`release_retained_inputs` removed; callsites now use header helpers or inline `.clear()`
- `xllm/core/runtime/dflash_worker_impl.{h,cpp}` — `DraftBlock` uses vector-shaped `retained_inputs`
- `xllm/core/runtime/dspark_worker_impl.cpp` — same

Net: +38/-53.

## Test plan

- [ ] Rebuild `xllm` (NPU) and run existing speculative decoding tests.
- [ ] Sanity: run DFlash/DSpark speculative decode under schedule-overlap to confirm no stream-reuse memory corruption in validation.
- [ ] `git diff` review: no callsite in `mtp_worker_impl.cpp` changed its behavior — `transfer_retained_inputs` name is preserved from main, only its definition body switched to the unified field.