### PR TITLE
bugfix: fix A5 TileLang and mRoPE support.

### DIFF
--- a/xllm/compiler/tilelang/targets/ascend/kernels/spec_verify_attention_tiling_update.py
+++ b/xllm/compiler/tilelang/targets/ascend/kernels/spec_verify_attention_tiling_update.py
@@ -55,7 +55,7 @@ class SpecVerifyAttentionTilingUpdateKernel(TilelangKernel):
     ]
     SPECIALIZATIONS = [
         {
-            "variant_key": f"w{spec_width}",
+            "variant_key": f"attn_tiling_w{spec_width}",
             "spec_width": spec_width,
         }
         for spec_width in SUPPORTED_SPEC_VERIFY_WIDTHS

--- a/xllm/compiler/tilelang/targets/ascend/kernels/spec_verify_token_update.py
+++ b/xllm/compiler/tilelang/targets/ascend/kernels/spec_verify_token_update.py
@@ -91,7 +91,7 @@ def build_spec_verify_token_update_kernel(spec_width: int):
 class SpecVerifyTokenUpdateKernel(TilelangKernel):
     DISPATCH_SCHEMA = [DispatchField("spec_width", "int32")]
     SPECIALIZATIONS = [
-        {"variant_key": f"w{spec_width}", "spec_width": spec_width}
+        {"variant_key": f"token_w{spec_width}", "spec_width": spec_width}
         for spec_width in SUPPORTED_SPEC_VERIFY_WIDTHS
     ]
 

--- a/xllm/compiler/tilelang/targets/ascend/kernels/split_qkv_rmsnorm_mrope.py
+++ b/xllm/compiler/tilelang/targets/ascend/kernels/split_qkv_rmsnorm_mrope.py
@@ -380,7 +380,6 @@ def build_split_qkv_rmsnorm_mrope_kernel(
 
                 # Init: load gather pattern, weights.
                 T.copy(gather_pattern, gather_offset_ub)
-                T.tile.fill(axes_ub, 0.0)
                 T.copy(q_weight[0, 0], q_weight_half_ub[0, :])
                 T.copy(k_weight[0, 0], k_weight_half_ub[0, :])
                 mte2_notify_v(E.INIT_WEIGHTS)

--- a/xllm/compiler/tilelang/targets/ascend/toolchain.py
+++ b/xllm/compiler/tilelang/targets/ascend/toolchain.py
@@ -138,6 +138,7 @@ def bisheng_include_dirs() -> list[str]:
         f"{npu_home_path}/include",
         f"{npu_home_path}/include/experiment/runtime",
         f"{npu_home_path}/include/experiment/msprof",
+        f"{npu_home_path}/pkg_inc",
         f"{npu_home_path}/compiler/tikcpp",
         f"{npu_home_path}/compiler/tikcpp/tikcfw",
         f"{npu_home_path}/compiler/tikcpp/tikcfw/impl",


### PR DESCRIPTION
## Description

Restore the A5 TileLang and mRoPE fixes from the reverted PR while keeping the change set limited to the required Ascend build and dispatch updates.

- Restore the A5 TileLang toolchain include path for `pkg_inc`.
- Use distinct dispatch variant keys for spec-verify token and attention-tiling kernels.
- Remove the stale `axes_ub` fill from the split QKV RMSNorm mRoPE kernel initialization.
- Update `third_party/torch_npu_ops` to commit `b5a2d50511df72ab1465745aa551c6db68405362`.

## Related Issues

Replaces the reverted changes from #2171.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [x] Test
- [ ] Build or CI

## Pull Request Checklist

### PR Title and Commit Messages

- [x] The PR title and commit message follow the xLLM commit format: `bugfix: <subject>.`

### Pre-commit Checks

- [x] `pre-commit run --all-files` has been run.

### Self Review

- [x] I have self-reviewed the change.
- [x] The branch is based on the latest `main`.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

- The PR  is ready for review.
- Full build/test validation run in the environments.
<img width="551" height="115" alt="image" src="https://github.com/user-attachments/assets/54ea0758-4f96-49a7-b3a1-58eec3ce0ca5" />
<img width="559" height="377" alt="image" src="https://github.com/user-attachments/assets/6701f192-7d91-499b-b001-1ccedc5b8510" />
