### PR TITLE
bugfix: Align empty DP shards for Qwen3.5 MTP ACL graphs.

### DIFF
--- a/tests/core/runtime/acl_graph_executor_test.cpp
+++ b/tests/core/runtime/acl_graph_executor_test.cpp
@@ -938,6 +938,102 @@ TEST_F(AclGraphExecutorTest, BatchInputCarriesLinearStateIds) {
   EXPECT_EQ(params_for_capture->linear_state_validity_mask[1], 0);
 }
 
+TEST(AclGraphPersistentParamTest,
+     EmptyHybridDpDecodePadsLinearStateGraphMetadata) {
+  ModelArgs args;
+  args.model_type("qwen3_5");
+  args.dtype("float32");
+  args.hidden_size(8);
+  args.max_position_embeddings(32);
+
+  runtime::Options options;
+  options.block_size(4);
+  options.max_seqs_per_batch(4);
+  options.max_tokens_per_batch(4);
+  options.num_decoding_tokens(1);
+
+  const torch::Device device("npu:0");
+  const auto int_options = torch::dtype(torch::kInt).device(device);
+  npu::GraphPersistentParam persistent_param(
+      args, device, options, false, true);
+
+  ModelInputParams params;
+  params.meta.batch_forward_type = BatchForwardType::DECODE;
+  params.meta.q_max_seq_len = 1;
+  params.meta.kv_max_seq_len = 1;
+  params.parallel.dp_global_token_nums = {1, 1};
+
+  const torch::Tensor tokens = torch::ones({1}, int_options);
+  const torch::Tensor positions = torch::zeros({1}, int_options);
+  std::optional<ModelInputParams> params_for_capture = persistent_param.update(
+      tokens, torch::Tensor(), torch::Tensor(), positions, params, 2, true);
+
+  ASSERT_TRUE(params_for_capture.has_value());
+  EXPECT_EQ(params_for_capture->meta.actual_num_sequences, 0);
+  EXPECT_EQ(params_for_capture->meta.num_sequences, 2);
+  EXPECT_EQ(
+      params_for_capture->embedding.linear_state_ids,
+      std::vector<int32_t>({kPaddingLinearStateId, kPaddingLinearStateId}));
+  EXPECT_TRUE(torch::equal(
+      params_for_capture->embedding.linear_state_indices.cpu(),
+      torch::tensor({kPaddingLinearStateId, kPaddingLinearStateId})));
+  EXPECT_EQ(params_for_capture->linear_state_validity_mask,
+            std::vector<int64_t>({0, 0}));
+  EXPECT_EQ(params_for_capture->parallel.query_start_loc,
+            std::vector<int64_t>({0, 1, 2}));
+}
+
+TEST(AclGraphPersistentParamTest,
+     EmptyHybridDpDecodeGraphMaskDoesNotDerefUndefinedKvSeqLens) {
+  ModelArgs args;
+  args.model_type("qwen3_5");
+  args.dtype("float32");
+  args.hidden_size(8);
+  args.max_position_embeddings(32);
+
+  runtime::Options options;
+  options.block_size(4);
+  options.max_seqs_per_batch(4);
+  options.max_tokens_per_batch(4);
+  options.num_decoding_tokens(1);
+
+  const torch::Device device("npu:0");
+  const auto int_options = torch::dtype(torch::kInt).device(device);
+  // need_update_attn_mask=true opens the attention-mask path that an empty DP
+  // decode shard used to crash on (undefined per-rank kv_seq_lens).
+  npu::GraphPersistentParam persistent_param(
+      args,
+      device,
+      options,
+      /*need_update_attn_mask=*/true,
+      /*is_hybrid_linear_attention=*/true);
+
+  ModelInputParams params;
+  params.meta.batch_forward_type = BatchForwardType::DECODE;
+  params.meta.q_max_seq_len = 1;
+  params.meta.kv_max_seq_len = 1;
+  params.parallel.dp_global_token_nums = {1, 1};
+  // attention.device.kv_seq_lens intentionally left undefined: this is the
+  // empty-shard state that previously threw in update_attention_mask().
+
+  const torch::Tensor tokens = torch::ones({1}, int_options);
+  const torch::Tensor positions = torch::zeros({1}, int_options);
+  std::optional<ModelInputParams> params_for_capture = persistent_param.update(
+      tokens, torch::Tensor(), torch::Tensor(), positions, params, 2, true);
+
+  // Core assertion: update() must not dereference the undefined kv_seq_lens.
+  ASSERT_TRUE(params_for_capture.has_value());
+  EXPECT_EQ(params_for_capture->meta.actual_num_sequences, 0);
+  EXPECT_EQ(params_for_capture->meta.num_sequences, 2);
+  // The captured graph mask must be a defined, all-cold (all-zero) mask over
+  // the padded rows, not a stale or undefined tensor.
+  const torch::Tensor& attn_mask = params_for_capture->graph.attn_mask;
+  ASSERT_TRUE(attn_mask.defined());
+  EXPECT_EQ(attn_mask.size(0), 2);
+  EXPECT_TRUE(
+      torch::equal(attn_mask.cpu(), torch::zeros_like(attn_mask.cpu())));
+}
+
 TEST_F(AclGraphExecutorTest, GraphDoubleBufferFlagControlsSlotCount) {
   ExecutionConfig& execution_config = ExecutionConfig::get_instance();
   const bool original_enable_graph_double_buffer =

--- a/tests/core/runtime/acl_graph_executor_test.cpp
+++ b/tests/core/runtime/acl_graph_executor_test.cpp
@@ -47,6 +47,7 @@ limitations under the License.
 #include "core/runtime/acl_graph_persistent_param.h"
 #include "core/runtime/base_executor_impl.h"
 #include "core/runtime/mtp_async_state.h"
+#include "core/runtime/mtp_worker_impl.h"
 #include "core/runtime/options.h"
 #include "core/runtime/speculative_worker_impl.h"
 #include "models/model_registry.h"
@@ -112,6 +113,22 @@ TEST(AclGraphStaticGraphTaskSignatureTest,
 }
 
 namespace {
+class EmptyValidateTestMTPWorker final : public MTPWorkerImpl {
+ public:
+  EmptyValidateTestMTPWorker(const ParallelArgs& parallel_args,
+                             const torch::Device& device,
+                             const runtime::Options& options)
+      : MTPWorkerImpl(parallel_args, device, options) {}
+
+  ForwardInput prepare_empty_qwen_validate_input(const ForwardInput& input) {
+    target_spec_verify_mode_ =
+        mtp_async::TargetSpecVerifyMode::QWEN3_5_EXPANDED_VERIFY;
+    ForwardInput validate_input;
+    prepare_empty_validate_inputs(input, validate_input);
+    return validate_input;
+  }
+};
+
 const KVCache& first_full_attention_cache(
     const std::vector<KVCache>& kv_caches) {
   for (const auto& kv_cache : kv_caches) {
@@ -1086,9 +1103,50 @@ TEST(AclGraphPersistentParamTest,
             kPaddedTokens);
 }
 
+TEST(MTPWorkerImplTest, EmptyRankUsesExpandedSpecVerifyTargetLayout) {
+  constexpr int32_t kSpeculativeTokens = 3;
+  constexpr int32_t kSpecWidth = kSpeculativeTokens + 1;
+  const torch::Device device("npu:0");
+  layer::test::MockProcessGroup process_group(
+      device, /*rank=*/0, /*world_size=*/1);
+  ParallelArgs parallel_args(
+      /*rank=*/0, /*world_size=*/1, &process_group);
+  runtime::Options options;
+  options.num_speculative_tokens(kSpeculativeTokens);
+  EmptyValidateTestMTPWorker worker(parallel_args, device, options);
+
+  ForwardInput input;
+  input.input_params.meta.num_sequences = 0;
+  input.input_params.meta.batch_forward_type = BatchForwardType::DECODE;
+  input.input_params.parallel.dp_global_token_nums = {1, 0};
+  input.input_params.parallel.raw_dp_global_token_nums = {1, 0};
+
+  ForwardInput validate_input = worker.prepare_empty_qwen_validate_input(input);
+  const ModelInputParams& params = validate_input.input_params;
+
+  EXPECT_TRUE(params.meta.batch_forward_type.is_chunked_prefill());
+  EXPECT_TRUE(params.is_spec_verify);
+  EXPECT_EQ(params.meta.num_sequences, 0);
+  EXPECT_EQ(params.meta.q_max_seq_len, kSpecWidth);
+  EXPECT_EQ(params.meta.kv_max_seq_len, 1);
+  EXPECT_EQ(params.parallel.dp_global_token_nums,
+            std::vector<int32_t>({kSpecWidth, 0}));
+  EXPECT_EQ(params.parallel.raw_dp_global_token_nums,
+            std::vector<int32_t>({kSpecWidth, 0}));
+  EXPECT_TRUE(params.graph.use_expanded_decode_for_spec_verify_attention);
+  EXPECT_EQ(params.graph.expanded_kv_seq_lens_vec, std::vector<int32_t>({1}));
+  ASSERT_TRUE(params.graph.expanded_kv_seq_lens.defined());
+  EXPECT_EQ(params.graph.expanded_kv_seq_lens.numel(), 1);
+  ASSERT_TRUE(params.graph.expanded_block_tables.defined());
+  EXPECT_EQ(params.graph.expanded_block_tables.size(0), 1);
+  EXPECT_EQ(params.graph.expanded_block_tables.size(1), 1);
+  EXPECT_FALSE(params.graph.spec_verify_source_addresses_stable);
+}
+
 TEST(AclGraphPersistentParamTest,
-     EmptyHybridMtpSpecVerifyDpGraphPadsEmptyShardMetadata) {
+     EmptyHybridMtpSpecVerifyDpGraphPadsDummyExpandedMetadata) {
   constexpr int32_t kSpecWidth = 4;
+  constexpr int32_t kLocalDummyTokens = 1;
   ModelArgs args;
   args.model_type("qwen3_5");
   args.dtype("float32");
@@ -1118,15 +1176,18 @@ TEST(AclGraphPersistentParamTest,
   params.meta.batch_forward_type = BatchForwardType::CHUNKED_PREFILL;
   params.meta.q_max_seq_len = kSpecWidth;
   params.meta.kv_max_seq_len = 1;
-  params.parallel.dp_global_token_nums = {kSpecWidth, kSpecWidth};
+  params.parallel.dp_global_token_nums = {kSpecWidth, 0};
+  params.parallel.raw_dp_global_token_nums = {kSpecWidth, 0};
 
-  const torch::Tensor tokens = torch::ones({kSpecWidth}, int_options);
-  const torch::Tensor positions = torch::zeros({kSpecWidth}, int_options);
+  const torch::Tensor tokens = torch::ones({kLocalDummyTokens}, int_options);
+  const torch::Tensor positions =
+      torch::zeros({kLocalDummyTokens}, int_options);
   params.graph.use_expanded_decode_for_spec_verify_attention = true;
-  params.graph.expanded_kv_seq_lens = torch::ones({kSpecWidth}, int_options);
-  params.graph.expanded_kv_seq_lens_vec.assign(kSpecWidth, 1);
+  params.graph.expanded_kv_seq_lens =
+      torch::ones({kLocalDummyTokens}, int_options);
+  params.graph.expanded_kv_seq_lens_vec.assign(kLocalDummyTokens, 1);
   params.graph.expanded_block_tables =
-      torch::zeros({kSpecWidth, 1}, int_options);
+      torch::zeros({kLocalDummyTokens, 1}, int_options);
   std::optional<ModelInputParams> params_for_capture =
       persistent_param.update(tokens,
                               torch::Tensor(),
@@ -1148,10 +1209,19 @@ TEST(AclGraphPersistentParamTest,
             std::vector<int64_t>({0}));
   EXPECT_EQ(params_for_capture->parallel.query_start_loc,
             std::vector<int64_t>({0, kSpecWidth}));
+  EXPECT_TRUE(
+      params_for_capture->graph.use_expanded_decode_for_spec_verify_attention);
   EXPECT_TRUE(params_for_capture->graph.expanded_kv_seq_lens.defined());
   EXPECT_EQ(params_for_capture->graph.expanded_kv_seq_lens.numel(), kSpecWidth);
   EXPECT_EQ(params_for_capture->graph.expanded_kv_seq_lens_vec,
             std::vector<int32_t>(kSpecWidth, 1));
+  ASSERT_TRUE(params_for_capture->graph.expanded_block_tables.defined());
+  EXPECT_EQ(params_for_capture->graph.expanded_block_tables.size(0),
+            kSpecWidth);
+  EXPECT_TRUE(
+      torch::equal(params_for_capture->graph.expanded_block_tables.cpu(),
+                   torch::zeros_like(
+                       params_for_capture->graph.expanded_block_tables.cpu())));
   EXPECT_FALSE(params_for_capture->graph.attn_mask.defined());
 }
 

--- a/tests/core/runtime/acl_graph_executor_test.cpp
+++ b/tests/core/runtime/acl_graph_executor_test.cpp
@@ -1225,6 +1225,138 @@ TEST(AclGraphPersistentParamTest,
   EXPECT_FALSE(params_for_capture->graph.attn_mask.defined());
 }
 
+TEST(AclGraphPersistentParamTest,
+     EmptyAndActiveRanksProduceIdenticalExpandedBlockTableWidth) {
+  constexpr int32_t kSpecWidth = 4;
+  constexpr int32_t kActiveNumSequences = 1;
+  constexpr int32_t kActiveNumTokens = kSpecWidth;
+  constexpr int32_t kEmptyLocalTokens = 1;
+  constexpr int32_t kActiveBlockTableWidth = 3;
+  constexpr int32_t kEmptyBlockTableWidth = 1;
+
+  ModelArgs args;
+  args.model_type("qwen3_5");
+  args.dtype("float32");
+  args.hidden_size(8);
+  args.max_position_embeddings(32);
+
+  runtime::Options options;
+  options.block_size(4);
+  options.dp_size(2);
+  options.max_seqs_per_batch(4);
+  options.max_tokens_per_batch(16);
+  options.num_decoding_tokens(kSpecWidth);
+  options.enable_speculative_decode(true);
+  options.is_draft_engine(false);
+
+  const torch::Device device("npu:0");
+  const auto int_options = torch::dtype(torch::kInt).device(device);
+
+  auto make_common_params = []() {
+    ModelInputParams params;
+    params.is_spec_verify = true;
+    params.meta.batch_forward_type = BatchForwardType::CHUNKED_PREFILL;
+    params.meta.q_max_seq_len = kSpecWidth;
+    params.meta.kv_max_seq_len = 1;
+    params.parallel.dp_global_token_nums = {kSpecWidth, 0};
+    params.parallel.raw_dp_global_token_nums = {kSpecWidth, 0};
+    params.graph.use_expanded_decode_for_spec_verify_attention = true;
+    return params;
+  };
+
+  npu::GraphPersistentParam active_persistent(args,
+                                              device,
+                                              options,
+                                              /*need_update_attn_mask=*/true,
+                                              /*is_hybrid_linear_attention=*/
+                                              true);
+  npu::GraphPersistentParam empty_persistent(args,
+                                             device,
+                                             options,
+                                             /*need_update_attn_mask=*/true,
+                                             /*is_hybrid_linear_attention=*/
+                                             true);
+
+  ModelInputParams active_params = make_common_params();
+  active_params.meta.num_sequences = kActiveNumSequences;
+  active_params.attention.host.q_seq_lens = {kSpecWidth};
+  active_params.attention.host.kv_seq_lens = {kSpecWidth};
+  active_params.attention.host.new_cache_slots =
+      std::vector<int32_t>(kActiveNumTokens, 0);
+  active_params.attention.host.block_tables = torch::zeros(
+      {kActiveNumSequences, kActiveBlockTableWidth},
+      torch::TensorOptions().dtype(torch::kInt).device(torch::kCPU));
+  active_params.attention.device.block_tables =
+      torch::zeros({kActiveNumSequences, kActiveBlockTableWidth}, int_options);
+  active_params.attention.device.q_seq_lens =
+      torch::full({kActiveNumSequences}, kSpecWidth, int_options);
+  active_params.attention.device.kv_seq_lens =
+      torch::full({kActiveNumSequences}, kSpecWidth, int_options);
+  active_params.attention.device.new_cache_slots =
+      torch::zeros({kActiveNumTokens}, int_options);
+  active_params.embedding.linear_state_ids =
+      std::vector<int32_t>(kActiveNumSequences, 0);
+  active_params.embedding.linear_state_indices =
+      torch::zeros({kActiveNumSequences}, int_options);
+  active_params.linear_state_validity_mask =
+      std::vector<int64_t>(kActiveNumSequences, 1);
+  active_params.graph.expanded_kv_seq_lens =
+      torch::ones({kActiveNumTokens}, int_options);
+  active_params.graph.expanded_kv_seq_lens_vec.assign(kActiveNumTokens, 1);
+  active_params.graph.expanded_block_tables =
+      torch::zeros({kActiveNumTokens, kActiveBlockTableWidth}, int_options);
+
+  const torch::Tensor active_tokens =
+      torch::ones({kActiveNumTokens}, int_options);
+  const torch::Tensor active_positions =
+      torch::zeros({kActiveNumTokens}, int_options);
+  std::optional<ModelInputParams> active_capture =
+      active_persistent.update(active_tokens,
+                               torch::Tensor(),
+                               torch::Tensor(),
+                               active_positions,
+                               active_params,
+                               kSpecWidth,
+                               true);
+  ASSERT_TRUE(active_capture.has_value());
+  ASSERT_TRUE(active_capture->graph.expanded_block_tables.defined());
+
+  ModelInputParams empty_params = make_common_params();
+  empty_params.meta.num_sequences = 0;
+  empty_params.graph.expanded_kv_seq_lens =
+      torch::ones({kEmptyLocalTokens}, int_options);
+  empty_params.graph.expanded_kv_seq_lens_vec.assign(kEmptyLocalTokens, 1);
+  empty_params.graph.expanded_block_tables =
+      torch::zeros({kEmptyLocalTokens, kEmptyBlockTableWidth}, int_options);
+
+  const torch::Tensor empty_tokens =
+      torch::ones({kEmptyLocalTokens}, int_options);
+  const torch::Tensor empty_positions =
+      torch::zeros({kEmptyLocalTokens}, int_options);
+  std::optional<ModelInputParams> empty_capture =
+      empty_persistent.update(empty_tokens,
+                              torch::Tensor(),
+                              torch::Tensor(),
+                              empty_positions,
+                              empty_params,
+                              kSpecWidth,
+                              true);
+  ASSERT_TRUE(empty_capture.has_value());
+  ASSERT_TRUE(empty_capture->graph.expanded_block_tables.defined());
+
+  EXPECT_EQ(active_capture->graph.expanded_block_tables.size(1),
+            empty_capture->graph.expanded_block_tables.size(1))
+      << "active/empty rank expanded_block_tables must share the same width "
+         "so both ranks bind the same tensor view into the captured graph";
+  EXPECT_EQ(active_capture->graph.expanded_block_tables.size(0),
+            empty_capture->graph.expanded_block_tables.size(0))
+      << "active/empty rank expanded_block_tables must also pad to the same "
+         "row count (padded_num_tokens)";
+  EXPECT_EQ(active_capture->graph.expanded_block_tables.size(1),
+            mtp_async::speculative_verify_block_table_capacity(
+                args.max_position_embeddings(), options.block_size()));
+}
+
 TEST_F(AclGraphExecutorTest, GraphDoubleBufferFlagControlsSlotCount) {
   ExecutionConfig& execution_config = ExecutionConfig::get_instance();
   const bool original_enable_graph_double_buffer =
@@ -1244,6 +1376,52 @@ TEST_F(AclGraphExecutorTest, GraphDoubleBufferFlagControlsSlotCount) {
 
   execution_config.enable_graph_double_buffer(
       original_enable_graph_double_buffer);
+}
+
+TEST_F(AclGraphExecutorTest,
+       GenericSpecVerifyPathActiveAndEmptyRanksProduceIdenticalGraphKey) {
+  constexpr int32_t kSpecWidth = 4;
+  constexpr uint32_t kBucketNumTokens = 4;
+
+  auto executor = std::make_unique<::xllm::npu::AclGraphExecutorImpl>(
+      model_.get(), model_args_, *device_, options_);
+
+  auto make_common_spec_verify_params = []() {
+    ModelInputParams params;
+    params.is_spec_verify = true;
+    params.meta.batch_forward_type = BatchForwardType::CHUNKED_PREFILL;
+    params.meta.q_max_seq_len = kSpecWidth;
+    params.graph.spec_verify_source_addresses_stable = false;
+    params.graph.use_expanded_decode_for_spec_verify_attention = true;
+    return params;
+  };
+
+  ModelInputParams active_params = make_common_spec_verify_params();
+  active_params.meta.num_sequences = 1;
+  active_params.parallel.dp_global_token_nums = {kSpecWidth, 0};
+  active_params.parallel.raw_dp_global_token_nums = {kSpecWidth, 0};
+  active_params.attention.host.q_seq_lens = {kSpecWidth};
+  active_params.attention.host.kv_seq_lens = {kSpecWidth};
+
+  ModelInputParams empty_params = make_common_spec_verify_params();
+  empty_params.meta.num_sequences = 0;
+  empty_params.parallel.dp_global_token_nums = {kSpecWidth, 0};
+  empty_params.parallel.raw_dp_global_token_nums = {kSpecWidth, 0};
+  empty_params.attention.host.q_seq_lens.clear();
+  empty_params.attention.host.kv_seq_lens.clear();
+
+  const uint64_t active_key = executor->get_graph_key_for_test(
+      kBucketNumTokens, active_params, /*attention_plan_class=*/0);
+  const uint64_t empty_key = executor->get_graph_key_for_test(
+      kBucketNumTokens, empty_params, /*attention_plan_class=*/0);
+
+  EXPECT_EQ(active_key, empty_key)
+      << "active/empty rank spec-verify graph keys must match; drift means "
+         "capture/replay would silently split across ranks";
+
+  const uint64_t pure_decode_key = static_cast<uint64_t>(kBucketNumTokens);
+  EXPECT_NE(active_key, pure_decode_key)
+      << "spec-verify path must not collapse into the pure-decode key space";
 }
 
 TEST(AclGraphPersistentParamTest, SpecVerifyMetadataUsesTokenCapacity) {

--- a/tests/core/runtime/acl_graph_executor_test.cpp
+++ b/tests/core/runtime/acl_graph_executor_test.cpp
@@ -1034,6 +1034,127 @@ TEST(AclGraphPersistentParamTest,
       torch::equal(attn_mask.cpu(), torch::zeros_like(attn_mask.cpu())));
 }
 
+TEST(AclGraphPersistentParamTest,
+     EmptyHybridMtpDpDecodeUsesTokenMetadataCapacity) {
+  constexpr int32_t kDecodeTokens = 4;
+  constexpr int32_t kMaxSequences = 4;
+  constexpr int32_t kPaddedTokens = kDecodeTokens * kMaxSequences;
+  ModelArgs args;
+  args.model_type("qwen3_5");
+  args.dtype("float32");
+  args.hidden_size(8);
+  args.max_position_embeddings(32);
+
+  runtime::Options options;
+  options.block_size(4);
+  options.dp_size(2);
+  options.max_seqs_per_batch(kMaxSequences);
+  options.max_tokens_per_batch(kPaddedTokens);
+  options.num_decoding_tokens(kDecodeTokens);
+  options.enable_speculative_decode(true);
+  options.is_draft_engine(false);
+
+  const torch::Device device("npu:0");
+  const auto int_options = torch::dtype(torch::kInt).device(device);
+  npu::GraphPersistentParam persistent_param(
+      args, device, options, false, true);
+
+  ModelInputParams params;
+  params.meta.batch_forward_type = BatchForwardType::DECODE;
+  params.meta.q_max_seq_len = 1;
+  params.meta.kv_max_seq_len = 1;
+  params.parallel.dp_global_token_nums = {1, 1};
+
+  const torch::Tensor tokens = torch::ones({kPaddedTokens}, int_options);
+  const torch::Tensor positions = torch::zeros({kPaddedTokens}, int_options);
+  std::optional<ModelInputParams> params_for_capture =
+      persistent_param.update(tokens,
+                              torch::Tensor(),
+                              torch::Tensor(),
+                              positions,
+                              params,
+                              kPaddedTokens,
+                              true);
+
+  ASSERT_TRUE(params_for_capture.has_value());
+  EXPECT_EQ(persistent_param.q_seq_lens().size(0), kPaddedTokens);
+  EXPECT_EQ(persistent_param.persistent_block_tables().size(0), kPaddedTokens);
+  EXPECT_EQ(params_for_capture->meta.num_sequences, kPaddedTokens);
+  EXPECT_EQ(params_for_capture->attention.device.block_tables.size(0),
+            kPaddedTokens);
+  EXPECT_EQ(params_for_capture->embedding.linear_state_indices.size(0),
+            kPaddedTokens);
+}
+
+TEST(AclGraphPersistentParamTest,
+     EmptyHybridMtpSpecVerifyDpGraphPadsEmptyShardMetadata) {
+  constexpr int32_t kSpecWidth = 4;
+  ModelArgs args;
+  args.model_type("qwen3_5");
+  args.dtype("float32");
+  args.hidden_size(8);
+  args.max_position_embeddings(32);
+
+  runtime::Options options;
+  options.block_size(4);
+  options.dp_size(2);
+  options.max_seqs_per_batch(4);
+  options.max_tokens_per_batch(16);
+  options.num_decoding_tokens(kSpecWidth);
+  options.enable_speculative_decode(true);
+  options.is_draft_engine(false);
+
+  const torch::Device device("npu:0");
+  const auto int_options = torch::dtype(torch::kInt).device(device);
+  npu::GraphPersistentParam persistent_param(
+      args,
+      device,
+      options,
+      /*need_update_attn_mask=*/true,
+      /*is_hybrid_linear_attention=*/true);
+
+  ModelInputParams params;
+  params.is_spec_verify = true;
+  params.meta.batch_forward_type = BatchForwardType::CHUNKED_PREFILL;
+  params.meta.q_max_seq_len = kSpecWidth;
+  params.meta.kv_max_seq_len = 1;
+  params.parallel.dp_global_token_nums = {kSpecWidth, kSpecWidth};
+
+  const torch::Tensor tokens = torch::ones({kSpecWidth}, int_options);
+  const torch::Tensor positions = torch::zeros({kSpecWidth}, int_options);
+  params.graph.use_expanded_decode_for_spec_verify_attention = true;
+  params.graph.expanded_kv_seq_lens = torch::ones({kSpecWidth}, int_options);
+  params.graph.expanded_kv_seq_lens_vec.assign(kSpecWidth, 1);
+  params.graph.expanded_block_tables =
+      torch::zeros({kSpecWidth, 1}, int_options);
+  std::optional<ModelInputParams> params_for_capture =
+      persistent_param.update(tokens,
+                              torch::Tensor(),
+                              torch::Tensor(),
+                              positions,
+                              params,
+                              kSpecWidth,
+                              true);
+
+  ASSERT_TRUE(params_for_capture.has_value());
+  EXPECT_EQ(params_for_capture->meta.actual_num_sequences, 0);
+  EXPECT_EQ(params_for_capture->meta.num_sequences, 1);
+  EXPECT_EQ(params_for_capture->embedding.linear_state_ids,
+            std::vector<int32_t>({kPaddingLinearStateId}));
+  EXPECT_TRUE(
+      torch::equal(params_for_capture->embedding.linear_state_indices.cpu(),
+                   torch::tensor({kPaddingLinearStateId}, torch::kInt32)));
+  EXPECT_EQ(params_for_capture->linear_state_validity_mask,
+            std::vector<int64_t>({0}));
+  EXPECT_EQ(params_for_capture->parallel.query_start_loc,
+            std::vector<int64_t>({0, kSpecWidth}));
+  EXPECT_TRUE(params_for_capture->graph.expanded_kv_seq_lens.defined());
+  EXPECT_EQ(params_for_capture->graph.expanded_kv_seq_lens.numel(), kSpecWidth);
+  EXPECT_EQ(params_for_capture->graph.expanded_kv_seq_lens_vec,
+            std::vector<int32_t>(kSpecWidth, 1));
+  EXPECT_FALSE(params_for_capture->graph.attn_mask.defined());
+}
+
 TEST_F(AclGraphExecutorTest, GraphDoubleBufferFlagControlsSlotCount) {
   ExecutionConfig& execution_config = ExecutionConfig::get_instance();
   const bool original_enable_graph_double_buffer =

--- a/xllm/core/layers/common/attention_metadata_builder.cpp
+++ b/xllm/core/layers/common/attention_metadata_builder.cpp
@@ -291,16 +291,22 @@ AttentionMetadata build_attention_metadata(
              "undefined";
       options = options.device(device.value());
     }
-    attn_metadata.slot_mapping = torch::tensor({0}, options);
-    attn_metadata.q_cu_seq_lens = torch::tensor({0, 1}, options);
-    attn_metadata.kv_cu_seq_lens = torch::tensor({0, 1}, options);
-    attn_metadata.q_seq_lens = torch::tensor({1}, options);
-    attn_metadata.kv_seq_lens = torch::tensor({1}, options);
+    // Build dummy metadata directly on-device. torch::tensor({...}, options)
+    // materializes a host tensor then copies to device (a synchronous
+    // host->device aclrtMemcpy), which is illegal inside an ACL graph capture
+    // region (NPU error 107030 -> capture abort -> eager fallback). zeros/ones/
+    // arange allocate on-device and fill via a device kernel, so they are
+    // capture-safe while producing the same values.
+    attn_metadata.slot_mapping = torch::zeros({1}, options);
+    attn_metadata.q_cu_seq_lens = torch::arange(2, options);
+    attn_metadata.kv_cu_seq_lens = torch::arange(2, options);
+    attn_metadata.q_seq_lens = torch::ones({1}, options);
+    attn_metadata.kv_seq_lens = torch::ones({1}, options);
     attn_metadata.q_seq_lens_vec = {0, 1};
     attn_metadata.kv_seq_lens_vec = {0, 1};
-    attn_metadata.paged_kv_indptr = torch::tensor({0, 1}, options);
-    attn_metadata.paged_kv_indices = torch::tensor({0}, options);
-    attn_metadata.paged_kv_last_page_len = torch::tensor({1}, options);
+    attn_metadata.paged_kv_indptr = torch::arange(2, options);
+    attn_metadata.paged_kv_indices = torch::zeros({1}, options);
+    attn_metadata.paged_kv_last_page_len = torch::ones({1}, options);
     attn_metadata.block_table = torch::zeros({1, 1}, options);
     attn_metadata.max_query_len = 1;
     attn_metadata.max_seq_len = std::max<int64_t>(attn_metadata.max_seq_len, 1);

--- a/xllm/core/layers/common/attention_metadata_builder.cpp
+++ b/xllm/core/layers/common/attention_metadata_builder.cpp
@@ -295,7 +295,8 @@ AttentionMetadata build_attention_metadata(
   }
 #endif
 
-  attn_metadata.is_dummy = (params.meta.q_max_seq_len == 0);
+  attn_metadata.is_dummy =
+      params.meta.q_max_seq_len == 0 || params.meta.num_sequences == 0;
   if (attn_metadata.is_dummy) {
     torch::TensorOptions options =
         int32_options_like(params.attention.device.new_cache_slots,

--- a/xllm/core/layers/common/attention_metadata_builder.cpp
+++ b/xllm/core/layers/common/attention_metadata_builder.cpp
@@ -95,10 +95,26 @@ void materialize_linear_state_validity(
     options = torch::TensorOptions().device(device.value());
   }
   options = options.dtype(torch::kBool);
+  if (attn_metadata.is_dummy && mask_rows == 0) {
+    // Dummy empty shard: pure on-device alloc, no host source (capture-safe).
+    attn_metadata.has_initial_states = torch::zeros({1}, options);
+    return;
+  }
+#if defined(USE_NPU)
+  // On NPU, GDN consumes input_params.linear_state_validity_mask (a host
+  // IntArrayRef passed straight to the kernel) and never reads
+  // attn_metadata.has_initial_states. Building this via
+  // torch::tensor(host_vector, device_options) would run a synchronous
+  // host->device aclrtMemcpy that is illegal inside an ACL graph capture
+  // region (NPU error 107030, hit on hybrid spec-verify chunked-prefill
+  // capture). Keep it on host on NPU: same defined bool tensor and values, no
+  // H2D copy during capture. Other backends still materialize on-device.
+  attn_metadata.has_initial_states = torch::tensor(
+      params.linear_state_validity_mask, options.device(torch::kCPU));
+#else
   attn_metadata.has_initial_states =
-      attn_metadata.is_dummy && mask_rows == 0
-          ? torch::zeros({1}, options)
-          : torch::tensor(params.linear_state_validity_mask, options);
+      torch::tensor(params.linear_state_validity_mask, options);
+#endif
 }
 
 AttentionMetadata build_attention_metadata(

--- a/xllm/core/runtime/acl_graph_executor_impl.cpp
+++ b/xllm/core/runtime/acl_graph_executor_impl.cpp
@@ -274,6 +274,7 @@ bool AclGraph::capture(CausalLM* model,
       static_cast<uint32_t>(tokens.size(/*dim=*/0));
   CHECK_GE(num_tokens_, actual_num_tokens)
       << "num_tokens_ >= actual_num_tokens";
+  captured_dp_global_token_nums_ = params.parallel.dp_global_token_nums;
   const bool update_spec_verify_tokens =
       params.graph.spec_verify_source_addresses_stable &&
       params.graph.input_tokens_override.defined() && params.is_spec_verify &&
@@ -452,6 +453,25 @@ bool AclGraph::capture(CausalLM* model,
   }
   make_current_stream_wait_for_graph(stream);
   return true;
+}
+
+bool AclGraph::is_replay_compatible(const ModelInputParams& params) const {
+  const std::vector<int32_t>& replay_dp_global_token_nums =
+      params.parallel.dp_global_token_nums;
+  const bool has_distributed_input =
+      captured_dp_global_token_nums_.size() > 1 ||
+      replay_dp_global_token_nums.size() > 1;
+  if (!has_distributed_input ||
+      captured_dp_global_token_nums_ == replay_dp_global_token_nums) {
+    return true;
+  }
+
+  LOG_FIRST_N(WARNING, 10)
+      << "Falling back to eager mode because the DP token distribution "
+         "differs from ACL graph capture. captured="
+      << captured_dp_global_token_nums_
+      << ", replay=" << replay_dp_global_token_nums;
+  return false;
 }
 
 bool AclGraph::update_graph_tasks(const ModelInputParams& params) {
@@ -1024,6 +1044,11 @@ ModelOutput AclGraphExecutorImpl::run(const torch::Tensor& tokens,
   }
 
   if (replay_graph != nullptr) {
+    if (!replay_graph->is_replay_compatible(params_single)) {
+      replay_graph->discard_prepared_replay_inputs();
+      COUNTER_INC(num_model_execution_total_eager);
+      return forward_eager(model_, tokens, positions, kv_caches, params);
+    }
     // Replay the existing graph
     VLOG(kGraphExecutorLogVerboseLevel)
         << "AclGraphExecutorImpl::run() in replay mode";
@@ -1182,6 +1207,10 @@ void AclGraphExecutorImpl::prepare_graph_input(const torch::Tensor& tokens,
     }
     auto it = slot.graphs.find(graph_key);
     if (it == slot.graphs.end()) {
+      return;
+    }
+    if (!it->second->is_replay_compatible(params)) {
+      it->second->discard_prepared_replay_inputs();
       return;
     }
     graph = it->second;

--- a/xllm/core/runtime/acl_graph_executor_impl.h
+++ b/xllm/core/runtime/acl_graph_executor_impl.h
@@ -206,6 +206,13 @@ class AclGraphExecutorImpl : public ExecutorImpl {
     return graph_slot_count_;
   }
 
+  [[nodiscard]] uint64_t get_graph_key_for_test(
+      uint32_t bucket_num_tokens,
+      const ModelInputParams& params,
+      uint64_t attention_plan_class = 0) const {
+    return get_graph_key(bucket_num_tokens, params, attention_plan_class);
+  }
+
  private:
   // not own
   CausalLM* model_;

--- a/xllm/core/runtime/acl_graph_executor_impl.h
+++ b/xllm/core/runtime/acl_graph_executor_impl.h
@@ -120,6 +120,12 @@ class AclGraph {
                              std::vector<KVCache>& kv_cache,
                              const ModelInputParams& params);
 
+  [[nodiscard]] bool is_replay_compatible(const ModelInputParams& params) const;
+
+  void discard_prepared_replay_inputs() {
+    replay_inputs_prepared_.store(false, std::memory_order_release);
+  }
+
   bool prepare_static_mtp_graph_tasks(const SpecVerifyGraphTaskSignal& signal,
                                       const c10_npu::NPUStream& signal_stream);
 
@@ -165,6 +171,7 @@ class AclGraph {
   std::shared_ptr<AclGraphTaskUpdateContext> graph_task_context_;
   std::optional<c10_npu::NPUStream> update_stream_;
   std::atomic<bool> replay_inputs_prepared_{false};
+  std::vector<int32_t> captured_dp_global_token_nums_;
   std::optional<StaticGraphTaskSignature> static_graph_task_signature_;
   std::optional<std::array<const void*, 11>>
       spec_verify_input_addresses_at_capture_;

--- a/xllm/core/runtime/acl_graph_persistent_param.cpp
+++ b/xllm/core/runtime/acl_graph_persistent_param.cpp
@@ -954,6 +954,10 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
                  /*end=*/padded_batch_size)
           .fill_(kPaddingLinearStateId);
     }
+  } else if (is_empty_dp_decode_rank && is_hybrid_linear_attention_) {
+    persistent_linear_state_indices_
+        .slice(/*dim=*/0, /*start=*/0, /*end=*/padded_batch_size)
+        .fill_(kPaddingLinearStateId);
   }
   if (params.num_accepted_tokens.defined()) {
     persistent_num_accepted_tokens_
@@ -1093,7 +1097,18 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
   const bool skip_unused_expanded_verify_mask =
       can_skip_unused_expanded_verify_mask(params, is_hybrid_linear_attention_);
   if (need_update_attn_mask_ && !skip_unused_expanded_verify_mask) {
-    update_attention_mask(params);
+    if (is_empty_dp_decode_rank) {
+      // An empty DP decode shard has no live sequence and an undefined
+      // per-rank kv_seq_lens; update_attention_mask() would dereference that
+      // undefined tensor. Publish a cold (all-zero) mask over the padded rows
+      // instead, mirroring the padding the empty-shard branch already applies
+      // to the linear-state indices. The zero_() also clears any -inf left in
+      // the persistent buffer by a previous non-empty request.
+      persistent_mask_.slice(/*dim=*/0, /*start=*/0, /*end=*/padded_num_tokens)
+          .zero_();
+    } else {
+      update_attention_mask(params);
+    }
   }
 
   std::vector<int32_t> padded_kv_seq_lens_vec(
@@ -1282,7 +1297,8 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
         persistent_new_cache_slots(padded_num_tokens);
     graph_params->attention.device.block_tables =
         persistent_block_tables(static_cast<uint32_t>(padded_batch_size));
-    if (!params.embedding.linear_state_ids.empty()) {
+    if (!params.embedding.linear_state_ids.empty() ||
+        (is_empty_dp_decode_rank && is_hybrid_linear_attention_)) {
       graph_params->embedding.linear_state_ids =
           params.embedding.linear_state_ids;
       graph_params->embedding.linear_state_ids.resize(

--- a/xllm/core/runtime/acl_graph_persistent_param.cpp
+++ b/xllm/core/runtime/acl_graph_persistent_param.cpp
@@ -212,11 +212,19 @@ GraphPersistentParam::GraphPersistentParam(const ModelArgs& args,
   // only serves decode / spec-verify batches, so the relevant row upper bound
   // comes from decode graph capacity instead.
   const int64_t max_graph_tokens = get_decode_graph_token_capacity(options);
-  // Hybrid spec verify keeps sequence-scoped metadata, while non-hybrid MTP
-  // expands every proposal token into its own decode metadata row.
-  const int64_t metadata_capacity = is_hybrid_linear_attention
-                                        ? get_decode_graph_capacity(options)
-                                        : max_graph_tokens;
+  // Hybrid speculative verification normally keeps sequence-scoped metadata.
+  // In DP target-MTP decode, however, an empty rank builds cold dummy metadata
+  // for every proposal-token row so that its graph shape matches active ranks.
+  // Reserve token capacity for that capture path; otherwise preserve the
+  // smaller sequence-scoped allocation used by hybrid speculative verification.
+  const bool needs_token_scoped_empty_dp_metadata =
+      is_hybrid_linear_attention && options.enable_speculative_decode() &&
+      !options.is_draft_engine() && options.dp_size() > 1;
+  const int64_t metadata_capacity =
+      needs_token_scoped_empty_dp_metadata
+          ? max_graph_tokens
+          : (is_hybrid_linear_attention ? get_decode_graph_capacity(options)
+                                        : max_graph_tokens);
 
   const int64_t max_seq_len = args_.max_position_embeddings();
 
@@ -818,13 +826,14 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
       is_chunked_prefill
           ? (padded_num_tokens + q_max_seq_len - 1) / q_max_seq_len
           : padded_num_tokens;
-  const bool is_empty_dp_decode_rank =
-      is_decode && params.meta.num_sequences == 0 && actual_num_tokens > 0 &&
+  const bool is_empty_dp_graph_rank =
+      (is_decode || is_hybrid_spec_verify_chunked_prefill) &&
+      params.meta.num_sequences == 0 && actual_num_tokens > 0 &&
       params.parallel.dp_global_token_nums.size() > 1 &&
       params.attention.host.kv_seq_lens.empty() &&
       params.attention.host.q_seq_lens.empty();
   const int64_t actual_seq_len_rows =
-      is_empty_dp_decode_rank
+      is_empty_dp_graph_rank
           ? 0
           : (is_chunked_prefill ? actual_batch_size : actual_num_tokens);
 
@@ -954,7 +963,7 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
                  /*end=*/padded_batch_size)
           .fill_(kPaddingLinearStateId);
     }
-  } else if (is_empty_dp_decode_rank && is_hybrid_linear_attention_) {
+  } else if (is_empty_dp_graph_rank && is_hybrid_linear_attention_) {
     persistent_linear_state_indices_
         .slice(/*dim=*/0, /*start=*/0, /*end=*/padded_batch_size)
         .fill_(kPaddingLinearStateId);
@@ -1068,7 +1077,7 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
     }
     if (padded_batch_size > actual_seq_len_rows) {
       int32_t offset =
-          is_empty_dp_decode_rank ? 0 : static_cast<int32_t>(actual_num_tokens);
+          is_empty_dp_graph_rank ? 0 : static_cast<int32_t>(actual_num_tokens);
       std::vector<int32_t> padded_q_cu_seq_lens;
       padded_q_cu_seq_lens.reserve(padded_batch_size - actual_seq_len_rows);
       const int32_t padding_q_len = is_chunked_prefill ? q_max_seq_len : 1;
@@ -1097,8 +1106,8 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
   const bool skip_unused_expanded_verify_mask =
       can_skip_unused_expanded_verify_mask(params, is_hybrid_linear_attention_);
   if (need_update_attn_mask_ && !skip_unused_expanded_verify_mask) {
-    if (is_empty_dp_decode_rank) {
-      // An empty DP decode shard has no live sequence and an undefined
+    if (is_empty_dp_graph_rank) {
+      // An empty DP graph shard has no live sequence and an undefined
       // per-rank kv_seq_lens; update_attention_mask() would dereference that
       // undefined tensor. Publish a cold (all-zero) mask over the padded rows
       // instead, mirroring the padding the empty-shard branch already applies
@@ -1233,7 +1242,7 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
     graph_params->attention.device.q_seq_lens =
         q_seq_lens(static_cast<uint32_t>(padded_batch_size));
     graph_params->meta.actual_num_sequences =
-        is_empty_dp_decode_rank ? 0 : static_cast<int32_t>(actual_num_tokens);
+        is_empty_dp_graph_rank ? 0 : static_cast<int32_t>(actual_num_tokens);
     if (supports_mla_graph_kv_bucketing_) {
       std::vector<int32_t> capture_host_kv_seq_lens_vec =
           persistent_host_kv_seq_lens_;
@@ -1298,7 +1307,7 @@ std::optional<ModelInputParams> GraphPersistentParam::update(
     graph_params->attention.device.block_tables =
         persistent_block_tables(static_cast<uint32_t>(padded_batch_size));
     if (!params.embedding.linear_state_ids.empty() ||
-        (is_empty_dp_decode_rank && is_hybrid_linear_attention_)) {
+        (is_empty_dp_graph_rank && is_hybrid_linear_attention_)) {
       graph_params->embedding.linear_state_ids =
           params.embedding.linear_state_ids;
       graph_params->embedding.linear_state_ids.resize(

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -225,7 +225,8 @@ void clear_expanded_spec_verify_graph_input(ModelInputParams& input_params) {
 }
 
 bool build_expanded_spec_verify_graph_host_input(
-    ModelInputParams& input_params) {
+    ModelInputParams& input_params,
+    int64_t empty_rank_token_rows = 0) {
   clear_expanded_spec_verify_graph_input(input_params);
   if (!input_params.is_spec_verify ||
       !input_params.meta.batch_forward_type.is_chunked_prefill()) {
@@ -237,7 +238,15 @@ bool build_expanded_spec_verify_graph_host_input(
   const std::vector<int32_t>& kv_seq_lens =
       input_params.attention.host.kv_seq_lens;
   if (q_seq_lens.empty() || kv_seq_lens.empty()) {
-    return false;
+    CHECK_EQ(q_seq_lens.empty(), kv_seq_lens.empty())
+        << "spec verify q/kv seq lens must both be present or both be empty";
+    if (input_params.meta.num_sequences != 0 || empty_rank_token_rows <= 0) {
+      return false;
+    }
+    input_params.graph.use_expanded_decode_for_spec_verify_attention = true;
+    input_params.graph.expanded_kv_seq_lens_vec.assign(
+        static_cast<size_t>(empty_rank_token_rows), 1);
+    return true;
   }
   CHECK_EQ(q_seq_lens.size(), kv_seq_lens.size())
       << "spec verify q/kv seq lens must both be sequence-scoped";
@@ -268,9 +277,43 @@ void bind_expanded_spec_verify_graph_input(ModelInputParams& input_params,
   if (!input_params.graph.use_expanded_decode_for_spec_verify_attention) {
     return;
   }
+  if (!kv_lens_already_bound) {
+    torch::Tensor expanded_kv_seq_lens_host =
+        torch::tensor(input_params.graph.expanded_kv_seq_lens_vec,
+                      torch::TensorOptions()
+                          .dtype(torch::kInt)
+                          .device(torch::kCPU)
+                          .pinned_memory(true));
+    input_params.graph.expanded_kv_seq_lens =
+        expanded_kv_seq_lens_host.to(device, /*non_blocking=*/true);
+  }
+
+  const std::vector<int32_t>& q_seq_lens =
+      input_params.attention.host.q_seq_lens;
+  if (q_seq_lens.empty()) {
+    CHECK_EQ(input_params.meta.num_sequences, 0)
+        << "empty expanded spec verify input requires an empty rank";
+    const int64_t expanded_rows = static_cast<int64_t>(
+        input_params.graph.expanded_kv_seq_lens_vec.size());
+    CHECK_GT(expanded_rows, 0);
+
+    int64_t block_table_width = 1;
+    torch::TensorOptions block_table_options =
+        torch::TensorOptions().dtype(torch::kInt).device(device);
+    if (input_params.attention.device.block_tables.defined()) {
+      CHECK_EQ(input_params.attention.device.block_tables.dim(), 2);
+      block_table_width = std::max<int64_t>(
+          input_params.attention.device.block_tables.size(1), 1);
+      block_table_options =
+          input_params.attention.device.block_tables.options().device(device);
+    }
+    input_params.graph.expanded_block_tables =
+        torch::zeros({expanded_rows, block_table_width}, block_table_options);
+    return;
+  }
+
   CHECK(input_params.attention.device.block_tables.defined())
       << "spec verify block tables must be rebuilt before graph input";
-  const auto& q_seq_lens = input_params.attention.host.q_seq_lens;
   CHECK_GE(input_params.attention.device.block_tables.size(0),
            static_cast<int64_t>(q_seq_lens.size()))
       << "spec verify block table rows are fewer than sequences";
@@ -286,17 +329,6 @@ void bind_expanded_spec_verify_graph_input(ModelInputParams& input_params,
     }
   }
 
-  if (!kv_lens_already_bound) {
-    torch::Tensor expanded_kv_seq_lens_host =
-        torch::tensor(input_params.graph.expanded_kv_seq_lens_vec,
-                      torch::TensorOptions()
-                          .dtype(torch::kInt)
-                          .device(torch::kCPU)
-                          .pinned_memory(true));
-    input_params.graph.expanded_kv_seq_lens =
-        expanded_kv_seq_lens_host.to(device, /*non_blocking=*/true);
-  }
-
   // ATB consumes this tensor as dense row-major storage. Keep the generic
   // fallback contiguous; a zero-stride expand view is rejected at runtime.
   input_params.graph.expanded_block_tables =
@@ -304,8 +336,10 @@ void bind_expanded_spec_verify_graph_input(ModelInputParams& input_params,
 }
 
 void build_expanded_spec_verify_graph_input(ModelInputParams& input_params,
-                                            const torch::Device& device) {
-  build_expanded_spec_verify_graph_host_input(input_params);
+                                            const torch::Device& device,
+                                            int64_t empty_rank_token_rows = 0) {
+  build_expanded_spec_verify_graph_host_input(input_params,
+                                              empty_rank_token_rows);
   bind_expanded_spec_verify_graph_input(input_params, device, false);
 }
 #endif
@@ -969,15 +1003,7 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_empty(
                                      .value());
     }
 
-    new_input = input;
-    for (int32_t& token_num :
-         new_input.input_params.parallel.dp_global_token_nums) {
-      token_num *= options_.num_speculative_tokens() + 1;
-    }
-    for (int32_t& token_num :
-         new_input.input_params.parallel.raw_dp_global_token_nums) {
-      token_num *= options_.num_speculative_tokens() + 1;
-    }
+    prepare_empty_validate_inputs(input, new_input);
     ForwardOutput output = run_llm_no_sync_impl(*impl_,
                                                 new_input,
                                                 *prepare_stream_,
@@ -1953,6 +1979,58 @@ void MTPWorkerImpl::update_decode_step_input(
   input.positions_host = specBuilder::make_cpu_int_tensor(positions_vec);
   input.input_params.attention.host.kv_seq_lens = std::move(kv_seq_lens_vec);
   input.device_tensors_ready = false;
+}
+
+void MTPWorkerImpl::prepare_empty_validate_inputs(
+    const ForwardInput& input,
+    ForwardInput& validate_input) {
+  CHECK_EQ(input.input_params.meta.num_sequences, 0)
+      << "empty target validation requires an empty rank";
+  c10::StreamGuard stream_guard = prepare_stream_->set_stream_guard();
+  validate_input = input;
+  clear_ready_events(validate_input);
+
+  ModelInputParams& input_params = validate_input.input_params;
+  const int32_t num_val_tokens = options_.num_speculative_tokens() + 1;
+  for (int32_t& token_num : input_params.parallel.dp_global_token_nums) {
+    token_num *= num_val_tokens;
+  }
+  for (int32_t& token_num : input_params.parallel.raw_dp_global_token_nums) {
+    token_num *= num_val_tokens;
+  }
+
+  if (!use_chunked_prefill_spec_verify_path()) {
+    return;
+  }
+
+  CHECK(input_params.attention.host.q_seq_lens.empty());
+  CHECK(input_params.attention.host.kv_seq_lens.empty());
+  input_params.attention.host.q_cu_seq_lens.clear();
+  input_params.attention.host.new_cache_slots.clear();
+  input_params.embedding.input_embedding = torch::Tensor();
+  input_params.meta.actual_num_sequences = 0;
+  input_params.meta.batch_forward_type = BatchForwardType::CHUNKED_PREFILL;
+  input_params.meta.q_max_seq_len = num_val_tokens;
+  input_params.meta.kv_max_seq_len = 1;
+  input_params.parallel.query_start_loc.clear();
+  input_params.is_spec_verify = true;
+  input_params.num_accepted_tokens = torch::Tensor();
+  input_params.num_accepted_tokens_host.clear();
+  input_params.graph.input_tokens_override = torch::Tensor();
+  input_params.graph.spec_verify_draft_token_sources.clear();
+  input_params.graph.spec_verify_source_addresses_stable = false;
+  input_params.graph.spec_verify_static_graph_tasks_prepared = false;
+
+#if defined(USE_NPU)
+  if (supports_explicit_spec_verify_replay_update()) {
+    const int64_t local_token_rows =
+        validate_input.token_ids.defined()
+            ? std::max<int64_t>(validate_input.token_ids.numel(), 1)
+            : 1;
+    build_expanded_spec_verify_graph_input(
+        input_params, device_, local_token_rows);
+  }
+#endif
 }
 
 void MTPWorkerImpl::prepare_validate_inputs(const ForwardInput& input,

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -2014,8 +2014,16 @@ void MTPWorkerImpl::prepare_empty_validate_inputs(
   input_params.meta.kv_max_seq_len = 1;
   input_params.parallel.query_start_loc.clear();
   input_params.is_spec_verify = true;
-  input_params.num_accepted_tokens = torch::Tensor();
-  input_params.num_accepted_tokens_host.clear();
+  // Pad num_accepted_tokens to match the single-row dummy linear_state_id the
+  // persistent layer writes for an empty DP shard. AclGraph::update_graph_tasks
+  // (acl_graph_executor_impl.cpp:489) CHECKs
+  //   num_accepted_tokens_host.size() == linear_state_indices_host.size()
+  // during replay of the causal_conv1d spec-verify task. Clearing this vector
+  // would break the CHECK (0 vs 1) on the empty rank while active ranks
+  // provide num_sequences entries via prepare_validate_inputs().
+  input_params.num_accepted_tokens_host.assign(1, 0);
+  input_params.num_accepted_tokens = torch::zeros(
+      {1}, torch::TensorOptions().dtype(torch::kInt).device(device_));
   input_params.graph.input_tokens_override = torch::Tensor();
   input_params.graph.spec_verify_draft_token_sources.clear();
   input_params.graph.spec_verify_source_addresses_stable = false;

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -741,6 +741,12 @@ bool MTPWorkerImpl::should_use_explicit_spec_verify_replay_update(
       block_tables.size(0) != input.input_params.meta.num_sequences) {
     return false;
   }
+  const std::vector<int32_t>& dp_token_nums =
+      input.input_params.parallel.dp_global_token_nums;
+  if (std::find(dp_token_nums.begin(), dp_token_nums.end(), 0) !=
+      dp_token_nums.end()) {
+    return false;
+  }
   const int64_t block_table_width = spec_verify_block_table_width(block_tables);
   if (block_table_width <= 0 ||
       block_table_width > kMaxSpecVerifyGraphUpdateBlockTableWidth) {
@@ -1989,6 +1995,8 @@ void MTPWorkerImpl::prepare_empty_validate_inputs(
   c10::StreamGuard stream_guard = prepare_stream_->set_stream_guard();
   validate_input = input;
   clear_ready_events(validate_input);
+  validate_input.input_host_buffer_has_layout = false;
+  validate_input.device_tensors_ready = false;
 
   ModelInputParams& input_params = validate_input.input_params;
   const int32_t num_val_tokens = options_.num_speculative_tokens() + 1;

--- a/xllm/core/runtime/mtp_worker_impl.h
+++ b/xllm/core/runtime/mtp_worker_impl.h
@@ -130,6 +130,8 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
   bool use_chunked_prefill_spec_verify_path() const;
 
   // Prepare target validate input from cached target context.
+  void prepare_empty_validate_inputs(const ForwardInput& inputs,
+                                     ForwardInput& validate_inputs);
   void prepare_validate_inputs(const ForwardInput& inputs,
                                ForwardInput& validate_inputs,
                                bool static_graph_tasks_prepared = false);

--- a/xllm/core/runtime/speculative_worker_impl.h
+++ b/xllm/core/runtime/speculative_worker_impl.h
@@ -100,6 +100,13 @@ class SpeculativeWorkerImpl : public WorkerImpl {
 
   ForwardInput update_input_by_last_step_output(ForwardInput& inputs) override;
 
+  // Speculative composite workers do not own a KVCache themselves; recurrent
+  // (conv/ssm) slots live on the inner target LLMWorkerImpl. Overriding to
+  // false stops WorkerImpl::prepare_work_before_execute_on_stream from calling
+  // restore_linear_state_slots on the outer worker's empty kv_caches_, which
+  // would trip discover_num_slots()==0 CHECK_GT.
+  bool owns_linear_state_cache() const override { return false; }
+
   folly::SemiFuture<bool> pull_kv_blocks_async(
       const uint64_t src_cluster_id,
       const std::string& src_addr,

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -300,7 +300,19 @@ void prepare_input_params_for_linear_attention(ModelInputParams& input_params) {
   LinearStateInputRows rows = get_host_linear_state_rows(input_params);
 #endif
   if (rows.empty_shard) {
+    // An empty DP shard has no local sequence, so it must not publish any
+    // local linear-state restore/reset operation. Historically only the
+    // validity mask was cleared here; the cache_ops vector kept whatever the
+    // batch input builder had emplaced from earlier sequences, and once the
+    // empty rank started running through the MTP spec-verify path it reached
+    // restore_linear_state_slots with a non-empty cache_ops. Even after the
+    // owns_linear_state_cache() guard blocks the outer composite from calling
+    // restore, the inner target LLMWorkerImpl still consumes these vectors
+    // together and expects them to remain synchronized. Clearing both here
+    // keeps the pair aligned and makes downstream restore an early-return
+    // no-op on the empty shard.
     input_params.linear_state_validity_mask.clear();
+    input_params.linear_state_cache_ops.clear();
     return;
   }
   input_params.linear_state_validity_mask =
@@ -921,7 +933,15 @@ void WorkerImpl::prepare_work_before_execute_on_stream(
       // Defer the slot-restore copy to step_for_schedule_overlap (worker
       // thread, on compute_stream_) so stream ordering between chunk N-1
       // writes and chunk N restore is automatic.
-      if (!enable_schedule_overlap()) {
+      //
+      // owns_linear_state_cache() gates against composite (speculative) outer
+      // workers that copied the target's ModelArgs (so
+      // has_linear_attention_layers() is true) but never allocated their own
+      // kv_caches_. The inner target LLMWorkerImpl is created with
+      // schedule_overlap forced off and its own recurrent cache, so it will
+      // still run this restore against its populated kv_caches_ during its
+      // own prepare_work_before_execute_on_stream.
+      if (!enable_schedule_overlap() && owns_linear_state_cache()) {
         restore_linear_state_slots(kv_caches_,
                                    input_params.linear_state_cache_ops,
                                    input_params.linear_state_validity_mask);

--- a/xllm/core/runtime/worker_impl.h
+++ b/xllm/core/runtime/worker_impl.h
@@ -124,6 +124,15 @@ class WorkerImpl {
   // False on MTP composite: only leaf workers run NpuCpPlan::prepare.
   virtual bool owns_npu_cp_plan_build() const { return true; }
 
+  // False on speculative composite workers: only leaf LLM workers allocate a
+  // KVCache with recurrent (conv/ssm) slots, so only they may drive the
+  // non-overlap linear-state restore in prepare_work_before_execute_on_stream.
+  // The outer composite copies the target's ModelArgs (so
+  // has_linear_attention_layers is true) but its own kv_caches_ is never
+  // populated - guarding the restore call by this policy avoids calling
+  // discover_num_slots() on an empty vector and tripping CHECK_GT there.
+  virtual bool owns_linear_state_cache() const { return true; }
+
   // Cached: whether the loaded model advertises NPU model-side CP.
   bool model_supports_model_cp() const;
 

--- a/xllm/models/llm/mtp_model_base.h
+++ b/xllm/models/llm/mtp_model_base.h
@@ -393,8 +393,12 @@ class MtpModelImplBase : public torch::nn::Module {
     ModelInputParams modified_input_params = input_params;
     if (dp_size_ > 1) {
       if (tokens.sizes() == 0) {
-        tokens = torch::tensor({1}).to(torch::kInt32).to(device_);
-        positions = torch::tensor({1}).to(torch::kInt32).to(device_);
+        // On-device dummy build. torch::tensor({...}).to(device_) runs a
+        // host->device memcpy that is illegal inside an ACL graph capture
+        // region (NPU 107030); see qwen3_next_hybrid_base.h for the same fix.
+        auto dummy_opts = torch::dtype(torch::kInt32).device(device_);
+        tokens = torch::ones({1}, dummy_opts);
+        positions = torch::ones({1}, dummy_opts);
       }
       auto& dp_token_nums = modified_input_params.parallel.dp_global_token_nums;
       std::replace(dp_token_nums.begin(), dp_token_nums.end(), 0, 1);

--- a/xllm/models/llm/qwen3_5_mtp_base.h
+++ b/xllm/models/llm/qwen3_5_mtp_base.h
@@ -108,8 +108,12 @@ class Qwen3_5MtpModelImplBase : public Qwen3HybridModelImplBase {
     torch::NoGradGuard no_grad;
 
     if (dp_size_ > 1 && tokens.sizes() == 0) {
-      tokens = torch::tensor({1}).to(torch::kInt32).to(device_);
-      positions = torch::tensor({0}).to(torch::kInt32).to(device_);
+      // On-device dummy build; torch::tensor({...}).to(device_) would run a
+      // capture-illegal host->device memcpy (NPU 107030). See
+      // qwen3_next_hybrid_base.h for the same fix.
+      auto dummy_opts = torch::dtype(torch::kInt32).device(device_);
+      tokens = torch::ones({1}, dummy_opts);
+      positions = torch::zeros({1}, dummy_opts);
     }
 
     layer::AttentionMetadata attn_metadata =

--- a/xllm/models/llm/qwen3_next_hybrid_base.h
+++ b/xllm/models/llm/qwen3_next_hybrid_base.h
@@ -100,8 +100,14 @@ class Qwen3HybridModelImplBase : public Qwen3HybridModelModule {
     torch::NoGradGuard no_grad;
     if (dp_size_ > 1) {
       if (tokens.sizes() == 0) {
-        tokens = torch::tensor({1}).to(torch::kInt32).to(device_);
-        positions = torch::tensor({0}).to(torch::kInt32).to(device_);
+        // Build the empty-shard dummy directly on-device. The previous
+        // torch::tensor({...}).to(device_) issues a synchronous host->device
+        // aclrtMemcpy that is illegal inside an ACL graph capture region (NPU
+        // error 107030 -> capture abort -> eager fallback). On-device alloc +
+        // constant fill runs a device kernel only: capture-safe, eager-same.
+        auto dummy_opts = torch::dtype(torch::kInt32).device(device_);
+        tokens = torch::ones({1}, dummy_opts);
+        positions = torch::zeros({1}, dummy_opts);
       }
     }
 

--- a/xllm/models/vlm/qwen3_5.h
+++ b/xllm/models/vlm/qwen3_5.h
@@ -103,8 +103,13 @@ class Qwen3_5ModelImpl final
 
     if (dp_size_ > 1) {
       if (tokens.numel() == 0) {
-        tokens = torch::tensor({1}).to(torch::kInt32).to(tokens.device());
-        positions = torch::tensor({1}).to(torch::kInt32).to(positions.device());
+        // On-device dummy build; torch::tensor({...}).to(device) would run a
+        // capture-illegal host->device memcpy (NPU 107030). See
+        // qwen3_next_hybrid_base.h for the same fix.
+        tokens = torch::ones(
+            {1}, torch::dtype(torch::kInt32).device(tokens.device()));
+        positions = torch::ones(
+            {1}, torch::dtype(torch::kInt32).device(positions.device()));
       }
       auto& dp_token_nums = input_params_new.parallel.dp_global_token_nums;
       std::replace(dp_token_nums.begin(), dp_token_nums.end(), 0, 1);


### PR DESCRIPTION
## Description

This draft aligns empty DP shards with active ranks during Qwen3.5 MTP ACL graph execution.

The branch currently:

- builds device-resident dummy graph metadata for empty DP shards;
- routes empty target validation through the spec-verify chunked-prefill phase;
- aligns active/empty spec-verify graph keys and persistent tensor layouts;
- adds graph-key and persistent-layout parity tests;
- prevents the outer speculative composite worker from restoring recurrent state through an unowned KV cache.

This remains a draft because the 35B schedule-overlap path still stalls after an active/empty DP transition. Current diagnostics indicate a bucket-4 graph captured with DP token distribution `[4, 4]` is later replayed with `[4, 0]`. A replay-compatibility guard or bounded per-distribution graph variants are being evaluated separately.

## Related Issues

No issue linked yet.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [x] Test
- [ ] Build or CI

## Pull Request Checklist

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

Targeted validation completed on the branch:

- ACL graph executor unit tests: 29/29 passed;
- 2B Qwen3.5 MTP graph DP smoke: 9/9 requests passed;
- 35B Qwen3.5 MTP graph with schedule overlap disabled: 9/9 requests passed;
- 35B schedule overlap enabled: still reproduces a silent stall and is the reason this PR remains draft.

## Reviewer Notes

Please focus on active/empty rank graph-phase parity, persistent tensor shape parity, and recurrent-state cache ownership. The unresolved overlap-on replay compatibility problem is documented as a known follow-up rather than hidden by an eager fallback in this draft.
