### PR TITLE
feat: enable dit cache for wan dual transformers.

### DIFF
--- a/xllm/core/framework/dit_cache/dit_cache.cpp
+++ b/xllm/core/framework/dit_cache/dit_cache.cpp
@@ -15,54 +15,91 @@ limitations under the License.
 
 #include "dit_cache.h"
 
+#include <glog/logging.h>
+
 namespace xllm {
 
 bool DiTCache::init(const DiTCacheConfig& cfg,
                     const ParallelArgs& parallel_args) {
-  active_cache_ = create_dit_cache(cfg);
-  active_cond_cache_ = create_dit_cache(cfg);
-  if (!active_cache_ || !active_cond_cache_) {
+  config_ = cfg;
+  parallel_args_ = &parallel_args;
+  active_scope_id_ = 0;
+  scopes_.clear();
+  return create_scope(active_scope_id_);
+}
+
+void DiTCache::set_context(const CacheContext& context) {
+  active_scope_id_ = context.scope_id;
+  CHECK(create_scope(active_scope_id_))
+      << "Failed to create DiT cache scope " << active_scope_id_;
+
+  CachePair& scope = active_scope();
+  scope.cache->set_context(context);
+  scope.cond_cache->set_context(context);
+}
+
+void DiTCache::reset_scope(int64_t scope_id) {
+  scopes_.erase(scope_id);
+  CHECK(create_scope(scope_id))
+      << "Failed to reset DiT cache scope " << scope_id;
+}
+
+bool DiTCache::create_scope(int64_t scope_id) {
+  auto [it, inserted] = scopes_.try_emplace(scope_id);
+  if (!inserted) {
+    return true;
+  }
+  CHECK(parallel_args_ != nullptr) << "DiT cache must be initialized first";
+
+  CachePair& scope = it->second;
+  scope.cache = create_dit_cache(config_);
+  scope.cond_cache = create_dit_cache(config_);
+  if (!scope.cache || !scope.cond_cache) {
+    scopes_.erase(it);
     return false;
   }
-  active_cache_->init(cfg, parallel_args);
-  active_cond_cache_->init(cfg, parallel_args);
+  scope.cache->init(config_, *parallel_args_);
+  scope.cond_cache->init(config_, *parallel_args_);
   return true;
 }
 
-torch::Tensor DiTCache::get_tensor_or_empty(const TensorMap& m,
-                                            const std::string& k) {
-  auto it = m.find(k);
-  if (it != m.end()) return it->second;
-  return torch::Tensor();
+DiTCache::CachePair& DiTCache::active_scope() {
+  auto it = scopes_.find(active_scope_id_);
+  CHECK(it != scopes_.end()) << "Active DiT cache scope is not initialized";
+  return it->second;
 }
 
 bool DiTCache::on_before_block(const CacheBlockIn& blockin, bool use_cfg) {
+  CachePair& scope = active_scope();
   if (use_cfg) {
-    return active_cond_cache_->on_before_block(blockin);
+    return scope.cond_cache->on_before_block(blockin);
   }
-  return active_cache_->on_before_block(blockin);
+  return scope.cache->on_before_block(blockin);
 }
 
 CacheBlockOut DiTCache::on_after_block(const CacheBlockIn& blockin,
                                        bool use_cfg) {
+  CachePair& scope = active_scope();
   if (use_cfg) {
-    return active_cond_cache_->on_after_block(blockin);
+    return scope.cond_cache->on_after_block(blockin);
   }
-  return active_cache_->on_after_block(blockin);
+  return scope.cache->on_after_block(blockin);
 }
 
 bool DiTCache::on_before_step(const CacheStepIn& stepin, bool use_cfg) {
+  CachePair& scope = active_scope();
   if (use_cfg) {
-    return active_cond_cache_->on_before_step(stepin);
+    return scope.cond_cache->on_before_step(stepin);
   }
-  return active_cache_->on_before_step(stepin);
+  return scope.cache->on_before_step(stepin);
 }
 
 CacheStepOut DiTCache::on_after_step(const CacheStepIn& stepin, bool use_cfg) {
+  CachePair& scope = active_scope();
   if (use_cfg) {
-    return active_cond_cache_->on_after_step(stepin);
+    return scope.cond_cache->on_after_step(stepin);
   }
-  return active_cache_->on_after_step(stepin);
+  return scope.cache->on_after_step(stepin);
 }
 
 }  // namespace xllm

--- a/xllm/core/framework/dit_cache/dit_cache.h
+++ b/xllm/core/framework/dit_cache/dit_cache.h
@@ -14,6 +14,11 @@ limitations under the License.
 ==============================================================================*/
 
 #pragma once
+
+#include <cstdint>
+#include <memory>
+#include <unordered_map>
+
 #include "dit_cache_impl.h"
 
 namespace xllm {
@@ -44,16 +49,22 @@ class DiTCache {
 
   CacheStepOut on_after_step(const CacheStepIn& stepin, bool use_cfg = false);
 
-  void set_context(const CacheContext& context) {
-    active_cache_->set_context(context);
-    active_cond_cache_->set_context(context);
-  }
+  void set_context(const CacheContext& context);
+  void reset_scope(int64_t scope_id);
 
  private:
-  torch::Tensor get_tensor_or_empty(const TensorMap& m, const std::string& k);
+  struct CachePair {
+    std::unique_ptr<DitCacheImpl> cache;
+    std::unique_ptr<DitCacheImpl> cond_cache;
+  };
 
-  std::unique_ptr<DitCacheImpl> active_cache_;
-  std::unique_ptr<DitCacheImpl> active_cond_cache_;
+  bool create_scope(int64_t scope_id);
+  CachePair& active_scope();
+
+  DiTCacheConfig config_;
+  const ParallelArgs* parallel_args_ = nullptr;
+  int64_t active_scope_id_ = 0;
+  std::unordered_map<int64_t, CachePair> scopes_;
 };
 
 }  // namespace xllm

--- a/xllm/core/framework/dit_cache/dit_cache_type.h
+++ b/xllm/core/framework/dit_cache/dit_cache_type.h
@@ -55,6 +55,7 @@ struct CacheBlockOut {
 struct CacheContext {
   int64_t infer_steps = 0;
   int64_t num_blocks = 0;
+  int64_t scope_id = 0;
 };
 
 }  // namespace xllm

--- a/xllm/models/dit/pipelines/pipeline_wan_i2v.h
+++ b/xllm/models/dit/pipelines/pipeline_wan_i2v.h
@@ -23,6 +23,7 @@ limitations under the License.
 #include "core/framework/config/dit_config.h"
 #include "core/framework/config/load_config.h"
 #include "core/framework/config/parallel_config.h"
+#include "core/framework/dit_cache/dit_cache.h"
 #include "core/framework/dit_model_loader.h"
 #include "core/framework/model_context.h"
 #include "core/framework/request/dit_request_state.h"
@@ -146,6 +147,7 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module,
                                generation_params.num_inference_steps,
                                generation_params.guidance_scale,
                                generation_params.guidance_scale_2,
+                               generation_params.boundary_ratio,
                                generation_params.num_videos_per_prompt,
                                seed,
                                latents,
@@ -413,6 +415,7 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module,
       int64_t num_inference_steps = 28,
       float guidance_scale = 5.0f,
       float guidance_scale_2 = -1.0f,
+      float boundary_ratio = 0.9f,
       int64_t num_videos_per_prompt = 1,
       int64_t seed = 42,
       std::optional<torch::Tensor> latents = std::nullopt,
@@ -449,7 +452,7 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module,
     // Call unified function for dimension adjustment
     AdjustVideoSize(images, height, width, dw, dh, false);
 
-    if (boundary_ratio_ > 0.0f && guidance_scale_2 < 0.0f) {
+    if (boundary_ratio > 0.0f && guidance_scale_2 < 0.0f) {
       guidance_scale_2 = guidance_scale;
     }
 
@@ -510,25 +513,57 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module,
                         latents);
 
     float boundary_timestep =
-        boundary_ratio_ > 0.0f ? boundary_ratio_ * num_train_timesteps_ : -1.0f;
+        boundary_ratio > 0.0f ? boundary_ratio * num_train_timesteps_ : -1.0f;
 
     // RainFusion config is static and already bound to the transformers in the
     // constructor. Only the per-inference dynamic state lives here.
     xllm::dit::SparseAttnState sparse_attn_state;
+    const bool use_rolling_load = use_rolling_load_;
+    int64_t primary_transformer_infer_steps = 0;
+    int64_t secondary_transformer_infer_steps = 0;
+    for (int64_t i = 0; i < timesteps.numel(); ++i) {
+      const float timestep_value = timesteps[i].item<float>();
+      const int64_t cache_scope_id =
+          boundary_timestep < 0 || timestep_value >= boundary_timestep ? 0 : 1;
+      if (cache_scope_id == 0) {
+        ++primary_transformer_infer_steps;
+      } else {
+        ++secondary_transformer_infer_steps;
+      }
+    }
+
+    int64_t primary_transformer_cache_step = 0;
+    int64_t secondary_transformer_cache_step = 0;
+    DiTCache::get_instance().reset_scope(/*scope_id=*/0);
+    DiTCache::get_instance().reset_scope(/*scope_id=*/1);
 
     for (int64_t i = 0; i < timesteps.numel(); ++i) {
       torch::Tensor t = timesteps[i];
 
       WanTransformer3DModel current_model = nullptr;
       float current_guidance;
+      const int64_t cache_scope_id =
+          boundary_timestep < 0 || t.item<float>() >= boundary_timestep ? 0 : 1;
+      const bool use_primary_transformer = cache_scope_id == 0;
 
-      if (boundary_timestep < 0 || t.item<float>() >= boundary_timestep) {
+      if (use_primary_transformer) {
         current_model = transformer_;
         current_guidance = guidance_scale;
       } else {
         current_model = transformer_2_;
         current_guidance = guidance_scale_2;
       }
+
+      const int64_t cache_infer_steps = use_primary_transformer
+                                            ? primary_transformer_infer_steps
+                                            : secondary_transformer_infer_steps;
+      const int64_t cache_step_id = use_primary_transformer
+                                        ? ++primary_transformer_cache_step
+                                        : ++secondary_transformer_cache_step;
+      DiTCache::get_instance().set_context(
+          {/*infer_steps=*/cache_infer_steps,
+           /*num_blocks=*/current_model->num_layers(),
+           /*scope_id=*/cache_scope_id});
 
       sparse_attn_state.current_step = i;
       torch::Tensor latent_model_input;
@@ -560,7 +595,7 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module,
       auto& rolling = (current_model.get() == transformer_.get())
                           ? rolling_transformer_
                           : rolling_transformer_2_;
-      auto rolling_forward = [&](const torch::Tensor& embeds) {
+      auto rolling_forward = [&](const torch::Tensor& embeds, bool use_cfg) {
         return current_model->forward(
             latent_model_input,
             timestep_input,
@@ -568,10 +603,13 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module,
             torch::Tensor(),
             sparse_attn_state,
             [&rolling](int32_t i) { rolling.wait_h2d(i); },
-            [&rolling](int32_t i) { rolling.schedule_next_h2d(i); });
+            [&rolling](int32_t i) { rolling.schedule_next_h2d(i); },
+            use_cfg,
+            cache_step_id);
       };
 #else
-      auto rolling_forward = [&](const torch::Tensor& /*embeds*/) {
+      auto rolling_forward = [&](const torch::Tensor& /*embeds*/,
+                                 bool /*use_cfg*/) {
         LOG(FATAL) << "Rolling load requires USE_NPU";
         return torch::Tensor{};
       };
@@ -581,12 +619,17 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module,
         auto [pos_noise, neg_noise] = exec_with_cfg([&](bool is_positive) {
           auto& embeds =
               is_positive ? encoded_prompt_embeds : encoded_negative_embeds;
-          return use_rolling_load_ ? rolling_forward(embeds)
-                                   : current_model->forward(latent_model_input,
-                                                            timestep_input,
-                                                            embeds,
-                                                            torch::Tensor(),
-                                                            sparse_attn_state);
+          const bool use_cfg = !is_positive;
+          return use_rolling_load ? rolling_forward(embeds, use_cfg)
+                                  : current_model->forward(latent_model_input,
+                                                           timestep_input,
+                                                           embeds,
+                                                           torch::Tensor(),
+                                                           sparse_attn_state,
+                                                           nullptr,
+                                                           nullptr,
+                                                           use_cfg,
+                                                           cache_step_id);
         });
 
         noise_pred =
@@ -594,13 +637,18 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module,
             static_cast<float>(current_guidance) *
                 (pos_noise.to(torch::kFloat32) - neg_noise.to(torch::kFloat32));
       } else {
-        noise_pred = use_rolling_load_
-                         ? rolling_forward(encoded_prompt_embeds)
+        noise_pred = use_rolling_load
+                         ? rolling_forward(encoded_prompt_embeds,
+                                           /*use_cfg=*/false)
                          : current_model->forward(latent_model_input,
                                                   timestep_input,
                                                   encoded_prompt_embeds,
                                                   torch::Tensor(),
-                                                  sparse_attn_state);
+                                                  sparse_attn_state,
+                                                  nullptr,
+                                                  nullptr,
+                                                  /*use_cfg=*/false,
+                                                  cache_step_id);
       }
       auto prev_latents = scheduler_->step(noise_pred, t, prepared_latents);
       prepared_latents = prev_latents.detach();
@@ -736,7 +784,6 @@ class WanImageToVideoPipelineImpl : public torch::nn::Module,
 
   int64_t vae_scale_factor_spatial_ = 8;
   int64_t vae_scale_factor_temporal_ = 4;
-  float boundary_ratio_ = 0.9f;
   bool expand_timesteps_ = false;
   int64_t zdim_ = 16;
   float num_train_timesteps_ = 1000.0f;

--- a/xllm/models/dit/transformers/transformer_wan.h
+++ b/xllm/models/dit/transformers/transformer_wan.h
@@ -30,6 +30,7 @@ limitations under the License.
 #include "core/framework/config/dit_config.h"
 #include "core/framework/config/load_config.h"
 #include "core/framework/config/parallel_config.h"
+#include "core/framework/dit_cache/dit_cache.h"
 #include "core/framework/dit_model_loader.h"
 #include "core/framework/model/model_input_params.h"
 #include "core/framework/state_dict/state_dict.h"
@@ -1547,13 +1548,17 @@ class WanTransformer3DModelImpl : public torch::nn::Module {
     }
   }
 
+  int64_t num_layers() const { return num_layers_; }
+
   torch::Tensor forward(const torch::Tensor& hidden_states_in,
                         const torch::Tensor& timestep,
                         const torch::Tensor& encoder_hidden_states,
                         const torch::Tensor& encoder_hidden_states_image,
                         xllm::dit::SparseAttnState& sparse_attn_state,
                         std::function<void(int32_t)> before_layer_cb = nullptr,
-                        std::function<void(int32_t)> after_layer_cb = nullptr) {
+                        std::function<void(int32_t)> after_layer_cb = nullptr,
+                        bool use_cfg = false,
+                        int64_t cache_step_id = 0) {
     int64_t batch_size = hidden_states_in.size(0);
     int64_t num_frames = hidden_states_in.size(2);
     int64_t height = hidden_states_in.size(3);
@@ -1625,20 +1630,55 @@ class WanTransformer3DModelImpl : public torch::nn::Module {
       }
     }
 
-    for (int64_t i = 0; i < transformer_layers_.size(); ++i) {
-      if (before_layer_cb) {
-        before_layer_cb(static_cast<int32_t>(i));
-      }
-      hidden_states =
-          transformer_layers_[i]->forward(hidden_states,
-                                          encoder_hidden_states_embedded,
-                                          timestep_proj,
-                                          rotary_emb,
-                                          sparse_attn_state);
-      if (after_layer_cb) {
-        after_layer_cb(static_cast<int32_t>(i));
+    if (cache_step_id <= 0) {
+      cache_step_id = sparse_attn_state.current_step + 1;
+    }
+    torch::Tensor original_hidden_states = hidden_states;
+    TensorMap step_in_map = {
+        {"hidden_states", hidden_states},
+        {"original_hidden_states", original_hidden_states}};
+    CacheStepIn step_before(cache_step_id, step_in_map);
+    const bool use_step_cache =
+        DiTCache::get_instance().on_before_step(step_before, use_cfg);
+
+    if (!use_step_cache) {
+      for (int64_t i = 0; i < transformer_layers_.size(); ++i) {
+        CacheBlockIn block_before(i);
+        const bool use_block_cache =
+            DiTCache::get_instance().on_before_block(block_before, use_cfg);
+        if (before_layer_cb) {
+          before_layer_cb(static_cast<int32_t>(i));
+        }
+        if (!use_block_cache) {
+          hidden_states =
+              transformer_layers_[i]->forward(hidden_states,
+                                              encoder_hidden_states_embedded,
+                                              timestep_proj,
+                                              rotary_emb,
+                                              sparse_attn_state);
+        }
+        if (after_layer_cb) {
+          after_layer_cb(static_cast<int32_t>(i));
+        }
+
+        TensorMap block_after_map = {
+            {"hidden_states", hidden_states},
+            {"encoder_hidden_states", encoder_hidden_states_embedded},
+            {"original_hidden_states", original_hidden_states}};
+        CacheBlockIn block_after(i, block_after_map);
+        CacheBlockOut block_out =
+            DiTCache::get_instance().on_after_block(block_after, use_cfg);
+        hidden_states = block_out.tensors.at("hidden_states");
       }
     }
+
+    TensorMap step_after_map = {
+        {"hidden_states", hidden_states},
+        {"original_hidden_states", original_hidden_states}};
+    CacheStepIn step_after(cache_step_id, step_after_map);
+    CacheStepOut step_out =
+        DiTCache::get_instance().on_after_step(step_after, use_cfg);
+    hidden_states = step_out.tensors.at("hidden_states");
 
     if (::xllm::ParallelConfig::get_instance().sp_size() > 1) {
       hidden_states =


### PR DESCRIPTION
## Description

This PR adds DiTCache support for the Wan2.2 dual-transformer pipeline.

The implementation:
- isolates cache state for `transformer` and `transformer_2` with separate scopes;
- maintains independent local cache step IDs for both transformers;
- separates normal and CFG cache states;
- passes the request-level `boundary_ratio` to transformer selection and cache-step accounting;
- integrates DiTCache step/block callbacks with rolling load;
- keeps rolling H2D scheduling consistent when cache skips individual blocks;
- preserves the existing behavior for non-cache and non-rolling-load paths.

These changes are required because Wan2.2 switches between two transformers during denoising. Sharing one cache state or using the global denoising step would cause cache state, warmup, and residual scheduling to become inconsistent between the two transformers.

## Related Issues

N/A

## Change Type

- [ ] Bug fix
- [x] New feature
- [x] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

Suggested title:

```text
feat: add dit cache support for wan dual transformers.