### PR TITLE
feat: add asynchronous host kv cache transfers.

### DIFF
--- a/tests/core/framework/kv_cache/kv_cache_test.cpp
+++ b/tests/core/framework/kv_cache/kv_cache_test.cpp
@@ -117,8 +117,7 @@ void ExpectMluCompressedStateLayout(const std::vector<KVCache>& caches,
   EXPECT_EQ(shape_vec(caches[1].get_compress_state()),
             (std::vector<int64_t>{swa_count, block_size, 4 * head_dim}));
   EXPECT_EQ(shape_vec(caches[1].get_compress_index_state()),
-            (std::vector<int64_t>{swa_count, block_size,
-                                  4 * index_head_dim}));
+            (std::vector<int64_t>{swa_count, block_size, 4 * index_head_dim}));
   EXPECT_TRUE(caches[1].get_compress_state().is_contiguous());
   EXPECT_TRUE(caches[1].get_compress_index_state().is_contiguous());
 

--- a/tests/core/framework/kv_cache_transfer/hierarchy_kv_cache_transfer_test.cpp
+++ b/tests/core/framework/kv_cache_transfer/hierarchy_kv_cache_transfer_test.cpp
@@ -92,13 +92,6 @@ class PendingBatchMemcpy final : public BatchMemcpy {
 
   void init(int32_t /*device_id*/) override {}
 
-  bool copy_h2d(const std::vector<torch::Tensor>& /*src_tensors*/,
-                const std::vector<torch::Tensor>& /*dst_tensors*/,
-                Stream* /*stream*/) override {
-    ADD_FAILURE() << "Unexpected synchronous H2D copy.";
-    return false;
-  }
-
   bool submit_h2d(const std::vector<torch::Tensor>& /*src_tensors*/,
                   const std::vector<torch::Tensor>& /*dst_tensors*/,
                   Stream* stream) override {

--- a/tests/core/framework/kv_cache_transfer/hierarchy_kv_cache_transfer_test.cpp
+++ b/tests/core/framework/kv_cache_transfer/hierarchy_kv_cache_transfer_test.cpp
@@ -15,12 +15,17 @@ limitations under the License.
 
 #include "framework/kv_cache_transfer/hierarchy_kv_cache_transfer.h"
 
+#include <cnrt.h>
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
 #include <cstdint>
+#include <future>
 #include <memory>
 #include <optional>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "framework/kv_cache/kv_cache_capacity.h"
@@ -30,7 +35,121 @@ limitations under the License.
 #include "platform/platform.h"
 
 namespace xllm {
+
+class HierarchyKVCacheTransferTestPeer final {
+ public:
+  static void replace_batch_memcpy(HierarchyKVCacheTransfer* transfer,
+                                   std::unique_ptr<BatchMemcpy> batch_memcpy) {
+    transfer->batch_memcpy_ = std::move(batch_memcpy);
+  }
+
+  static void set_layer_batch_ranges(
+      HierarchyKVCacheTransfer* transfer,
+      std::vector<HierarchyKVCacheTransfer::LayerBatchRange> ranges) {
+    transfer->layer_batch_ranges_ = std::move(ranges);
+  }
+
+  static bool load_from_host(
+      HierarchyKVCacheTransfer* transfer,
+      std::shared_ptr<LayerSynchronizer> synchronizer,
+      const std::vector<BlockTransferInfo>& block_transfer_info) {
+    return transfer->load_from_host(std::move(synchronizer),
+                                    block_transfer_info);
+  }
+};
+
 namespace {
+
+struct LoadFailureState {
+  std::atomic<bool> gate_open{false};
+  std::atomic<bool> copy_finished{false};
+  std::atomic<bool> record_failed{false};
+  std::atomic<bool> abort_called{false};
+  std::atomic<bool> abort_saw_completed_copy{false};
+};
+
+void finish_pending_copy(void* user_data) {
+  LoadFailureState* state = static_cast<LoadFailureState*>(user_data);
+  while (!state->gate_open.load(std::memory_order_acquire)) {
+    std::this_thread::yield();
+  }
+  state->copy_finished.store(true, std::memory_order_release);
+}
+
+bool wait_for_flag(const std::atomic<bool>& flag) {
+  const std::chrono::steady_clock::time_point deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (!flag.load(std::memory_order_acquire) &&
+         std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::yield();
+  }
+  return flag.load(std::memory_order_acquire);
+}
+
+class PendingBatchMemcpy final : public BatchMemcpy {
+ public:
+  explicit PendingBatchMemcpy(LoadFailureState* state) : state_(state) {}
+
+  void init(int32_t /*device_id*/) override {}
+
+  bool copy_h2d(const std::vector<torch::Tensor>& /*src_tensors*/,
+                const std::vector<torch::Tensor>& /*dst_tensors*/,
+                Stream* /*stream*/) override {
+    ADD_FAILURE() << "Unexpected synchronous H2D copy.";
+    return false;
+  }
+
+  bool submit_h2d(const std::vector<torch::Tensor>& /*src_tensors*/,
+                  const std::vector<torch::Tensor>& /*dst_tensors*/,
+                  Stream* stream) override {
+    return cnrtInvokeHostFunc(stream->get_stream()->stream(),
+                              finish_pending_copy,
+                              state_) == cnrtSuccess;
+  }
+
+  bool copy_d2h(const std::vector<torch::Tensor>& /*src_tensors*/,
+                const std::vector<torch::Tensor>& /*dst_tensors*/,
+                Stream* /*stream*/) override {
+    ADD_FAILURE() << "Unexpected D2H copy.";
+    return false;
+  }
+
+ private:
+  LoadFailureState* state_ = nullptr;
+};
+
+class SecondRecordFailsSynchronizer final : public LayerSynchronizer {
+ public:
+  explicit SecondRecordFailsSynchronizer(LoadFailureState* state)
+      : state_(state) {}
+
+  bool synchronize_layer(int64_t /*layer_index*/) override {
+    ADD_FAILURE() << "Unexpected layer synchronization.";
+    return false;
+  }
+
+  bool record_stream(int64_t /*layer_index*/, Stream* /*stream*/) override {
+    ++record_count_;
+    if (record_count_ == 1) {
+      return true;
+    }
+    state_->record_failed.store(true, std::memory_order_release);
+    return false;
+  }
+
+  void abort() override {
+    state_->abort_saw_completed_copy.store(
+        state_->copy_finished.load(std::memory_order_acquire),
+        std::memory_order_release);
+    state_->abort_called.store(true, std::memory_order_release);
+  }
+
+  uint32_t size() const override { return 2; }
+
+ private:
+  LoadFailureState* state_ = nullptr;
+  int32_t record_count_ = 0;
+};
 
 TEST(HierarchyKVCacheTransferTest,
      RestoreRegistersReadyEventsForConfiguredLayerGroups) {
@@ -220,6 +339,89 @@ TEST(HierarchyKVCacheTransferTest,
                    caches[0].get_index_cache()[kDestinationBlockId].cpu()));
   EXPECT_TRUE(torch::equal(source_scale.cpu(),
                            index_scale.value()[kDestinationBlockId].cpu()));
+}
+
+TEST(HierarchyKVCacheTransferTest, EventFailureDrainsEarlierCopyBeforeAbort) {
+  if (Platform::device_count() < 1) {
+    GTEST_SKIP() << "MLU device is required for hierarchy KV cache transfer.";
+  }
+
+  constexpr int64_t kLayerCount = 1;
+  Device device(/*device_index=*/0);
+  device.set_device();
+  device.init_device_context();
+
+  KVCacheCapacity capacity;
+  capacity.n_blocks(2).block_size(4);
+  ModelArgs model_args;
+  model_args.model_type("test_model")
+      .n_layers(kLayerCount)
+      .n_heads(2)
+      .n_kv_heads(1)
+      .head_dim(8);
+  const KVCacheShape cache_shape(capacity, model_args, /*world_size=*/1);
+
+  KVCacheCreateOptions create_options;
+  create_options.device(device.unwrap())
+      .dtype(torch::kFloat32)
+      .num_layers(kLayerCount)
+      .model_type("test_model");
+  std::vector<KVCache> caches;
+  allocate_kv_caches(caches, cache_shape, create_options);
+
+  HierarchyKVCacheTransfer::Options transfer_options;
+  transfer_options.tp_rank(0)
+      .tp_size(1)
+      .layers(kLayerCount)
+      .host_blocks_factor(2.0)
+      .layers_wise_copy_batchs(1);
+  std::unique_ptr<Stream> compute_stream = device.current_stream();
+  HierarchyKVCacheTransfer transfer(transfer_options,
+                                    device.unwrap(),
+                                    compute_stream.get(),
+                                    &caches,
+                                    cache_shape,
+                                    create_options);
+
+  LoadFailureState state;
+  HierarchyKVCacheTransferTestPeer::replace_batch_memcpy(
+      &transfer, std::make_unique<PendingBatchMemcpy>(&state));
+  HierarchyKVCacheTransferTestPeer::set_layer_batch_ranges(
+      &transfer,
+      {{/*begin_layer=*/0, /*end_layer=*/1},
+       {/*begin_layer=*/1, /*end_layer=*/1}});
+  std::shared_ptr<LayerSynchronizer> synchronizer =
+      std::make_shared<SecondRecordFailsSynchronizer>(&state);
+  BlockTransferInfo load_info(/*src_block_id=*/0, /*dst_block_id=*/1);
+  load_info.block_type = BlockType::KV;
+  load_info.transfer_type = TransferType::H2D;
+
+  std::future<bool> load_result = std::async(
+      std::launch::async, [&device, &transfer, &synchronizer, &load_info]() {
+        device.set_device();
+        device.init_device_context();
+        return HierarchyKVCacheTransferTestPeer::load_from_host(
+            &transfer, synchronizer, {load_info});
+      });
+
+  const bool record_failure_observed = wait_for_flag(state.record_failed);
+  if (!record_failure_observed) {
+    state.gate_open.store(true, std::memory_order_release);
+  }
+  ASSERT_TRUE(record_failure_observed);
+  const std::future_status drain_status =
+      load_result.wait_for(std::chrono::milliseconds(100));
+  EXPECT_FALSE(state.abort_called.load(std::memory_order_acquire));
+
+  state.gate_open.store(true, std::memory_order_release);
+
+  ASSERT_EQ(load_result.wait_for(std::chrono::seconds(2)),
+            std::future_status::ready);
+  EXPECT_FALSE(load_result.get());
+  EXPECT_EQ(drain_status, std::future_status::timeout);
+  EXPECT_TRUE(state.copy_finished.load(std::memory_order_acquire));
+  EXPECT_TRUE(state.abort_called.load(std::memory_order_acquire));
+  EXPECT_TRUE(state.abort_saw_completed_copy.load(std::memory_order_acquire));
 }
 
 }  // namespace

--- a/tests/core/framework/kv_cache_transfer/kv_transfer_completion_test.cpp
+++ b/tests/core/framework/kv_cache_transfer/kv_transfer_completion_test.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include <chrono>
 #include <future>
+#include <memory>
 
 namespace xllm {
 namespace {
@@ -80,6 +81,44 @@ TEST(KVTransferCompletionTest, RejectsPendingTransferAtDestruction) {
         completion.add(promise.getSemiFuture());
       },
       "pending KV transfers");
+}
+
+TEST(KVTransferTrackerTest, WaitsForEveryTrackedTransfer) {
+  KVTransferTracker tracker;
+  std::shared_ptr<KVTransferTracker::Completion> first = tracker.track();
+  std::shared_ptr<KVTransferTracker::Completion> second = tracker.track();
+
+  std::promise<void> waiter_started;
+  std::future<void> started = waiter_started.get_future();
+  std::future<void> result = std::async(std::launch::async, [&]() {
+    waiter_started.set_value();
+    tracker.wait();
+  });
+
+  started.wait();
+  first.reset();
+  EXPECT_EQ(result.wait_for(50ms), std::future_status::timeout);
+  second.reset();
+  EXPECT_EQ(result.wait_for(1s), std::future_status::ready);
+}
+
+TEST(KVTransferTrackerTest, DestructionWaitsForTrackedTransfer) {
+  auto tracker = std::make_unique<KVTransferTracker>();
+  std::shared_ptr<KVTransferTracker::Completion> completion = tracker->track();
+
+  std::promise<void> destruction_started;
+  std::future<void> started = destruction_started.get_future();
+  std::future<void> result = std::async(
+      std::launch::async,
+      [tracker = std::move(tracker), &destruction_started]() mutable {
+        destruction_started.set_value();
+        tracker.reset();
+      });
+
+  started.wait();
+  EXPECT_EQ(result.wait_for(50ms), std::future_status::timeout);
+  completion.reset();
+  EXPECT_EQ(result.wait_for(1s), std::future_status::ready);
 }
 
 }  // namespace

--- a/tests/core/framework/kv_cache_transfer/kv_transfer_completion_test.cpp
+++ b/tests/core/framework/kv_cache_transfer/kv_transfer_completion_test.cpp
@@ -102,6 +102,21 @@ TEST(KVTransferTrackerTest, WaitsForEveryTrackedTransfer) {
   EXPECT_EQ(result.wait_for(1s), std::future_status::ready);
 }
 
+TEST(KVTransferTrackerTest, ReportsPendingUntilEveryTransferFinishes) {
+  KVTransferTracker tracker;
+  EXPECT_FALSE(tracker.has_pending());
+
+  std::shared_ptr<KVTransferTracker::Completion> first = tracker.track();
+  std::shared_ptr<KVTransferTracker::Completion> second = tracker.track();
+  EXPECT_TRUE(tracker.has_pending());
+
+  first.reset();
+  EXPECT_TRUE(tracker.has_pending());
+
+  second.reset();
+  EXPECT_FALSE(tracker.has_pending());
+}
+
 TEST(KVTransferTrackerTest, DestructionWaitsForTrackedTransfer) {
   auto tracker = std::make_unique<KVTransferTracker>();
   std::shared_ptr<KVTransferTracker::Completion> completion = tracker->track();

--- a/tests/core/platform/mlu/CMakeLists.txt
+++ b/tests/core/platform/mlu/CMakeLists.txt
@@ -25,6 +25,9 @@ cc_test(
     cndrv
     torch
 )
+target_link_options(mlu_batch_memcpy_test PRIVATE
+  -Wl,--wrap=cnMemcpyBatchAsync
+  -Wl,--wrap=cnQueueSync)
 
 cc_test(
   NAME

--- a/tests/core/platform/mlu/mlu_batch_memcpy_test.cpp
+++ b/tests/core/platform/mlu/mlu_batch_memcpy_test.cpp
@@ -15,11 +15,16 @@ limitations under the License.
 
 #include "core/platform/mlu/mlu_batch_memcpy.h"
 
+#include <cnrt.h>
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <future>
 #include <memory>
+#include <thread>
 #include <vector>
 
 #include "core/framework/kv_cache/kv_cache_utils.h"
@@ -123,6 +128,48 @@ TEST_F(MLUBatchMemcpyTest, RoundTripSupportsDifferentTensorSizes) {
   for (size_t index = 0; index < widths.size(); ++index) {
     EXPECT_TRUE(torch::equal(sources[index], restored[index]));
   }
+}
+
+TEST_F(MLUBatchMemcpyTest, SubmitH2DReturnsBeforeCopyStreamCompletes) {
+  torch::Tensor host;
+  HostPageAlignedRegion host_region;
+  create_host_page_aligned_tensor({16}, torch::kUInt8, &host, &host_region);
+  host.fill_(23);
+  const torch::Tensor device_tensor = torch::zeros(
+      {16},
+      torch::TensorOptions().dtype(torch::kUInt8).device(device_->unwrap()));
+  ASSERT_EQ(device_->synchronize_default_stream(), 0);
+
+  std::atomic<bool> gate_open{false};
+  ASSERT_EQ(cnrtInvokeHostFunc(
+                stream_->get_stream()->stream(),
+                [](void* user_data) {
+                  std::atomic<bool>* gate =
+                      static_cast<std::atomic<bool>*>(user_data);
+                  while (!gate->load(std::memory_order_acquire)) {
+                    std::this_thread::yield();
+                  }
+                },
+                &gate_open),
+            cnrtSuccess);
+
+  std::future<bool> submit_result =
+      std::async(std::launch::async, [this, &host, &device_tensor]() {
+        device_->set_device();
+        device_->init_device_context();
+        return batch_memcpy_->submit_h2d(
+            {host}, {device_tensor}, stream_.get());
+      });
+  const std::future_status submit_status =
+      submit_result.wait_for(std::chrono::milliseconds(250));
+  gate_open.store(true, std::memory_order_release);
+
+  ASSERT_EQ(submit_result.wait_for(std::chrono::seconds(2)),
+            std::future_status::ready);
+  ASSERT_TRUE(submit_result.get());
+  ASSERT_EQ(stream_->synchronize(), 0);
+  EXPECT_EQ(submit_status, std::future_status::ready);
+  EXPECT_TRUE(torch::all(device_tensor.cpu() == 23).item<bool>());
 }
 
 TEST_F(MLUBatchMemcpyTest, RejectsInvalidInputs) {

--- a/tests/core/platform/mlu/mlu_batch_memcpy_test.cpp
+++ b/tests/core/platform/mlu/mlu_batch_memcpy_test.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "core/platform/mlu/mlu_batch_memcpy.h"
 
+#include <cn_api.h>
 #include <cnrt.h>
 #include <gtest/gtest.h>
 
@@ -31,6 +32,85 @@ limitations under the License.
 #include "core/platform/batch_memcpy.h"
 #include "core/platform/device.h"
 #include "core/platform/platform.h"
+
+namespace {
+
+enum class BatchCopyFault : int8_t {
+  NONE = 0,
+  FAIL_SECOND_SUBMISSION = 1,
+  FAIL_SUBMISSION_AND_SYNC = 2,
+};
+
+std::atomic<BatchCopyFault> g_batch_copy_fault{BatchCopyFault::NONE};
+std::atomic<int32_t> g_batch_submit_calls{0};
+std::atomic<int32_t> g_queue_sync_calls{0};
+
+class ScopedBatchCopyFault final {
+ public:
+  explicit ScopedBatchCopyFault(BatchCopyFault fault) {
+    g_batch_submit_calls.store(0, std::memory_order_relaxed);
+    g_queue_sync_calls.store(0, std::memory_order_relaxed);
+    g_batch_copy_fault.store(fault, std::memory_order_release);
+  }
+
+  ~ScopedBatchCopyFault() {
+    g_batch_copy_fault.store(BatchCopyFault::NONE, std::memory_order_release);
+  }
+
+  ScopedBatchCopyFault(const ScopedBatchCopyFault&) = delete;
+  ScopedBatchCopyFault& operator=(const ScopedBatchCopyFault&) = delete;
+};
+
+void wait_for_queue_gate(void* user_data) {
+  std::atomic<bool>* gate_open = static_cast<std::atomic<bool>*>(user_data);
+  while (!gate_open->load(std::memory_order_acquire)) {
+    std::this_thread::yield();
+  }
+}
+
+}  // namespace
+
+extern "C" CNresult __real_cnMemcpyBatchAsync(
+    CNaddr* dsts,
+    CNaddr* srcs,
+    size_t* bytes,
+    size_t count,
+    CNmemcpyBatchAsyncAttributes* attrs,
+    size_t* attr_indexes,
+    size_t num_attrs,
+    CNqueue queue);
+
+extern "C" CNresult __wrap_cnMemcpyBatchAsync(
+    CNaddr* dsts,
+    CNaddr* srcs,
+    size_t* bytes,
+    size_t count,
+    CNmemcpyBatchAsyncAttributes* attrs,
+    size_t* attr_indexes,
+    size_t num_attrs,
+    CNqueue queue) {
+  const int32_t call =
+      g_batch_submit_calls.fetch_add(1, std::memory_order_relaxed) + 1;
+  const BatchCopyFault fault =
+      g_batch_copy_fault.load(std::memory_order_acquire);
+  if ((fault == BatchCopyFault::FAIL_SECOND_SUBMISSION && call == 2) ||
+      (fault == BatchCopyFault::FAIL_SUBMISSION_AND_SYNC && call == 1)) {
+    return CN_ERROR_INVALID_VALUE;
+  }
+  return __real_cnMemcpyBatchAsync(
+      dsts, srcs, bytes, count, attrs, attr_indexes, num_attrs, queue);
+}
+
+extern "C" CNresult __real_cnQueueSync(CNqueue queue);
+
+extern "C" CNresult __wrap_cnQueueSync(CNqueue queue) {
+  g_queue_sync_calls.fetch_add(1, std::memory_order_relaxed);
+  if (g_batch_copy_fault.load(std::memory_order_acquire) ==
+      BatchCopyFault::FAIL_SUBMISSION_AND_SYNC) {
+    return CN_ERROR_INVALID_VALUE;
+  }
+  return __real_cnQueueSync(queue);
+}
 
 namespace xllm::mlu {
 namespace {
@@ -170,6 +250,66 @@ TEST_F(MLUBatchMemcpyTest, SubmitH2DReturnsBeforeCopyStreamCompletes) {
   ASSERT_EQ(stream_->synchronize(), 0);
   EXPECT_EQ(submit_status, std::future_status::ready);
   EXPECT_TRUE(torch::all(device_tensor.cpu() == 23).item<bool>());
+}
+
+TEST_F(MLUBatchMemcpyTest, SubmissionFailureDrainsPreviouslySubmittedChunks) {
+  constexpr int64_t kDescriptorCount = 4097;
+  torch::Tensor host;
+  HostPageAlignedRegion host_region;
+  create_host_page_aligned_tensor(
+      {kDescriptorCount, 1}, torch::kUInt8, &host, &host_region);
+  host.fill_(31);
+  const torch::Tensor device_tensor = torch::zeros(
+      {kDescriptorCount, 1},
+      torch::TensorOptions().dtype(torch::kUInt8).device(device_->unwrap()));
+  ASSERT_EQ(device_->synchronize_default_stream(), 0);
+
+  std::atomic<bool> gate_open{false};
+  ASSERT_EQ(
+      cnrtInvokeHostFunc(
+          stream_->get_stream()->stream(), wait_for_queue_gate, &gate_open),
+      cnrtSuccess);
+  ScopedBatchCopyFault fault(BatchCopyFault::FAIL_SECOND_SUBMISSION);
+  const std::vector<torch::Tensor> host_rows = rows(host);
+  const std::vector<torch::Tensor> device_rows = rows(device_tensor);
+  std::future<bool> submit_result =
+      std::async(std::launch::async, [this, &host_rows, &device_rows]() {
+        device_->set_device();
+        device_->init_device_context();
+        return batch_memcpy_->submit_h2d(host_rows, device_rows, stream_.get());
+      });
+
+  const std::future_status drain_status =
+      submit_result.wait_for(std::chrono::milliseconds(100));
+  gate_open.store(true, std::memory_order_release);
+
+  ASSERT_EQ(submit_result.wait_for(std::chrono::seconds(2)),
+            std::future_status::ready);
+  EXPECT_FALSE(submit_result.get());
+  EXPECT_EQ(drain_status, std::future_status::timeout);
+  EXPECT_EQ(g_batch_submit_calls.load(std::memory_order_relaxed), 2);
+  EXPECT_EQ(g_queue_sync_calls.load(std::memory_order_relaxed), 1);
+  EXPECT_TRUE(
+      torch::all(
+          device_tensor.slice(/*dim=*/0, /*start=*/0, /*end=*/4096).cpu() == 31)
+          .item<bool>());
+  EXPECT_TRUE(torch::all(device_tensor[4096].cpu() == 0).item<bool>());
+}
+
+TEST_F(MLUBatchMemcpyTest, UndrainableSubmissionFailureTerminatesProcess) {
+  torch::Tensor host;
+  HostPageAlignedRegion host_region;
+  create_host_page_aligned_tensor({1}, torch::kUInt8, &host, &host_region);
+  const torch::Tensor device_tensor = torch::zeros(
+      {1},
+      torch::TensorOptions().dtype(torch::kUInt8).device(device_->unwrap()));
+
+  EXPECT_DEATH(
+      {
+        ScopedBatchCopyFault fault(BatchCopyFault::FAIL_SUBMISSION_AND_SYNC);
+        (void)batch_memcpy_->submit_h2d({host}, {device_tensor}, stream_.get());
+      },
+      "Failed to drain MLU batch memcpy queue after submission failure");
 }
 
 TEST_F(MLUBatchMemcpyTest, RejectsInvalidInputs) {

--- a/tests/core/platform/mlu/mlu_batch_memcpy_test.cpp
+++ b/tests/core/platform/mlu/mlu_batch_memcpy_test.cpp
@@ -155,7 +155,7 @@ class MLUBatchMemcpyTest : public ::testing::Test {
     create_host_page_aligned_tensor(
         {count, width}, torch::kUInt8, &restored, &restored_region);
 
-    ASSERT_TRUE(batch_memcpy_->copy_h2d(
+    ASSERT_TRUE(batch_memcpy_->submit_h2d(
         rows(source), rows(device_tensor), stream_.get()));
     ASSERT_TRUE(batch_memcpy_->copy_d2h(
         rows(device_tensor), rows(restored), stream_.get()));
@@ -203,7 +203,8 @@ TEST_F(MLUBatchMemcpyTest, RoundTripSupportsDifferentTensorSizes) {
         torch::TensorOptions().dtype(torch::kUInt8).device(device_->unwrap())));
   }
 
-  ASSERT_TRUE(batch_memcpy_->copy_h2d(sources, device_tensors, stream_.get()));
+  ASSERT_TRUE(
+      batch_memcpy_->submit_h2d(sources, device_tensors, stream_.get()));
   ASSERT_TRUE(batch_memcpy_->copy_d2h(device_tensors, restored, stream_.get()));
   for (size_t index = 0; index < widths.size(); ++index) {
     EXPECT_TRUE(torch::equal(sources[index], restored[index]));
@@ -320,18 +321,19 @@ TEST_F(MLUBatchMemcpyTest, RejectsInvalidInputs) {
       {2, 4},
       torch::TensorOptions().dtype(torch::kUInt8).device(device_->unwrap()));
 
-  EXPECT_FALSE(batch_memcpy_->copy_h2d(
+  EXPECT_FALSE(batch_memcpy_->submit_h2d(
       {host[0]}, {device_tensor[0], device_tensor[1]}, stream_.get()));
-  EXPECT_FALSE(batch_memcpy_->copy_h2d(
+  EXPECT_FALSE(batch_memcpy_->submit_h2d(
       {host[0]}, {device_tensor.flatten()}, stream_.get()));
-  EXPECT_FALSE(batch_memcpy_->copy_h2d(
+  EXPECT_FALSE(batch_memcpy_->submit_h2d(
       {host.transpose(0, 1)}, {device_tensor}, stream_.get()));
   EXPECT_FALSE(
-      batch_memcpy_->copy_h2d({device_tensor[0]}, {host[0]}, stream_.get()));
+      batch_memcpy_->submit_h2d({device_tensor[0]}, {host[0]}, stream_.get()));
   EXPECT_FALSE(
       batch_memcpy_->copy_d2h({host[0]}, {device_tensor[0]}, stream_.get()));
-  EXPECT_FALSE(batch_memcpy_->copy_h2d({host[0]}, {device_tensor[0]}, nullptr));
-  EXPECT_FALSE(batch_memcpy_->copy_h2d(
+  EXPECT_FALSE(
+      batch_memcpy_->submit_h2d({host[0]}, {device_tensor[0]}, nullptr));
+  EXPECT_FALSE(batch_memcpy_->submit_h2d(
       {torch::Tensor()}, {device_tensor[0]}, stream_.get()));
 }
 
@@ -352,7 +354,8 @@ TEST_F(MLUBatchMemcpyTest, RejectsStreamFromAnotherDevice) {
                        .device(other_device.unwrap()));
   device_->set_device();
 
-  EXPECT_FALSE(batch_memcpy_->copy_h2d({host}, {other_tensor}, stream_.get()));
+  EXPECT_FALSE(
+      batch_memcpy_->submit_h2d({host}, {other_tensor}, stream_.get()));
 }
 
 }  // namespace

--- a/tests/core/platform/mlu/mlu_layer_synchronizer_test.cpp
+++ b/tests/core/platform/mlu/mlu_layer_synchronizer_test.cpp
@@ -208,14 +208,26 @@ TEST_F(MLULayerSynchronizerTest, AbortUnblocksAnUnrecordedRange) {
   EXPECT_FALSE(wait_result.get());
 }
 
-TEST_F(MLULayerSynchronizerTest, RecordFailureAbortsPendingWaits) {
+TEST_F(MLULayerSynchronizerTest, RecordFailureWaitsForOwnerAbort) {
   std::shared_ptr<LayerSynchronizer> synchronizer =
       create_layer_synchronizer(/*num_layers=*/2);
   ASSERT_NE(synchronizer, nullptr);
 
+  std::future<bool> wait_result =
+      std::async(std::launch::async, [synchronizer]() {
+        return synchronizer->synchronize_layer(/*layer_index=*/1);
+      });
+
   EXPECT_FALSE(
       synchronizer->record_stream(/*layer_index=*/0, /*stream=*/nullptr));
-  EXPECT_FALSE(synchronizer->synchronize_layer(/*layer_index=*/1));
+  EXPECT_EQ(wait_result.wait_for(std::chrono::milliseconds(100)),
+            std::future_status::timeout);
+
+  synchronizer->abort();
+
+  ASSERT_EQ(wait_result.wait_for(std::chrono::seconds(2)),
+            std::future_status::ready);
+  EXPECT_FALSE(wait_result.get());
 }
 
 TEST_F(MLULayerSynchronizerTest, ModelInputWaitsAtRangeBoundaries) {

--- a/xllm/core/framework/block/CMakeLists.txt
+++ b/xllm/core/framework/block/CMakeLists.txt
@@ -43,6 +43,7 @@ cc_library(
     :request
     :common
     :prefix_cache
+    :kv_transfer_completion
     glog::glog
     Boost::serialization
     SMHasherSupport

--- a/xllm/core/framework/block/hierarchy_block_manager_pool.cpp
+++ b/xllm/core/framework/block/hierarchy_block_manager_pool.cpp
@@ -971,7 +971,7 @@ void HierarchyBlockManagerPool::transfer_blocks(std::vector<Batch>& batches) {
 void HierarchyBlockManagerPool::transfer_blocks() { transfer_offload_blocks(); }
 
 bool HierarchyBlockManagerPool::has_pending_async_block_release() const {
-  if (pending_offload_transfers_.load(std::memory_order_relaxed) > 0) {
+  if (offload_transfers_.has_pending()) {
     return true;
   }
   for (const OffloadBlockPairQueue& queue : offload_block_pair_queues_) {
@@ -1014,9 +1014,6 @@ void HierarchyBlockManagerPool::transfer_offload_blocks() {
       for (const auto& [type, entry] : host_block_managers_[i]) {
         host_leaves_snapshot.emplace(type, entry.leaf.get());
       }
-      pending_offload_transfers_.fetch_add(1, std::memory_order_relaxed);
-      std::atomic<size_t>* pending_offload_transfers =
-          &pending_offload_transfers_;
       std::shared_ptr<KVTransferTracker::Completion> completion =
           offload_transfers_.track();
       folly::collectAll(
@@ -1026,8 +1023,7 @@ void HierarchyBlockManagerPool::transfer_offload_blocks() {
                       host_blocks = std::move(dst_blocks),
                       block_types_vec = std::move(block_types),
                       device_block_mgr_ptr = block_managers_[i].get(),
-                      host_leaves = std::move(host_leaves_snapshot),
-                      completion = std::move(completion)](
+                      host_leaves = std::move(host_leaves_snapshot)](
                          std::vector<folly::Try<uint32_t>>&& results) mutable {
             bool copy_ok = true;
             for (auto&& result : results) {
@@ -1054,11 +1050,10 @@ void HierarchyBlockManagerPool::transfer_offload_blocks() {
             finalize_host_blocks(
                 copy_ok, std::move(host_blocks), block_types_vec, host_leaves);
 
-            completion.reset();
             return 0;
           })
-          .ensure([pending_offload_transfers]() {
-            pending_offload_transfers->fetch_sub(1, std::memory_order_relaxed);
+          .ensure([completion = std::move(completion)]() mutable {
+            completion.reset();
           });
     }
   }

--- a/xllm/core/framework/block/hierarchy_block_manager_pool.cpp
+++ b/xllm/core/framework/block/hierarchy_block_manager_pool.cpp
@@ -15,6 +15,8 @@ limitations under the License.
 
 #include "hierarchy_block_manager_pool.h"
 
+#include <folly/executors/InlineExecutor.h>
+
 #include <algorithm>
 #include <iterator>
 #include <limits>
@@ -31,6 +33,31 @@ namespace xllm {
 namespace {
 
 using ProbeResult = CompositeBlockManager::ProbeResult;
+using HostLeafSnapshot = std::unordered_map<BlockType, BlockManager*>;
+
+void finalize_host_blocks(bool publish,
+                          std::vector<Block> host_blocks,
+                          const std::vector<BlockType>& block_types,
+                          const HostLeafSnapshot& host_leaves) {
+  CHECK_EQ(host_blocks.size(), block_types.size());
+  std::unordered_map<BlockType, std::vector<Block>> blocks_by_type;
+  for (size_t i = 0; i < host_blocks.size(); ++i) {
+    blocks_by_type[block_types[i]].emplace_back(std::move(host_blocks[i]));
+  }
+
+  for (auto& [type, blocks] : blocks_by_type) {
+    auto leaf = host_leaves.find(type);
+    if (leaf == host_leaves.end()) {
+      LOG(ERROR) << "Missing Host block manager for block type "
+                 << static_cast<int32_t>(type);
+      continue;
+    }
+    if (publish) {
+      leaf->second->cache(blocks);
+    }
+    leaf->second->deallocate(blocks);
+  }
+}
 
 // Wrap a leaf in the concurrency adapter when the D2H offload callback frees
 // blocks off-thread. Host-offload leaves always need this wrap.
@@ -983,21 +1010,24 @@ void HierarchyBlockManagerPool::transfer_offload_blocks() {
     if (!transfer_infos.empty()) {
       // Capture per-leaf host manager pointers so the completion callback can
       // route each block to the correct host leaf on publish.
-      std::unordered_map<BlockType, BlockManager*> host_leaves_snapshot;
+      HostLeafSnapshot host_leaves_snapshot;
       for (const auto& [type, entry] : host_block_managers_[i]) {
         host_leaves_snapshot.emplace(type, entry.leaf.get());
       }
       pending_offload_transfers_.fetch_add(1, std::memory_order_relaxed);
       std::atomic<size_t>* pending_offload_transfers =
           &pending_offload_transfers_;
+      std::shared_ptr<KVTransferTracker::Completion> completion =
+          offload_transfers_.track();
       folly::collectAll(
           std::move(engine_->transfer_kv_blocks(i, std::move(transfer_infos))))
-          .via(folly::getGlobalCPUExecutor())
+          .via(&folly::InlineExecutor::instance())
           .thenValue([device_blocks = std::move(src_blocks),
                       host_blocks = std::move(dst_blocks),
                       block_types_vec = std::move(block_types),
                       device_block_mgr_ptr = block_managers_[i].get(),
-                      host_leaves = std::move(host_leaves_snapshot)](
+                      host_leaves = std::move(host_leaves_snapshot),
+                      completion = std::move(completion)](
                          std::vector<folly::Try<uint32_t>>&& results) mutable {
             bool copy_ok = true;
             for (auto&& result : results) {
@@ -1018,50 +1048,13 @@ void HierarchyBlockManagerPool::transfer_offload_blocks() {
             device_block_mgr_ptr->deallocate(device_blocks);
             device_blocks.clear();
 
-            if (copy_ok) {
-              // Group host blocks by type and cache/free them on the matching
-              // host leaf. Publishing per-type keeps a partial success from
-              // corrupting sibling leaves.
-              std::unordered_map<BlockType, std::vector<Block>> by_type;
-              for (size_t k = 0; k < host_blocks.size(); ++k) {
-                by_type[block_types_vec[k]].emplace_back(
-                    std::move(host_blocks[k]));
-              }
-              for (auto& [type, blocks] : by_type) {
-                auto it = host_leaves.find(type);
-                if (it == host_leaves.end()) {
-                  LOG(ERROR) << "Missing Host block manager for block type "
-                             << static_cast<int32_t>(type);
-                  blocks.clear();
-                  continue;
-                }
-                it->second->cache(blocks);
-                it->second->deallocate(blocks);
-                blocks.clear();
-              }
-              host_blocks.clear();
-            } else {
-              // Publish nothing on failure. Return all host ids to their
-              // owning leaf so no host slot leaks.
-              std::unordered_map<BlockType, std::vector<Block>> by_type;
-              for (size_t k = 0; k < host_blocks.size(); ++k) {
-                by_type[block_types_vec[k]].emplace_back(
-                    std::move(host_blocks[k]));
-              }
-              for (auto& [type, blocks] : by_type) {
-                auto it = host_leaves.find(type);
-                if (it == host_leaves.end()) {
-                  LOG(ERROR) << "Missing Host block manager for block type "
-                             << static_cast<int32_t>(type);
-                  blocks.clear();
-                  continue;
-                }
-                it->second->deallocate(blocks);
-                blocks.clear();
-              }
-              host_blocks.clear();
-            }
+            // Successful copies become visible in the Host prefix cache.
+            // Failures publish nothing, but both paths release every reserved
+            // Host id through the same type-aware ownership path.
+            finalize_host_blocks(
+                copy_ok, std::move(host_blocks), block_types_vec, host_leaves);
 
+            completion.reset();
             return 0;
           })
           .ensure([pending_offload_transfers]() {

--- a/xllm/core/framework/block/hierarchy_block_manager_pool.h
+++ b/xllm/core/framework/block/hierarchy_block_manager_pool.h
@@ -15,7 +15,6 @@ limitations under the License.
 
 #pragma once
 
-#include <atomic>
 #include <map>
 #include <mutex>
 #include <unordered_map>
@@ -109,7 +108,6 @@ class HierarchyBlockManagerPool : public BlockManagerPool {
   // owned only by the Sequence's Host/device cache states.
   std::vector<std::vector<BlockTransferInfo>> load_block_transfer_infos_;
   std::vector<OffloadBlockPairQueue> offload_block_pair_queues_;
-  std::atomic<size_t> pending_offload_transfers_{0};
 
   std::mutex prefetch_plans_mutex_;
   std::unordered_map<Sequence*, std::shared_ptr<PrefetchPlan>> prefetch_plans_;

--- a/xllm/core/framework/block/hierarchy_block_manager_pool.h
+++ b/xllm/core/framework/block/hierarchy_block_manager_pool.h
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "block_manager_pool.h"
 #include "composite_block_manager.h"
+#include "core/framework/kv_cache_transfer/kv_transfer_completion.h"
 #include "distributed_runtime/engine.h"
 #include "util/blockingconcurrentqueue.h"
 #include "util/timer.h"
@@ -112,6 +113,10 @@ class HierarchyBlockManagerPool : public BlockManagerPool {
 
   std::mutex prefetch_plans_mutex_;
   std::unordered_map<Sequence*, std::shared_ptr<PrefetchPlan>> prefetch_plans_;
+
+  // Declared last so destruction waits for callbacks before any manager or
+  // block storage captured by those callbacks is released.
+  KVTransferTracker offload_transfers_;
 };
 
 }  // namespace xllm

--- a/xllm/core/framework/kv_cache_transfer/hierarchy_kv_cache_transfer.cpp
+++ b/xllm/core/framework/kv_cache_transfer/hierarchy_kv_cache_transfer.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 #include "framework/kv_cache_transfer/hierarchy_kv_cache_transfer.h"
 
 #include <algorithm>
+#include <exception>
 #include <future>
 #include <memory>
 #include <string>
@@ -79,6 +80,46 @@ std::string make_store_local_hostname(const std::string& configured,
 // one stream per such thread so concurrent offloads never block on the stream
 // queue.
 constexpr size_t kOffloadStreamCount = 4;
+
+using CopyStreamQueue =
+    moodycamel::BlockingConcurrentQueue<std::unique_ptr<Stream>>;
+
+class CopyStreamLease final {
+ public:
+  explicit CopyStreamLease(CopyStreamQueue* stream_pool)
+      : stream_pool_(stream_pool) {
+    CHECK(stream_pool_ != nullptr) << "copy stream pool must not be null.";
+    stream_pool_->wait_dequeue(stream_);
+    CHECK(stream_ != nullptr) << "copy stream must not be null.";
+  }
+
+  ~CopyStreamLease() { stream_pool_->enqueue(std::move(stream_)); }
+
+  CopyStreamLease(const CopyStreamLease&) = delete;
+  CopyStreamLease& operator=(const CopyStreamLease&) = delete;
+
+  Stream* get() const { return stream_.get(); }
+
+  void drain_or_die(const char* reason) const {
+    try {
+      const int synchronize_result = stream_->synchronize();
+      if (synchronize_result != 0) {
+        LOG(FATAL) << "Failed to drain KV Cache copy stream: reason=" << reason
+                   << ", result=" << synchronize_result;
+      }
+    } catch (const std::exception& error) {
+      LOG(FATAL) << "Failed to drain KV Cache copy stream: reason=" << reason
+                 << ", error=" << error.what();
+    } catch (...) {
+      LOG(FATAL) << "Failed to drain KV Cache copy stream: reason=" << reason
+                 << ", unknown error.";
+    }
+  }
+
+ private:
+  CopyStreamQueue* stream_pool_ = nullptr;
+  std::unique_ptr<Stream> stream_;
+};
 
 std::vector<HierarchyKVCacheTransfer::LayerBatchRange> build_layer_batch_ranges(
     int64_t num_layers,
@@ -535,13 +576,12 @@ bool HierarchyKVCacheTransfer::offload_to_host(
   }
 
   CHECK(batch_memcpy_ != nullptr) << "batch memcpy must be initialized.";
-  std::unique_ptr<Stream> stream;
-  copy_stream_.wait_dequeue(stream);
+  CopyStreamLease stream(&copy_stream_);
   // D2H is issued from an RPC worker, while the preceding forward is enqueued
   // on WorkerImpl's compute stream. Establish a device-side dependency before
   // reading KV; the RPC thread's current/default stream is unrelated when
   // schedule overlap is enabled.
-  stream->wait_stream(*compute_stream_);
+  stream.get()->wait_stream(*compute_stream_);
   bool success = true;
   for (const auto& range : layer_batch_ranges_) {
     CopyPlan plan = build_copy_plan(
@@ -556,7 +596,6 @@ bool HierarchyKVCacheTransfer::offload_to_host(
       break;
     }
   }
-  copy_stream_.enqueue(std::move(stream));
   return success;
 }
 
@@ -570,34 +609,33 @@ bool HierarchyKVCacheTransfer::load_from_host(
   CHECK(synchronizer != nullptr) << "layer synchronizer must not be null.";
   CHECK(batch_memcpy_ != nullptr) << "batch memcpy must be initialized.";
 
-  std::unique_ptr<Stream> stream;
-  copy_stream_.wait_dequeue(stream);
+  CopyStreamLease stream(&copy_stream_);
   bool success = true;
+  bool stream_has_async_h2d = false;
   for (size_t range_idx = 0; range_idx < layer_batch_ranges_.size();
        ++range_idx) {
     CopyPlan plan =
         build_copy_plan(block_transfer_info, layer_batch_ranges_[range_idx]);
-    if (plan.src_tensors.empty()) {
-      if (!synchronizer->record_stream(static_cast<int64_t>(range_idx),
-                                       stream.get())) {
+    if (!plan.src_tensors.empty()) {
+      if (!batch_memcpy_->submit_h2d(
+              plan.src_tensors, plan.dst_tensors, stream.get())) {
+        stream_has_async_h2d = false;
         success = false;
         break;
       }
-      continue;
-    }
-    if (!batch_memcpy_->submit_h2d(
-            plan.src_tensors, plan.dst_tensors, stream.get())) {
-      success = false;
-      break;
+      stream_has_async_h2d = true;
     }
     if (!synchronizer->record_stream(static_cast<int64_t>(range_idx),
                                      stream.get())) {
+      if (stream_has_async_h2d) {
+        stream.drain_or_die("layer-ready event recording failed");
+        stream_has_async_h2d = false;
+      }
       success = false;
       break;
     }
   }
 
-  copy_stream_.enqueue(std::move(stream));
   // On failure some ranges were never recorded; abort the synchronizer so a
   // forward thread spinning on those layers unblocks and reports failure
   // (aborting the forward) instead of hanging or reading uncopied KV cache.

--- a/xllm/core/framework/kv_cache_transfer/hierarchy_kv_cache_transfer.cpp
+++ b/xllm/core/framework/kv_cache_transfer/hierarchy_kv_cache_transfer.cpp
@@ -256,7 +256,24 @@ HierarchyKVCacheTransfer::HierarchyKVCacheTransfer(
   }
 }
 
-HierarchyKVCacheTransfer::~HierarchyKVCacheTransfer() = default;
+HierarchyKVCacheTransfer::~HierarchyKVCacheTransfer() {
+  // Joining the load pool first guarantees no producer can enqueue more work
+  // while the copy streams and host cache storage are being released.
+  load_threadpool_.reset();
+
+  device_.set_device();
+  std::unique_ptr<Stream> stream;
+  while (copy_stream_.try_dequeue(stream)) {
+    if (stream == nullptr) {
+      continue;
+    }
+    CHECK_EQ(stream->synchronize(), 0)
+        << "Failed to drain hierarchy KV copy stream during shutdown.";
+  }
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  layer_wise_load_synchronizer_.clear();
+}
 
 void HierarchyKVCacheTransfer::build_device_block_type_map() {
   device_kv_caches_.clear();
@@ -568,7 +585,7 @@ bool HierarchyKVCacheTransfer::load_from_host(
       }
       continue;
     }
-    if (!batch_memcpy_->copy_h2d(
+    if (!batch_memcpy_->submit_h2d(
             plan.src_tensors, plan.dst_tensors, stream.get())) {
       success = false;
       break;

--- a/xllm/core/framework/kv_cache_transfer/hierarchy_kv_cache_transfer.h
+++ b/xllm/core/framework/kv_cache_transfer/hierarchy_kv_cache_transfer.h
@@ -94,6 +94,8 @@ class HierarchyKVCacheTransfer {
   void set_layer_synchronizer(ModelInputParams& params);
 
  private:
+  friend class HierarchyKVCacheTransferTestPeer;
+
   void build_device_block_type_map();
   void create_host_cache();
   CopyPlan build_copy_plan(

--- a/xllm/core/framework/kv_cache_transfer/kv_transfer_completion.cpp
+++ b/xllm/core/framework/kv_cache_transfer/kv_transfer_completion.cpp
@@ -19,6 +19,9 @@ limitations under the License.
 
 #include <algorithm>
 #include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <mutex>
 #include <utility>
 
 namespace xllm {
@@ -59,5 +62,50 @@ bool KVTransferCompletion::wait() {
         return result.hasValue() && result.value();
       });
 }
+
+class KVTransferTracker::State final {
+ public:
+  void start() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++pending_transfers_;
+  }
+
+  void finish() {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      CHECK_GT(pending_transfers_, 0u);
+      --pending_transfers_;
+    }
+    completion_cv_.notify_all();
+  }
+
+  void wait() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    completion_cv_.wait(lock, [this]() { return pending_transfers_ == 0; });
+  }
+
+ private:
+  std::mutex mutex_;
+  std::condition_variable completion_cv_;
+  size_t pending_transfers_ = 0;
+};
+
+KVTransferTracker::Completion::Completion(std::shared_ptr<State> state)
+    : state_(std::move(state)) {
+  CHECK(state_ != nullptr);
+  state_->start();
+}
+
+KVTransferTracker::Completion::~Completion() { state_->finish(); }
+
+KVTransferTracker::KVTransferTracker() : state_(std::make_shared<State>()) {}
+
+KVTransferTracker::~KVTransferTracker() { wait(); }
+
+std::shared_ptr<KVTransferTracker::Completion> KVTransferTracker::track() {
+  return std::shared_ptr<Completion>(new Completion(state_));
+}
+
+void KVTransferTracker::wait() { state_->wait(); }
 
 }  // namespace xllm

--- a/xllm/core/framework/kv_cache_transfer/kv_transfer_completion.cpp
+++ b/xllm/core/framework/kv_cache_transfer/kv_transfer_completion.cpp
@@ -79,13 +79,18 @@ class KVTransferTracker::State final {
     completion_cv_.notify_all();
   }
 
+  bool has_pending() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return pending_transfers_ > 0;
+  }
+
   void wait() {
     std::unique_lock<std::mutex> lock(mutex_);
     completion_cv_.wait(lock, [this]() { return pending_transfers_ == 0; });
   }
 
  private:
-  std::mutex mutex_;
+  mutable std::mutex mutex_;
   std::condition_variable completion_cv_;
   size_t pending_transfers_ = 0;
 };
@@ -105,6 +110,8 @@ KVTransferTracker::~KVTransferTracker() { wait(); }
 std::shared_ptr<KVTransferTracker::Completion> KVTransferTracker::track() {
   return std::shared_ptr<Completion>(new Completion(state_));
 }
+
+bool KVTransferTracker::has_pending() const { return state_->has_pending(); }
 
 void KVTransferTracker::wait() { state_->wait(); }
 

--- a/xllm/core/framework/kv_cache_transfer/kv_transfer_completion.h
+++ b/xllm/core/framework/kv_cache_transfer/kv_transfer_completion.h
@@ -18,6 +18,7 @@ limitations under the License.
 #include <folly/futures/Future.h>
 
 #include <chrono>
+#include <memory>
 #include <vector>
 
 namespace xllm {
@@ -44,6 +45,47 @@ class KVTransferCompletion final {
  private:
   std::chrono::milliseconds wait_timeout_;
   std::vector<folly::SemiFuture<bool>> futures_;
+};
+
+// Tracks callbacks that retain KV block managers or blocks. A Completion
+// token keeps one callback pending; releasing the last token unblocks wait().
+// Destruction waits so owners can declare this as their last member and make
+// callback lifetime a construction invariant instead of custom teardown code.
+class KVTransferTracker final {
+ private:
+  class State;
+
+ public:
+  class Completion final {
+   public:
+    ~Completion();
+
+    Completion(const Completion&) = delete;
+    Completion& operator=(const Completion&) = delete;
+    Completion(Completion&&) = delete;
+    Completion& operator=(Completion&&) = delete;
+
+   private:
+    friend class KVTransferTracker;
+
+    explicit Completion(std::shared_ptr<State> state);
+
+    std::shared_ptr<State> state_;
+  };
+
+  KVTransferTracker();
+  ~KVTransferTracker();
+
+  KVTransferTracker(const KVTransferTracker&) = delete;
+  KVTransferTracker& operator=(const KVTransferTracker&) = delete;
+  KVTransferTracker(KVTransferTracker&&) = delete;
+  KVTransferTracker& operator=(KVTransferTracker&&) = delete;
+
+  std::shared_ptr<Completion> track();
+  void wait();
+
+ private:
+  std::shared_ptr<State> state_;
 };
 
 }  // namespace xllm

--- a/xllm/core/framework/kv_cache_transfer/kv_transfer_completion.h
+++ b/xllm/core/framework/kv_cache_transfer/kv_transfer_completion.h
@@ -82,6 +82,7 @@ class KVTransferTracker final {
   KVTransferTracker& operator=(KVTransferTracker&&) = delete;
 
   std::shared_ptr<Completion> track();
+  bool has_pending() const;
   void wait();
 
  private:

--- a/xllm/core/platform/batch_memcpy.h
+++ b/xllm/core/platform/batch_memcpy.h
@@ -37,6 +37,14 @@ class BatchMemcpy {
                         const std::vector<torch::Tensor>& dst_tensors,
                         Stream* stream) = 0;
 
+  // Submits H2D copies without waiting for stream completion. Backends that
+  // do not support non-blocking submission keep the synchronous contract.
+  virtual bool submit_h2d(const std::vector<torch::Tensor>& src_tensors,
+                          const std::vector<torch::Tensor>& dst_tensors,
+                          Stream* stream) {
+    return copy_h2d(src_tensors, dst_tensors, stream);
+  }
+
   virtual bool copy_d2h(const std::vector<torch::Tensor>& src_tensors,
                         const std::vector<torch::Tensor>& dst_tensors,
                         Stream* stream) = 0;

--- a/xllm/core/platform/batch_memcpy.h
+++ b/xllm/core/platform/batch_memcpy.h
@@ -37,8 +37,12 @@ class BatchMemcpy {
                         const std::vector<torch::Tensor>& dst_tensors,
                         Stream* stream) = 0;
 
-  // Submits H2D copies without waiting for stream completion. Backends that
-  // do not support non-blocking submission keep the synchronous contract.
+  // Submits H2D copies without waiting for stream completion. A true result
+  // requires the caller to protect buffer lifetime with stream ordering,
+  // events, or explicit synchronization. A false result guarantees that any
+  // work accepted by this call has been drained; a backend must fail-stop if
+  // it cannot establish that guarantee. Backends without non-blocking
+  // submission keep the synchronous copy_h2d contract.
   virtual bool submit_h2d(const std::vector<torch::Tensor>& src_tensors,
                           const std::vector<torch::Tensor>& dst_tensors,
                           Stream* stream) {

--- a/xllm/core/platform/batch_memcpy.h
+++ b/xllm/core/platform/batch_memcpy.h
@@ -33,21 +33,15 @@ class BatchMemcpy {
 
   virtual void init(int32_t device_id) = 0;
 
-  virtual bool copy_h2d(const std::vector<torch::Tensor>& src_tensors,
-                        const std::vector<torch::Tensor>& dst_tensors,
-                        Stream* stream) = 0;
-
   // Submits H2D copies without waiting for stream completion. A true result
   // requires the caller to protect buffer lifetime with stream ordering,
   // events, or explicit synchronization. A false result guarantees that any
   // work accepted by this call has been drained; a backend must fail-stop if
   // it cannot establish that guarantee. Backends without non-blocking
-  // submission keep the synchronous copy_h2d contract.
+  // submission may complete copies synchronously before returning.
   virtual bool submit_h2d(const std::vector<torch::Tensor>& src_tensors,
                           const std::vector<torch::Tensor>& dst_tensors,
-                          Stream* stream) {
-    return copy_h2d(src_tensors, dst_tensors, stream);
-  }
+                          Stream* stream) = 0;
 
   virtual bool copy_d2h(const std::vector<torch::Tensor>& src_tensors,
                         const std::vector<torch::Tensor>& dst_tensors,

--- a/xllm/core/platform/layer_synchronizer.h
+++ b/xllm/core/platform/layer_synchronizer.h
@@ -27,6 +27,8 @@ class LayerSynchronizer {
   virtual ~LayerSynchronizer() = default;
 
   virtual bool synchronize_layer(int64_t layer_index) = 0;
+  // Reports record failure without aborting pending waits. The stream owner
+  // must first make any submitted work safe, then call abort().
   virtual bool record_stream(int64_t layer_index, Stream* stream) = 0;
   // Force every layer's wait to unblock and report failure. Called when a copy
   // fails so a forward thread spinning in synchronize_layer does not hang

--- a/xllm/core/platform/mlu/mlu_batch_memcpy.cpp
+++ b/xllm/core/platform/mlu/mlu_batch_memcpy.cpp
@@ -52,13 +52,31 @@ void MLUBatchMemcpy::init(int32_t device_id) {
 bool MLUBatchMemcpy::copy_h2d(const std::vector<torch::Tensor>& src_tensors,
                               const std::vector<torch::Tensor>& dst_tensors,
                               Stream* stream) {
-  return copy(src_tensors, dst_tensors, stream, Direction::H2D);
+  return copy(src_tensors,
+              dst_tensors,
+              stream,
+              Direction::H2D,
+              CompletionMode::SYNCHRONIZE);
+}
+
+bool MLUBatchMemcpy::submit_h2d(const std::vector<torch::Tensor>& src_tensors,
+                                const std::vector<torch::Tensor>& dst_tensors,
+                                Stream* stream) {
+  return copy(src_tensors,
+              dst_tensors,
+              stream,
+              Direction::H2D,
+              CompletionMode::SUBMIT_ONLY);
 }
 
 bool MLUBatchMemcpy::copy_d2h(const std::vector<torch::Tensor>& src_tensors,
                               const std::vector<torch::Tensor>& dst_tensors,
                               Stream* stream) {
-  return copy(src_tensors, dst_tensors, stream, Direction::D2H);
+  return copy(src_tensors,
+              dst_tensors,
+              stream,
+              Direction::D2H,
+              CompletionMode::SYNCHRONIZE);
 }
 
 bool MLUBatchMemcpy::valid_inputs(const std::vector<torch::Tensor>& src_tensors,
@@ -129,7 +147,8 @@ bool MLUBatchMemcpy::valid_inputs(const std::vector<torch::Tensor>& src_tensors,
 bool MLUBatchMemcpy::copy(const std::vector<torch::Tensor>& src_tensors,
                           const std::vector<torch::Tensor>& dst_tensors,
                           Stream* stream,
-                          Direction direction) {
+                          Direction direction,
+                          CompletionMode completion_mode) {
   try {
     if (!valid_inputs(src_tensors, dst_tensors, stream, direction)) {
       return false;
@@ -186,7 +205,6 @@ bool MLUBatchMemcpy::copy(const std::vector<torch::Tensor>& src_tensors,
       }
     }
 
-    const CNresult sync_result = cnQueueSync(queue);
     if (!submitted) {
       LOG(ERROR) << "MLU batch memcpy " << direction_name(h2d)
                  << " submission failed: chunk_offset=" << failed_offset
@@ -194,13 +212,18 @@ bool MLUBatchMemcpy::copy(const std::vector<torch::Tensor>& src_tensors,
                  << ", result=" << static_cast<int32_t>(submit_result)
                  << ", error=" << cn_error_text(submit_result);
     }
+    if (!submitted || completion_mode == CompletionMode::SUBMIT_ONLY) {
+      return submitted;
+    }
+
+    const CNresult sync_result = cnQueueSync(queue);
     if (sync_result != CN_SUCCESS) {
       LOG(ERROR) << "MLU batch memcpy " << direction_name(h2d)
                  << " queue sync failed: chunk_offset=0, chunk_count=" << count
                  << ", result=" << static_cast<int32_t>(sync_result)
                  << ", error=" << cn_error_text(sync_result);
     }
-    return submitted && sync_result == CN_SUCCESS;
+    return sync_result == CN_SUCCESS;
   } catch (const std::exception& error) {
     LOG(ERROR) << "MLU batch memcpy "
                << direction_name(direction == Direction::H2D)

--- a/xllm/core/platform/mlu/mlu_batch_memcpy.cpp
+++ b/xllm/core/platform/mlu/mlu_batch_memcpy.cpp
@@ -36,6 +36,24 @@ std::string cn_error_text(CNresult result) {
 
 const char* direction_name(bool h2d) { return h2d ? "H2D" : "D2H"; }
 
+void drain_queue_after_failure(CNqueue queue,
+                               const char* operation,
+                               size_t descriptor_count) {
+  const CNresult drain_result = cnQueueSync(queue);
+  LOG(ERROR) << "MLU batch memcpy " << operation
+             << " failure recovery queue sync: descriptor_count="
+             << descriptor_count
+             << ", result=" << static_cast<int32_t>(drain_result)
+             << ", error=" << cn_error_text(drain_result);
+  if (drain_result != CN_SUCCESS) {
+    LOG(FATAL) << "Failed to drain MLU batch memcpy queue after submission "
+                  "failure: operation="
+               << operation << ", descriptor_count=" << descriptor_count
+               << ", result=" << static_cast<int32_t>(drain_result)
+               << ", error=" << cn_error_text(drain_result);
+  }
+}
+
 }  // namespace
 
 void MLUBatchMemcpy::init(int32_t device_id) {
@@ -149,6 +167,9 @@ bool MLUBatchMemcpy::copy(const std::vector<torch::Tensor>& src_tensors,
                           Stream* stream,
                           Direction direction,
                           CompletionMode completion_mode) {
+  CNqueue queue = nullptr;
+  bool queue_has_submitted_work = false;
+  const bool h2d = direction == Direction::H2D;
   try {
     if (!valid_inputs(src_tensors, dst_tensors, stream, direction)) {
       return false;
@@ -181,39 +202,32 @@ bool MLUBatchMemcpy::copy(const std::vector<torch::Tensor>& src_tensors,
     size_t attr_index = 0;
     const c10::StreamGuard guard = stream->set_stream_guard();
     const cnrtQueue_t runtime_queue = stream->get_stream()->stream();
-    const CNqueue queue = reinterpret_cast<CNqueue>(runtime_queue);
-    const bool h2d = direction == Direction::H2D;
-    bool submitted = true;
-    size_t failed_offset = 0;
-    size_t failed_count = 0;
-    CNresult submit_result = CN_SUCCESS;
+    queue = reinterpret_cast<CNqueue>(runtime_queue);
     for (size_t offset = 0; offset < count; offset += kMaxBatchCopyCount) {
       const size_t chunk = std::min(kMaxBatchCopyCount, count - offset);
-      submit_result = cnMemcpyBatchAsync(dst_addrs.data() + offset,
-                                         src_addrs.data() + offset,
-                                         byte_counts.data() + offset,
-                                         chunk,
-                                         &attr,
-                                         &attr_index,
-                                         /*numAttrs=*/1,
-                                         queue);
+      const CNresult submit_result =
+          cnMemcpyBatchAsync(dst_addrs.data() + offset,
+                             src_addrs.data() + offset,
+                             byte_counts.data() + offset,
+                             chunk,
+                             &attr,
+                             &attr_index,
+                             /*numAttrs=*/1,
+                             queue);
       if (submit_result != CN_SUCCESS) {
-        submitted = false;
-        failed_offset = offset;
-        failed_count = chunk;
-        break;
+        LOG(ERROR) << "MLU batch memcpy " << direction_name(h2d)
+                   << " submission failed: chunk_offset=" << offset
+                   << ", chunk_count=" << chunk
+                   << ", result=" << static_cast<int32_t>(submit_result)
+                   << ", error=" << cn_error_text(submit_result);
+        drain_queue_after_failure(queue, direction_name(h2d), count);
+        return false;
       }
+      queue_has_submitted_work = true;
     }
 
-    if (!submitted) {
-      LOG(ERROR) << "MLU batch memcpy " << direction_name(h2d)
-                 << " submission failed: chunk_offset=" << failed_offset
-                 << ", chunk_count=" << failed_count
-                 << ", result=" << static_cast<int32_t>(submit_result)
-                 << ", error=" << cn_error_text(submit_result);
-    }
-    if (!submitted || completion_mode == CompletionMode::SUBMIT_ONLY) {
-      return submitted;
+    if (completion_mode == CompletionMode::SUBMIT_ONLY) {
+      return true;
     }
 
     const CNresult sync_result = cnQueueSync(queue);
@@ -225,13 +239,14 @@ bool MLUBatchMemcpy::copy(const std::vector<torch::Tensor>& src_tensors,
     }
     return sync_result == CN_SUCCESS;
   } catch (const std::exception& error) {
-    LOG(ERROR) << "MLU batch memcpy "
-               << direction_name(direction == Direction::H2D)
+    LOG(ERROR) << "MLU batch memcpy " << direction_name(h2d)
                << " raised an exception: " << error.what();
   } catch (...) {
-    LOG(ERROR) << "MLU batch memcpy "
-               << direction_name(direction == Direction::H2D)
+    LOG(ERROR) << "MLU batch memcpy " << direction_name(h2d)
                << " raised an unknown exception.";
+  }
+  if (queue_has_submitted_work) {
+    drain_queue_after_failure(queue, direction_name(h2d), src_tensors.size());
   }
   return false;
 }

--- a/xllm/core/platform/mlu/mlu_batch_memcpy.cpp
+++ b/xllm/core/platform/mlu/mlu_batch_memcpy.cpp
@@ -67,16 +67,6 @@ void MLUBatchMemcpy::init(int32_t device_id) {
   initialized_ = true;
 }
 
-bool MLUBatchMemcpy::copy_h2d(const std::vector<torch::Tensor>& src_tensors,
-                              const std::vector<torch::Tensor>& dst_tensors,
-                              Stream* stream) {
-  return copy(src_tensors,
-              dst_tensors,
-              stream,
-              Direction::H2D,
-              CompletionMode::SYNCHRONIZE);
-}
-
 bool MLUBatchMemcpy::submit_h2d(const std::vector<torch::Tensor>& src_tensors,
                                 const std::vector<torch::Tensor>& dst_tensors,
                                 Stream* stream) {

--- a/xllm/core/platform/mlu/mlu_batch_memcpy.h
+++ b/xllm/core/platform/mlu/mlu_batch_memcpy.h
@@ -37,19 +37,25 @@ class MLUBatchMemcpy final : public BatchMemcpy {
                 const std::vector<torch::Tensor>& dst_tensors,
                 Stream* stream) override;
 
+  bool submit_h2d(const std::vector<torch::Tensor>& src_tensors,
+                  const std::vector<torch::Tensor>& dst_tensors,
+                  Stream* stream) override;
+
   bool copy_d2h(const std::vector<torch::Tensor>& src_tensors,
                 const std::vector<torch::Tensor>& dst_tensors,
                 Stream* stream) override;
 
  private:
   enum class Direction : int8_t { H2D = 0, D2H = 1 };
+  enum class CompletionMode : int8_t { SYNCHRONIZE = 0, SUBMIT_ONLY = 1 };
 
   static constexpr size_t kMaxBatchCopyCount = 4096;
 
   bool copy(const std::vector<torch::Tensor>& src_tensors,
             const std::vector<torch::Tensor>& dst_tensors,
             Stream* stream,
-            Direction direction);
+            Direction direction,
+            CompletionMode completion_mode);
   bool valid_inputs(const std::vector<torch::Tensor>& src_tensors,
                     const std::vector<torch::Tensor>& dst_tensors,
                     const Stream* stream,

--- a/xllm/core/platform/mlu/mlu_batch_memcpy.h
+++ b/xllm/core/platform/mlu/mlu_batch_memcpy.h
@@ -33,10 +33,6 @@ class MLUBatchMemcpy final : public BatchMemcpy {
 
   void init(int32_t device_id) override;
 
-  bool copy_h2d(const std::vector<torch::Tensor>& src_tensors,
-                const std::vector<torch::Tensor>& dst_tensors,
-                Stream* stream) override;
-
   bool submit_h2d(const std::vector<torch::Tensor>& src_tensors,
                   const std::vector<torch::Tensor>& dst_tensors,
                   Stream* stream) override;

--- a/xllm/core/platform/mlu/mlu_layer_synchronizer.cpp
+++ b/xllm/core/platform/mlu/mlu_layer_synchronizer.cpp
@@ -115,13 +115,11 @@ bool MLULayerSynchronizerImpl::record_stream(int64_t layer_index,
                                              Stream* stream) {
   if (!valid_index(layer_index) || stream == nullptr ||
       aborted_.load(std::memory_order_acquire)) {
-    abort();
     return false;
   }
   StreamEventPtr event = stream->record_event();
   if (event == nullptr) {
     LOG(ERROR) << "Failed to record MLU copy event for range=" << layer_index;
-    abort();
     return false;
   }
   events_[layer_index] = std::move(event);
@@ -133,7 +131,9 @@ bool MLULayerSynchronizerImpl::record_current(int64_t layer_index,
                                               int32_t device_index) {
   try {
     Stream current_stream(torch_mlu::getCurrentMLUStream(device_index));
-    return record_stream(layer_index, &current_stream);
+    if (record_stream(layer_index, &current_stream)) {
+      return true;
+    }
   } catch (const std::exception& error) {
     LOG(ERROR) << "Failed to get current MLU stream: device=" << device_index
                << ", error=" << error.what();

--- a/xllm/core/platform/npu/npu_batch_memcpy.cpp
+++ b/xllm/core/platform/npu/npu_batch_memcpy.cpp
@@ -43,9 +43,9 @@ void NPUBatchMemcpy::init(int32_t device_id) {
   initialized_ = true;
 }
 
-bool NPUBatchMemcpy::copy_h2d(const std::vector<torch::Tensor>& src_tensors,
-                              const std::vector<torch::Tensor>& dst_tensors,
-                              Stream* stream) {
+bool NPUBatchMemcpy::submit_h2d(const std::vector<torch::Tensor>& src_tensors,
+                                const std::vector<torch::Tensor>& dst_tensors,
+                                Stream* stream) {
   return copy(src_tensors, dst_tensors, h2d_attr_, stream);
 }
 

--- a/xllm/core/platform/npu/npu_batch_memcpy.h
+++ b/xllm/core/platform/npu/npu_batch_memcpy.h
@@ -36,9 +36,9 @@ class NPUBatchMemcpy final : public BatchMemcpy {
 
   void init(int32_t device_id) override;
 
-  bool copy_h2d(const std::vector<torch::Tensor>& src_tensors,
-                const std::vector<torch::Tensor>& dst_tensors,
-                Stream* stream) override;
+  bool submit_h2d(const std::vector<torch::Tensor>& src_tensors,
+                  const std::vector<torch::Tensor>& dst_tensors,
+                  Stream* stream) override;
 
   bool copy_d2h(const std::vector<torch::Tensor>& src_tensors,
                 const std::vector<torch::Tensor>& dst_tensors,


### PR DESCRIPTION
  ### English

  This PR **does not make NPU Host KV Cache copies asynchronously submitted**.

  Although the common loading path now calls `submit_h2d()`, `NPUBatchMemcpy` does not override this
  method. It therefore uses the base-class fallback, which calls the existing `copy_h2d()` implementation.
  The NPU implementation still invokes `stream->synchronize()` before returning.

  Therefore:

  - NPU Host-to-Device KV Cache reloads remain synchronous;
  - NPU Device-to-Host offloads remain synchronous;
  - the new copy/compute overlap applies only to the MLU H2D reload path;
  - no NPU backend files or `third_party/torch_npu_ops` gitlinks are changed by this PR.

  Some platform-independent lifetime changes also apply to NPU:

  - offload completion callbacks now run through `InlineExecutor`;
  - `KVTransferTracker` waits for pending callbacks during block-manager destruction;
  - `HierarchyKVCacheTransfer` drains pooled copy streams during destruction.

  These shared changes may affect callback execution context, completion timing, and shutdown waiting
  behavior on NPU, but they do not change NPU DMA copy synchronization semantics.

  ## Change Type

  - [ ] Bug fix
  - [ ] New feature
  - [x] Performance improvement
  - [x] Refactor
  - [ ] Documentation
  - [x] Test
  - [ ] Build or CI

  ## Test Coverage / 测试覆盖

  Added or updated tests:

  - `MLUBatchMemcpyTest.SubmitH2DReturnsBeforeCopyStreamCompletes`
  - `KVTransferTrackerTest.WaitsForEveryTrackedTransfer`
  - `KVTransferTrackerTest.DestructionWaitsForTrackedTransfer`

  Validation status:

  - [x] Tests have been added or updated as needed.
  - [ ] `pre-commit run --all-files`
  - [x] MLU build
  - [x] MLU unit tests
  - [x] NPU build
  - [ ] NPU regression tests

  ## Reviewer Notes / 审查重点

  Please pay particular attention to:

  - queue draining when only part of a chunked MLU batch has been submitted successfully;
  - stream synchronization when H2D submission succeeds but event recording fails;
  - lifetime safety of Host/device blocks captured by asynchronous callbacks;
  - preservation of the synchronous fallback behavior for NPU.
