### PR TITLE
feat: add data-parallel support for qwen3 dense in NPU Python ACL graph decode.

### DIFF
--- a/xllm/python/attention/npu_paged_attention.py
+++ b/xllm/python/attention/npu_paged_attention.py
@@ -195,9 +195,12 @@ class NpuPagedAttentionBackend(AttentionBackend):
                     "decode attention requires scheduler-provided host KV lengths"
                 )
             if len(kv_seq_lens_host_values) != real_batch:
-                raise RuntimeError(
-                    "host KV lengths must have one entry per block-table row"
-                )
+                if len(kv_seq_lens_host_values) > real_batch:
+                    kv_seq_lens_host_values = kv_seq_lens_host_values[:real_batch]
+                else:
+                    raise RuntimeError(
+                        "host KV lengths must have one entry per block-table row"
+                    )
             self._actual_seq_q: list[int] = list(range(1, real_batch + 1))
             self._actual_seq_kv: list[int] = list(kv_seq_lens_host_values)
         else:

--- a/xllm/python/model_executor/executor.py
+++ b/xllm/python/model_executor/executor.py
@@ -122,9 +122,11 @@ class ModelExecutor:
             "none",
             "0",
             "cudagraphs",
+            "aclgraph",
         ):
             raise NotImplementedError(
-                "Python data parallel graph execution supports cudagraphs only"
+                "Python data parallel graph execution supports cudagraphs and "
+                "aclgraph only"
             )
         if graph_backend in ("", "off", "none", "0"):
             pass
@@ -151,6 +153,8 @@ class ModelExecutor:
                 device,
                 max_seqs_per_batch,
                 int(config["max_position_embeddings"]),
+                dp_size,
+                dp_rank,
             )
         else:
             if self.eager_runner.cp_size > 1:

--- a/xllm/python/model_executor/runners/decode_acl_graph.py
+++ b/xllm/python/model_executor/runners/decode_acl_graph.py
@@ -113,9 +113,13 @@ class DecodeAclGraphRunner(BaseRunner):
         device: torch.device,
         max_batch: int,
         max_model_len: int,
+        dp_size: int = 1,
+        dp_rank: int = 0,
     ) -> None:
         super().__init__(model, attention_backend, device)
-        self.max_batch = max_batch
+        self.dp_size = dp_size
+        self.dp_rank = dp_rank
+        self.max_batch = (max_batch + dp_size - 1) // dp_size
         self.max_model_len = max_model_len
         self._graphs: dict[_GraphKey, _DecodeGraphEntry] = {}
         self._paged_kv_indices_buffer: torch.Tensor | None = None

--- a/xllm/python/models/qwen3.py
+++ b/xllm/python/models/qwen3.py
@@ -66,6 +66,8 @@ class Qwen3Config:
     attention_bias: bool = False
     tp_size: int = 1
     tp_rank: int = 0
+    dp_size: int = 1
+    dp_rank: int = 0
 
     @classmethod
     def from_dict(cls, d: dict) -> "Qwen3Config":
@@ -95,6 +97,8 @@ class Qwen3Config:
             attention_bias=bool(pick("attention_bias", default=False)),
             tp_size=int(pick("tp_size", default=1)),
             tp_rank=int(pick("tp_rank", default=0)),
+            dp_size=int(pick("dp_size", default=1)),
+            dp_rank=int(pick("dp_rank", default=0)),
         )
 
     def head_split(self) -> Tuple[int, int, int]:
@@ -356,6 +360,11 @@ class Qwen3ForCausalLM(PyModelBase):
         self.device = device
 
         tp = self.cfg.tp_size
+        dp = self.cfg.dp_size
+        if tp * dp != int(config.get("world_size", tp * dp)):
+            raise ValueError("world_size must equal tp_size * dp_size")
+        if not 0 <= self.cfg.dp_rank < dp:
+            raise ValueError("dp_rank must be in [0, dp_size)")
         assert self.cfg.vocab_size % tp == 0
         self.model = Qwen3Model(self.cfg, dtype, device)
         self.lm_head = ColumnParallelLinear(


### PR DESCRIPTION
- Propagate dp_size/dp_rank through Qwen3Config and executor to DecodeAclGraphRunner, partitioning max_batch by DP degree.
- Allow kv_seq_lens truncation when scheduler provides more entries than the per-rank batch slice.
- Register aclgraph as a valid graph_backend alongside cudagraphs.

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
