### PR TITLE
feat: adaptive speculative decoding for DFlash and DSpark on NPU.

### DIFF
--- a/tests/core/runtime/CMakeLists.txt
+++ b/tests/core/runtime/CMakeLists.txt
@@ -25,6 +25,32 @@ if(USE_NPU)
 
   cc_test(
     NAME
+      dspark_confidence_head_test
+    SRCS
+      dspark_confidence_head_test.cpp
+    DEPS
+      :models
+      :state_dict
+      :xllm_ops
+      glog::glog
+      torch
+      GTest::gtest_main
+  )
+  target_link_libraries(dspark_confidence_head_test
+                        PRIVATE
+                        torch_npu
+                        ascendcl
+                        hccl
+                        c_sec
+                        nnopbase
+                        atb)
+  target_link_options(dspark_confidence_head_test PRIVATE
+    "-Wl,--whole-archive"
+    "${CMAKE_BINARY_DIR}/third_party/spdlog/libspdlog.a"
+    "-Wl,--no-whole-archive")
+
+  cc_test(
+    NAME
       acl_graph_executor_test
     SRCS
       acl_graph_executor_test.cpp

--- a/tests/core/runtime/dspark_confidence_head_test.cpp
+++ b/tests/core/runtime/dspark_confidence_head_test.cpp
@@ -133,10 +133,10 @@ TEST(DSparkConfidenceHeadParity, NoMarkov_Gamma16) {
   check_parity(/*with_markov=*/false, /*batch=*/3, /*gamma=*/16);
 }
 
-// forward and forward_batched read the SAME cached confidence_temperature(), so
-// whatever value the process froze at, both paths scale identically — parity
-// holds under any temperature. This case just exercises a non-default T env.
-TEST(DSparkConfidenceHeadParity, WithMarkov_TemperatureEnv) {
+// forward and forward_batched apply the same fixed confidence_temperature(), so
+// both paths scale identically and parity holds. An extra batch/gamma shape for
+// coverage beyond the cases above.
+TEST(DSparkConfidenceHeadParity, WithMarkov_Batch6Gamma8) {
   check_parity(/*with_markov=*/true, /*batch=*/6, /*gamma=*/8);
 }
 

--- a/tests/core/runtime/dspark_confidence_head_test.cpp
+++ b/tests/core/runtime/dspark_confidence_head_test.cpp
@@ -1,0 +1,143 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Numerical parity between DSparkConfidenceHead::forward_batched (O11) and the
+// original per-step forward it replaced. The batched path hoists the whole
+// gamma-step ConfidenceHead out of the sample loop; it must produce bit-close
+// results to gamma independent per-step calls, otherwise adaptive pruning would
+// silently change behavior.
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "framework/state_dict/state_dict.h"
+#include "models/llm/npu/qwen3_dspark.h"
+
+namespace xllm::npu::model {
+namespace {
+
+constexpr int64_t kHidden = 64;
+constexpr int64_t kMarkovRank = 16;
+constexpr int64_t kVocab = 128;
+
+torch::TensorOptions f32_cpu() {
+  return torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCPU);
+}
+
+// Build a ConfidenceHead with random weights via its public load_state_dict.
+DSparkConfidenceHead make_confidence_head(bool with_markov, int64_t seed) {
+  torch::manual_seed(seed);
+  DSparkConfidenceHead head;
+  head.initialize(f32_cpu(), kHidden, kMarkovRank, with_markov);
+  const int64_t in_dim = with_markov ? kHidden + kMarkovRank : kHidden;
+  std::unordered_map<std::string, torch::Tensor> w;
+  w["confidence_head.proj.weight"] = torch::randn({1, in_dim}, f32_cpu());
+  w["confidence_head.proj.bias"] = torch::randn({1}, f32_cpu());
+  StateDict sd(std::move(w));
+  head.load_state_dict(sd);
+  return head;
+}
+
+DSparkMarkovHead make_markov_head(int64_t seed) {
+  torch::manual_seed(seed + 999);
+  DSparkMarkovHead head;
+  head.initialize(f32_cpu(), kMarkovRank);
+  std::unordered_map<std::string, torch::Tensor> w;
+  // markov_w1: [vocab, rank]; markov_w2: [draft_vocab, rank]. Only markov_w1 is
+  // exercised by confidence (markov_embed); w2 just needs to satisfy load.
+  w["markov_head.markov_w1.weight"] =
+      torch::randn({kVocab, kMarkovRank}, f32_cpu());
+  w["markov_head.markov_w2.weight"] =
+      torch::randn({kVocab, kMarkovRank}, f32_cpu());
+  StateDict sd(std::move(w));
+  head.load_state_dict(sd);
+  return head;
+}
+
+// Reference: gamma independent per-step forward() calls, stacked to [B, gamma].
+torch::Tensor per_step_reference(const DSparkConfidenceHead& head,
+                                 const DSparkMarkovHead& markov,
+                                 const torch::Tensor& hidden_all,   // [B, g, H]
+                                 const torch::Tensor& prev_matrix,  // [B, g]
+                                 bool with_markov) {
+  const int64_t gamma = hidden_all.size(1);
+  std::vector<torch::Tensor> cols;
+  cols.reserve(gamma);
+  for (int64_t k = 0; k < gamma; ++k) {
+    torch::Tensor step_hidden = hidden_all.select(/*dim=*/1, k);  // [B, H]
+    torch::Tensor prev_k = prev_matrix.select(/*dim=*/1, k);      // [B]
+    torch::Tensor embed =
+        with_markov ? markov.markov_embed(prev_k) : torch::Tensor();
+    cols.push_back(head.forward(step_hidden, embed));  // [B]
+  }
+  return torch::stack(cols, /*dim=*/1);  // [B, gamma]
+}
+
+void check_parity(bool with_markov, int64_t batch, int64_t gamma) {
+  DSparkConfidenceHead head = make_confidence_head(with_markov, /*seed=*/7);
+  DSparkMarkovHead markov = make_markov_head(/*seed=*/7);
+
+  torch::manual_seed(1234);
+  torch::Tensor hidden_all = torch::randn({batch, gamma, kHidden}, f32_cpu());
+  torch::Tensor prev_matrix = torch::randint(
+      0, kVocab, {batch, gamma}, torch::TensorOptions().dtype(torch::kLong));
+
+  torch::Tensor ref =
+      per_step_reference(head, markov, hidden_all, prev_matrix, with_markov);
+
+  torch::Tensor markov_embed_all =
+      with_markov ? markov.markov_embed(prev_matrix) : torch::Tensor();
+  torch::Tensor batched = head.forward_batched(hidden_all, markov_embed_all);
+
+  ASSERT_EQ(batched.sizes(), ref.sizes());
+  double max_abs = (batched - ref).abs().max().item<double>();
+  EXPECT_LT(max_abs, 1e-5) << "with_markov=" << with_markov
+                           << " batch=" << batch << " gamma=" << gamma
+                           << " max_abs=" << max_abs;
+}
+
+}  // namespace
+
+TEST(DSparkConfidenceHeadParity, WithMarkov_Gamma7) {
+  check_parity(/*with_markov=*/true, /*batch=*/5, /*gamma=*/7);
+}
+
+TEST(DSparkConfidenceHeadParity, WithMarkov_Gamma16) {
+  check_parity(/*with_markov=*/true, /*batch=*/3, /*gamma=*/16);
+}
+
+TEST(DSparkConfidenceHeadParity, WithMarkov_Gamma1) {
+  check_parity(/*with_markov=*/true, /*batch=*/4, /*gamma=*/1);
+}
+
+TEST(DSparkConfidenceHeadParity, NoMarkov_Gamma16) {
+  check_parity(/*with_markov=*/false, /*batch=*/3, /*gamma=*/16);
+}
+
+// forward and forward_batched read the SAME cached confidence_temperature(), so
+// whatever value the process froze at, both paths scale identically — parity
+// holds under any temperature. This case just exercises a non-default T env.
+TEST(DSparkConfidenceHeadParity, WithMarkov_TemperatureEnv) {
+  check_parity(/*with_markov=*/true, /*batch=*/6, /*gamma=*/8);
+}
+
+}  // namespace xllm::npu::model

--- a/xllm/core/distributed_runtime/worker_service.cpp
+++ b/xllm/core/distributed_runtime/worker_service.cpp
@@ -78,6 +78,16 @@ void record_speculative_metrics_from_output(const torch::Tensor& next_tokens,
       next_tokens.dim() != 2 || next_tokens.numel() == 0) {
     return;
   }
+  // DFlash / DSpark record metrics inline in their own worker
+  // (DFlashWorkerImpl::record_validate_metrics) with precise per-seq
+  // widths, so this generic per-tensor count would double-count them.
+  std::string algo = options.speculative_algorithm();
+  std::transform(algo.begin(), algo.end(), algo.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
+  if (algo == "dflash" || algo == "dspark") {
+    return;
+  }
 
   const int64_t batch_size = next_tokens.size(0);
   const int64_t token_width = next_tokens.size(1);

--- a/xllm/core/distributed_runtime/worker_service.cpp
+++ b/xllm/core/distributed_runtime/worker_service.cpp
@@ -72,6 +72,42 @@ int64_t count_negative_tokens(const torch::Tensor& tokens) {
   return count;
 }
 
+// Count attempted draft slots for a [batch, width] next_tokens buffer.
+// Under adaptive per-seq varlen pruning some columns are padded to -1 (see
+// apply_pruned_prefix_lengths). Both padded and truly-rejected drafts show as
+// -1, so we cannot tell them apart per element; but per row the padded region
+// is always a contiguous tail (positions beyond per_seq_val_tokens[i]-1).
+// Draft-attempted slots = per-row scan up to the last non-negative token.
+// Bonus column (final slot) is unconditionally attempted for accepted paths
+// but is only present when the row still has anything else non-negative; if
+// the whole row is -1, count zero drafts.
+template <typename T>
+int64_t count_attempted_draft_slots(const torch::Tensor& tokens) {
+  const int64_t batch_size = tokens.size(0);
+  const int64_t width = tokens.size(1);
+  if (width < 2) {
+    return 0;
+  }
+  const T* data = tokens.const_data_ptr<T>();
+  int64_t attempted = 0;
+  for (int64_t b = 0; b < batch_size; ++b) {
+    int64_t last_non_neg = -1;
+    const T* row = data + b * width;
+    for (int64_t j = 0; j < width; ++j) {
+      if (row[j] >= static_cast<T>(0)) {
+        last_non_neg = j;
+      }
+    }
+    // last_non_neg is the highest index in the row that was actually filled;
+    // everything before it (inclusive) was attempted, everything after is
+    // padding for a seq the controller pruned narrower.
+    if (last_non_neg >= 1) {
+      attempted += last_non_neg;  // exclude bonus column at position last
+    }
+  }
+  return attempted;
+}
+
 void record_speculative_metrics_from_output(const torch::Tensor& next_tokens,
                                             const runtime::Options& options) {
   if (!options.enable_speculative_decode() || !next_tokens.defined() ||
@@ -96,18 +132,23 @@ void record_speculative_metrics_from_output(const torch::Tensor& next_tokens,
 
   torch::Tensor tokens = next_tokens.contiguous();
   int64_t rejected_count = 0;
+  int64_t attempted_slots = 0;
   switch (tokens.scalar_type()) {
     case torch::kInt64:
       rejected_count = count_negative_tokens<int64_t>(tokens);
+      attempted_slots = count_attempted_draft_slots<int64_t>(tokens);
       break;
     case torch::kInt32:
       rejected_count = count_negative_tokens<int32_t>(tokens);
+      attempted_slots = count_attempted_draft_slots<int32_t>(tokens);
       break;
     case torch::kInt16:
       rejected_count = count_negative_tokens<int16_t>(tokens);
+      attempted_slots = count_attempted_draft_slots<int16_t>(tokens);
       break;
     case torch::kInt8:
       rejected_count = count_negative_tokens<int8_t>(tokens);
+      attempted_slots = count_attempted_draft_slots<int8_t>(tokens);
       break;
     default:
       LOG(WARNING) << "Unsupported speculative next_tokens dtype for metrics: "
@@ -115,7 +156,15 @@ void record_speculative_metrics_from_output(const torch::Tensor& next_tokens,
       return;
   }
 
-  const int64_t num_draft_tokens = batch_size * effective_speculative_tokens;
+  // Under adaptive per-seq varlen pruning, some rows carry a padded tail (-1
+  // at positions past per_seq_val_tokens[i]-1). `attempted_slots` counts only
+  // slots that were actually validated per row; `rejected_count` still counts
+  // all -1s. The difference is exactly the padding, which we subtract off so
+  // acceptance-rate metrics reflect actual work.
+  const int64_t max_slots = batch_size * effective_speculative_tokens;
+  const int64_t num_draft_tokens = std::min(attempted_slots, max_slots);
+  const int64_t padding = max_slots - num_draft_tokens;
+  rejected_count = std::max<int64_t>(0, rejected_count - padding);
   rejected_count = std::min(rejected_count, num_draft_tokens);
   COUNTER_ADD(speculative_num_draft_tokens_total, num_draft_tokens);
   COUNTER_ADD(speculative_num_accepted_tokens_total,

--- a/xllm/core/distributed_runtime/worker_service.cpp
+++ b/xllm/core/distributed_runtime/worker_service.cpp
@@ -72,42 +72,6 @@ int64_t count_negative_tokens(const torch::Tensor& tokens) {
   return count;
 }
 
-// Count attempted draft slots for a [batch, width] next_tokens buffer.
-// Under adaptive per-seq varlen pruning some columns are padded to -1 (see
-// apply_pruned_prefix_lengths). Both padded and truly-rejected drafts show as
-// -1, so we cannot tell them apart per element; but per row the padded region
-// is always a contiguous tail (positions beyond per_seq_val_tokens[i]-1).
-// Draft-attempted slots = per-row scan up to the last non-negative token.
-// Bonus column (final slot) is unconditionally attempted for accepted paths
-// but is only present when the row still has anything else non-negative; if
-// the whole row is -1, count zero drafts.
-template <typename T>
-int64_t count_attempted_draft_slots(const torch::Tensor& tokens) {
-  const int64_t batch_size = tokens.size(0);
-  const int64_t width = tokens.size(1);
-  if (width < 2) {
-    return 0;
-  }
-  const T* data = tokens.const_data_ptr<T>();
-  int64_t attempted = 0;
-  for (int64_t b = 0; b < batch_size; ++b) {
-    int64_t last_non_neg = -1;
-    const T* row = data + b * width;
-    for (int64_t j = 0; j < width; ++j) {
-      if (row[j] >= static_cast<T>(0)) {
-        last_non_neg = j;
-      }
-    }
-    // last_non_neg is the highest index in the row that was actually filled;
-    // everything before it (inclusive) was attempted, everything after is
-    // padding for a seq the controller pruned narrower.
-    if (last_non_neg >= 1) {
-      attempted += last_non_neg;  // exclude bonus column at position last
-    }
-  }
-  return attempted;
-}
-
 void record_speculative_metrics_from_output(const torch::Tensor& next_tokens,
                                             const runtime::Options& options) {
   if (!options.enable_speculative_decode() || !next_tokens.defined() ||
@@ -132,23 +96,18 @@ void record_speculative_metrics_from_output(const torch::Tensor& next_tokens,
 
   torch::Tensor tokens = next_tokens.contiguous();
   int64_t rejected_count = 0;
-  int64_t attempted_slots = 0;
   switch (tokens.scalar_type()) {
     case torch::kInt64:
       rejected_count = count_negative_tokens<int64_t>(tokens);
-      attempted_slots = count_attempted_draft_slots<int64_t>(tokens);
       break;
     case torch::kInt32:
       rejected_count = count_negative_tokens<int32_t>(tokens);
-      attempted_slots = count_attempted_draft_slots<int32_t>(tokens);
       break;
     case torch::kInt16:
       rejected_count = count_negative_tokens<int16_t>(tokens);
-      attempted_slots = count_attempted_draft_slots<int16_t>(tokens);
       break;
     case torch::kInt8:
       rejected_count = count_negative_tokens<int8_t>(tokens);
-      attempted_slots = count_attempted_draft_slots<int8_t>(tokens);
       break;
     default:
       LOG(WARNING) << "Unsupported speculative next_tokens dtype for metrics: "
@@ -156,15 +115,7 @@ void record_speculative_metrics_from_output(const torch::Tensor& next_tokens,
       return;
   }
 
-  // Under adaptive per-seq varlen pruning, some rows carry a padded tail (-1
-  // at positions past per_seq_val_tokens[i]-1). `attempted_slots` counts only
-  // slots that were actually validated per row; `rejected_count` still counts
-  // all -1s. The difference is exactly the padding, which we subtract off so
-  // acceptance-rate metrics reflect actual work.
-  const int64_t max_slots = batch_size * effective_speculative_tokens;
-  const int64_t num_draft_tokens = std::min(attempted_slots, max_slots);
-  const int64_t padding = max_slots - num_draft_tokens;
-  rejected_count = std::max<int64_t>(0, rejected_count - padding);
+  const int64_t num_draft_tokens = batch_size * effective_speculative_tokens;
   rejected_count = std::min(rejected_count, num_draft_tokens);
   COUNTER_ADD(speculative_num_draft_tokens_total, num_draft_tokens);
   COUNTER_ADD(speculative_num_accepted_tokens_total,

--- a/xllm/core/distributed_runtime/worker_service.cpp
+++ b/xllm/core/distributed_runtime/worker_service.cpp
@@ -82,10 +82,17 @@ void record_speculative_metrics_from_output(const torch::Tensor& next_tokens,
   const int64_t batch_size = next_tokens.size(0);
   const int64_t token_width = next_tokens.size(1);
   const int64_t num_speculative_tokens = options.num_speculative_tokens();
-  if (num_speculative_tokens <= 0 ||
-      token_width != num_speculative_tokens + 1) {
+  if (num_speculative_tokens <= 0 || token_width < 2) {
     return;
   }
+  // For MTP the check was strict `token_width == num_speculative_tokens + 1`;
+  // DFlash / DSpark adaptive pruning may hand back a narrower validate block
+  // (effective_val_tokens < N+1), so accept any width in [2, N+1] and derive
+  // the actual draft count from `token_width - 1`.
+  if (token_width > num_speculative_tokens + 1) {
+    return;
+  }
+  const int64_t effective_speculative_tokens = token_width - 1;
 
   torch::Tensor tokens = next_tokens.contiguous();
   int64_t rejected_count = 0;
@@ -108,7 +115,7 @@ void record_speculative_metrics_from_output(const torch::Tensor& next_tokens,
       return;
   }
 
-  const int64_t num_draft_tokens = batch_size * num_speculative_tokens;
+  const int64_t num_draft_tokens = batch_size * effective_speculative_tokens;
   rejected_count = std::min(rejected_count, num_draft_tokens);
   COUNTER_ADD(speculative_num_draft_tokens_total, num_draft_tokens);
   COUNTER_ADD(speculative_num_accepted_tokens_total,

--- a/xllm/core/distributed_runtime/worker_service.cpp
+++ b/xllm/core/distributed_runtime/worker_service.cpp
@@ -29,6 +29,7 @@ limitations under the License.
 #include "common/types.h"
 #include "core/distributed_runtime/comm_channel.h"
 #include "core/framework/config/eplb_config.h"
+#include "core/framework/config/speculative_config.h"
 #include "framework/kv_cache/kv_cache_shape.h"
 #include "framework/model/model_input_params.h"
 #include "framework/request/sequence.h"
@@ -81,11 +82,8 @@ void record_speculative_metrics_from_output(const torch::Tensor& next_tokens,
   // DFlash / DSpark record metrics inline in their own worker
   // (DFlashWorkerImpl::record_validate_metrics) with precise per-seq
   // widths, so this generic per-tensor count would double-count them.
-  std::string algo = options.speculative_algorithm();
-  std::transform(algo.begin(), algo.end(), algo.begin(), [](unsigned char c) {
-    return static_cast<char>(std::tolower(c));
-  });
-  if (algo == "dflash" || algo == "dspark") {
+  if (SpeculativeConfig::is_block_diffusion_algorithm(
+          options.speculative_algorithm())) {
     return;
   }
 

--- a/xllm/core/framework/config/speculative_config.h
+++ b/xllm/core/framework/config/speculative_config.h
@@ -54,6 +54,15 @@ class SpeculativeConfig final {
            (algorithm[2] == 'P' || algorithm[2] == 'p');
   }
 
+  // True for the block-diffusion draft algorithms (DFlash, DSpark) that record
+  // validate metrics inline per-seq and drive the adaptive per-seq varlen
+  // prune. Case-insensitive so it matches however the flag was cased. MTP is
+  // classified separately via is_mtp_algorithm; callers that also accept MTP
+  // must OR the two.
+  static bool is_block_diffusion_algorithm(std::string_view algorithm) {
+    return iequals(algorithm, "dflash") || iequals(algorithm, "dspark");
+  }
+
   void from_flags();
   void from_json(const JsonReader& json);
   void append_config_json(nlohmann::ordered_json& config_json) const;
@@ -106,6 +115,29 @@ class SpeculativeConfig final {
   PROPERTY(bool, enable_adaptive_speculative_decode) = false;
 
   PROPERTY(double, adaptive_speculative_min_gain) = 0.0;
+
+ private:
+  // ASCII case-insensitive equality. Mirrors the manual case handling in
+  // is_mtp_algorithm rather than pulling <algorithm>/<cctype> into this header.
+  static bool iequals(std::string_view a, std::string_view b) {
+    if (a.size() != b.size()) {
+      return false;
+    }
+    for (size_t i = 0; i < a.size(); ++i) {
+      char ca = a[i];
+      char cb = b[i];
+      if (ca >= 'A' && ca <= 'Z') {
+        ca = static_cast<char>(ca - 'A' + 'a');
+      }
+      if (cb >= 'A' && cb <= 'Z') {
+        cb = static_cast<char>(cb - 'A' + 'a');
+      }
+      if (ca != cb) {
+        return false;
+      }
+    }
+    return true;
+  }
 };
 
 }  // namespace xllm

--- a/xllm/core/framework/model/causal_lm.h
+++ b/xllm/core/framework/model/causal_lm.h
@@ -201,6 +201,13 @@ class CausalLM : public torch::nn::Module {
       const torch::Tensor& previous_token_ids) {
     return {};
   }
+  // Batched over the whole draft block: hidden [num_reqs, num_spec, H],
+  // prev_matrix [num_reqs, num_spec]; returns [num_reqs, num_spec] fp32.
+  virtual torch::Tensor dspark_confidence_probs_batched(
+      const torch::Tensor& hidden_all,
+      const torch::Tensor& prev_matrix) {
+    return {};
+  }
   virtual bool has_dspark_confidence_head() const { return false; }
 
   virtual void lazy_load_model(std::unique_ptr<ModelLoader> loader) {
@@ -327,6 +334,15 @@ class CausalLMImpl : public CausalLM {
       return model_->dspark_confidence_probs(hidden, previous_token_ids);
     }
     return CausalLM::dspark_confidence_probs(hidden, previous_token_ids);
+  }
+
+  torch::Tensor dspark_confidence_probs_batched(
+      const torch::Tensor& hidden_all,
+      const torch::Tensor& prev_matrix) override {
+    if constexpr (detail::has_dspark_confidence_probs_batched<Model>::value) {
+      return model_->dspark_confidence_probs_batched(hidden_all, prev_matrix);
+    }
+    return CausalLM::dspark_confidence_probs_batched(hidden_all, prev_matrix);
   }
 
   bool has_dspark_confidence_head() const override {

--- a/xllm/core/framework/model/causal_lm.h
+++ b/xllm/core/framework/model/causal_lm.h
@@ -192,6 +192,17 @@ class CausalLM : public torch::nn::Module {
     return {};
   }
 
+  // DSpark ConfidenceHead: acceptance-prob estimate for adaptive-speculative
+  // pruning. Returns [num_reqs] fp32 in [0, 1]. When the confidence head is
+  // absent (not built or feature disabled), returns an undefined tensor; the
+  // worker falls back to the sampler-gathered draft prob.
+  virtual torch::Tensor dspark_confidence_probs(
+      const torch::Tensor& hidden,
+      const torch::Tensor& previous_token_ids) {
+    return {};
+  }
+  virtual bool has_dspark_confidence_head() const { return false; }
+
   virtual void lazy_load_model(std::unique_ptr<ModelLoader> loader) {
     NOT_IMPLEMENTED();
   }
@@ -307,6 +318,22 @@ class CausalLMImpl : public CausalLM {
       return model_->dspark_markov_bias(previous_token_ids);
     }
     return CausalLM::dspark_markov_bias(previous_token_ids);
+  }
+
+  torch::Tensor dspark_confidence_probs(
+      const torch::Tensor& hidden,
+      const torch::Tensor& previous_token_ids) override {
+    if constexpr (detail::has_dspark_confidence_probs<Model>::value) {
+      return model_->dspark_confidence_probs(hidden, previous_token_ids);
+    }
+    return CausalLM::dspark_confidence_probs(hidden, previous_token_ids);
+  }
+
+  bool has_dspark_confidence_head() const override {
+    if constexpr (detail::has_has_dspark_confidence_head<Model>::value) {
+      return model_->has_dspark_confidence_head();
+    }
+    return false;
   }
 
   void lazy_load_model(std::unique_ptr<ModelLoader> loader) override {

--- a/xllm/core/framework/model/model_args.h
+++ b/xllm/core/framework/model/model_args.h
@@ -71,6 +71,14 @@ struct ModelArgs {
   // non-DSpark models).
   PROPERTY(int64_t, markov_rank) = 0;
 
+  // DSpark ConfidenceHead switches. When enabled, DSpark's ForCausalLM
+  // registers a `confidence_head.proj` layer used for adaptive-speculative
+  // pruning acceptance-probability estimation. `with_markov` toggles whether
+  // the head is applied on `concat(hidden, markov_embedding[prev])` (True in
+  // released dspark_qwen3_*b_block* checkpoints) or on `hidden` alone.
+  PROPERTY(bool, enable_confidence_head) = false;
+  PROPERTY(bool, confidence_head_with_markov) = false;
+
   PROPERTY(bool, use_qk_norm) = false;
   PROPERTY(float, rms_norm_eps) = 0.0f;
 

--- a/xllm/core/framework/model/model_traits.h
+++ b/xllm/core/framework/model/model_traits.h
@@ -270,5 +270,24 @@ struct has_dspark_markov_bias<
     std::void_t<decltype(std::declval<T>()->dspark_markov_bias(
         std::declval<const torch::Tensor&>()))>> : std::true_type {};
 
+template <typename T, typename = void>
+struct has_dspark_confidence_probs : std::false_type {};
+
+template <typename T>
+struct has_dspark_confidence_probs<
+    T,
+    std::void_t<decltype(std::declval<T>()->dspark_confidence_probs(
+        std::declval<const torch::Tensor&>(),
+        std::declval<const torch::Tensor&>()))>> : std::true_type {};
+
+template <typename T, typename = void>
+struct has_has_dspark_confidence_head : std::false_type {};
+
+template <typename T>
+struct has_has_dspark_confidence_head<
+    T,
+    std::void_t<decltype(std::declval<T>()->has_dspark_confidence_head())>>
+    : std::true_type {};
+
 }  // namespace detail
 }  // namespace xllm

--- a/xllm/core/framework/model/model_traits.h
+++ b/xllm/core/framework/model/model_traits.h
@@ -281,6 +281,16 @@ struct has_dspark_confidence_probs<
         std::declval<const torch::Tensor&>()))>> : std::true_type {};
 
 template <typename T, typename = void>
+struct has_dspark_confidence_probs_batched : std::false_type {};
+
+template <typename T>
+struct has_dspark_confidence_probs_batched<
+    T,
+    std::void_t<decltype(std::declval<T>()->dspark_confidence_probs_batched(
+        std::declval<const torch::Tensor&>(),
+        std::declval<const torch::Tensor&>()))>> : std::true_type {};
+
+template <typename T, typename = void>
 struct has_has_dspark_confidence_head : std::false_type {};
 
 template <typename T>

--- a/xllm/core/framework/speculative/adaptive_pruning_helpers.cpp
+++ b/xllm/core/framework/speculative/adaptive_pruning_helpers.cpp
@@ -329,5 +329,128 @@ void sync_pruned_boundary_outputs(SampleOutput& sample_output,
       sample_output, target_output, batch_size, num_val_tokens, masks);
 }
 
+void scatter_varlen_target_output_to_dense(
+    ForwardOutput& target_output,
+    const std::vector<int32_t>& per_seq_val_tokens,
+    int32_t batch_size,
+    int32_t max_val_tokens,
+    int64_t next_token_pad_value) {
+  CHECK(target_output.logits.defined())
+      << "target logits must be defined for varlen->dense scatter";
+  const int32_t total_tokens =
+      static_cast<int32_t>(target_output.logits.size(0));
+  const int64_t padded_total =
+      static_cast<int64_t>(batch_size) * max_val_tokens;
+  if (total_tokens == static_cast<int32_t>(padded_total)) {
+    // Already uniform max width; no scatter needed.
+    return;
+  }
+  const int32_t vocab_size =
+      static_cast<int32_t>(target_output.logits.size(-1));
+
+  // Pure order-preserving scatter: seq i's cu-packed rows [cu_offset,
+  // cu_offset + seq_tokens) map 1:1 onto dense cols [0, seq_tokens) of row i.
+  // The source rows are exactly [0, total_tokens) in order, so index_copy_
+  // reads target_output.logits directly with no source gather. Row j is the
+  // target's prediction after seeing anchor + draft[0..j-1]; col 0 predicts
+  // draft[0] (anchor row) and col (seq_tokens - 1) is the per-seq bonus.
+  // Trailing cols [seq_tokens, max_val_tokens) stay padded, so the bonus lands
+  // at col (seq_tokens - 1), NOT the fixed last column; validate() and
+  // apply_pruned_prefix_lengths therefore read the bonus/cut position per-seq.
+  std::vector<int64_t> dst_indices_vec;
+  dst_indices_vec.reserve(static_cast<size_t>(total_tokens));
+  for (int32_t i = 0; i < batch_size; ++i) {
+    const int32_t seq_tokens = per_seq_val_tokens[static_cast<size_t>(i)];
+    for (int32_t j = 0; j < seq_tokens; ++j) {
+      dst_indices_vec.push_back(static_cast<int64_t>(i) * max_val_tokens + j);
+    }
+  }
+  torch::Tensor dst_indices =
+      torch::tensor(dst_indices_vec,
+                    torch::TensorOptions()
+                        .dtype(torch::kLong)
+                        .device(target_output.logits.device()));
+
+  // Logits pad to [B*max_val_tokens, V]. Only the padding rows need the -inf
+  // sentinel (strictly-rejecting distribution); using empty + a targeted
+  // index_fill_ over the complement of dst_indices avoids paying vocab_size ×
+  // padded_total writes when most rows get overwritten by index_copy_.
+  torch::Tensor padded_logits =
+      torch::empty({padded_total, vocab_size}, target_output.logits.options());
+  if (dst_indices_vec.size() < static_cast<size_t>(padded_total)) {
+    std::vector<bool> valid(static_cast<size_t>(padded_total), false);
+    for (int64_t idx : dst_indices_vec) {
+      valid[static_cast<size_t>(idx)] = true;
+    }
+    std::vector<int64_t> pad_indices_vec;
+    pad_indices_vec.reserve(static_cast<size_t>(padded_total) -
+                            dst_indices_vec.size());
+    for (int64_t i = 0; i < padded_total; ++i) {
+      if (!valid[static_cast<size_t>(i)]) {
+        pad_indices_vec.push_back(i);
+      }
+    }
+    torch::Tensor pad_indices =
+        torch::tensor(pad_indices_vec,
+                      torch::TensorOptions()
+                          .dtype(torch::kLong)
+                          .device(target_output.logits.device()));
+    padded_logits.index_fill_(/*dim=*/0, pad_indices, -1e9);
+  }
+  padded_logits.index_copy_(/*dim=*/0, dst_indices, target_output.logits);
+  target_output.logits = padded_logits;
+
+  if (target_output.sample_output.next_tokens.defined()) {
+    torch::Tensor padded_next_tokens =
+        torch::full({padded_total},
+                    next_token_pad_value,
+                    target_output.sample_output.next_tokens.options());
+    padded_next_tokens.index_copy_(
+        /*dim=*/0, dst_indices, target_output.sample_output.next_tokens);
+    target_output.sample_output.next_tokens = padded_next_tokens;
+  }
+  if (target_output.sample_output.embeddings.defined()) {
+    const int32_t hidden_size =
+        static_cast<int32_t>(target_output.sample_output.embeddings.size(-1));
+    torch::Tensor padded_embeddings =
+        torch::zeros({padded_total, hidden_size},
+                     target_output.sample_output.embeddings.options());
+    padded_embeddings.index_copy_(
+        /*dim=*/0, dst_indices, target_output.sample_output.embeddings);
+    target_output.sample_output.embeddings = padded_embeddings;
+  }
+
+  // Pad sampled logprobs / top_tokens / top_logprobs into the same dense
+  // [B*max_val_tokens, ...] layout. sync_pruned_boundary_{logprobs,
+  // top_logprobs} CHECK_EQ these against B*max_val_tokens and view them as
+  // [batch, max_val_tokens, ...]; leaving them varlen aborts on any actually-
+  // pruned adaptive step whenever the request set logprobs/top_logprobs.
+  if (target_output.sample_output.logprobs.defined()) {
+    torch::Tensor padded_logprobs = torch::zeros(
+        {padded_total}, target_output.sample_output.logprobs.options());
+    padded_logprobs.index_copy_(
+        /*dim=*/0, dst_indices, target_output.sample_output.logprobs);
+    target_output.sample_output.logprobs = padded_logprobs;
+  }
+  if (target_output.sample_output.top_tokens.defined()) {
+    const int64_t top_k = target_output.sample_output.top_tokens.size(-1);
+    torch::Tensor padded_top_tokens =
+        torch::zeros({padded_total, top_k},
+                     target_output.sample_output.top_tokens.options());
+    padded_top_tokens.index_copy_(
+        /*dim=*/0, dst_indices, target_output.sample_output.top_tokens);
+    target_output.sample_output.top_tokens = padded_top_tokens;
+  }
+  if (target_output.sample_output.top_logprobs.defined()) {
+    const int64_t top_k = target_output.sample_output.top_logprobs.size(-1);
+    torch::Tensor padded_top_logprobs =
+        torch::zeros({padded_total, top_k},
+                     target_output.sample_output.top_logprobs.options());
+    padded_top_logprobs.index_copy_(
+        /*dim=*/0, dst_indices, target_output.sample_output.top_logprobs);
+    target_output.sample_output.top_logprobs = padded_top_logprobs;
+  }
+}
+
 }  // namespace adaptive_pruning
 }  // namespace xllm

--- a/xllm/core/framework/speculative/adaptive_pruning_helpers.h
+++ b/xllm/core/framework/speculative/adaptive_pruning_helpers.h
@@ -88,5 +88,29 @@ void sync_pruned_boundary_outputs(SampleOutput& sample_output,
                                   int32_t num_val_tokens,
                                   const PrunedPrefixMasks& masks);
 
+// Scatter a per-seq variable-length target output (produced by a pruned
+// validate forward) back into the padded dense [batch * max_val_tokens, ...]
+// layout the rejection sampler and the sync/apply pruning helpers expect.
+//
+// seq i's cu-packed rows [cu_offset, cu_offset + per_seq_val_tokens[i]) map
+// 1:1 onto dense cols [0, per_seq_val_tokens[i]) of row i, so the per-seq
+// bonus lands at col (per_seq_val_tokens[i] - 1), not the fixed last column.
+// Every populated field of `target_output` (logits, next_tokens, embeddings,
+// logprobs, top_tokens, top_logprobs) is padded in lockstep; logits pad with
+// -inf (strictly-rejecting), the rest with 0 except next_tokens which pads
+// with `next_token_pad_value`. Rewrites `target_output` in place; no-op when
+// its rows already equal batch_size * max_val_tokens (uniform width).
+//
+// next_token_pad_value differs by caller: DFlash uses -1 (a padded slot read
+// at a per-seq cut position must not surface a real token id — Qwen id 0 is
+// "!"); MTP passes 0 to preserve its established output. Both are masked to
+// -1 by apply_pruned_prefix_lengths at trailing positions downstream.
+void scatter_varlen_target_output_to_dense(
+    ForwardOutput& target_output,
+    const std::vector<int32_t>& per_seq_val_tokens,
+    int32_t batch_size,
+    int32_t max_val_tokens,
+    int64_t next_token_pad_value);
+
 }  // namespace adaptive_pruning
 }  // namespace xllm

--- a/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
+++ b/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
@@ -31,15 +31,8 @@ namespace {
 // Returns true when the adaptive controller can operate on the given
 // speculative algorithm name. Currently: MTP, DFlash, DSpark.
 bool is_supported_algorithm(const std::string& algorithm) {
-  if (SpeculativeConfig::is_mtp_algorithm(algorithm)) {
-    return true;
-  }
-  std::string lower = algorithm;
-  std::transform(
-      lower.begin(), lower.end(), lower.begin(), [](unsigned char c) {
-        return static_cast<char>(std::tolower(c));
-      });
-  return lower == "dflash" || lower == "dspark";
+  return SpeculativeConfig::is_mtp_algorithm(algorithm) ||
+         SpeculativeConfig::is_block_diffusion_algorithm(algorithm);
 }
 
 struct PruneCandidate {

--- a/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
+++ b/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
@@ -28,6 +28,19 @@ limitations under the License.
 namespace xllm {
 namespace {
 
+// Returns true when the adaptive controller can operate on the given
+// speculative algorithm name. Currently: MTP, DFlash, DSpark.
+bool is_supported_algorithm(const std::string& algorithm) {
+  if (SpeculativeConfig::is_mtp_algorithm(algorithm)) return true;
+  std::string lower = algorithm;
+  std::transform(
+      lower.begin(),
+      lower.end(),
+      lower.begin(),
+      [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return lower == "dflash" || lower == "dspark";
+}
+
 struct PruneCandidate {
   int32_t seq_id = 0;
   int32_t prefix_len = 0;
@@ -40,8 +53,7 @@ AdaptiveSpeculativeController::AdaptiveSpeculativeController(
     const runtime::Options& options)
     : enabled_(options.enable_adaptive_speculative_decode() &&
                options.num_speculative_tokens() > 1 &&
-               SpeculativeConfig::is_mtp_algorithm(
-                   options.speculative_algorithm()) &&
+               is_supported_algorithm(options.speculative_algorithm()) &&
                !options.enable_graph()),
       min_gain_(options.adaptive_speculative_min_gain()) {}
 

--- a/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
+++ b/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
@@ -31,7 +31,9 @@ namespace {
 // Returns true when the adaptive controller can operate on the given
 // speculative algorithm name. Currently: MTP, DFlash, DSpark.
 bool is_supported_algorithm(const std::string& algorithm) {
-  if (SpeculativeConfig::is_mtp_algorithm(algorithm)) return true;
+  if (SpeculativeConfig::is_mtp_algorithm(algorithm)) {
+    return true;
+  }
   std::string lower = algorithm;
   std::transform(
       lower.begin(), lower.end(), lower.begin(), [](unsigned char c) {

--- a/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
+++ b/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
@@ -34,10 +34,9 @@ bool is_supported_algorithm(const std::string& algorithm) {
   if (SpeculativeConfig::is_mtp_algorithm(algorithm)) return true;
   std::string lower = algorithm;
   std::transform(
-      lower.begin(),
-      lower.end(),
-      lower.begin(),
-      [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+      lower.begin(), lower.end(), lower.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+      });
   return lower == "dflash" || lower == "dspark";
 }
 
@@ -67,8 +66,7 @@ std::vector<int32_t>
 AdaptiveSpeculativeController::select_pruned_prefix_lengths(
     const torch::Tensor& selected_probs_by_step,
     double full_draft_time_ms,
-    const std::vector<double>& per_seq_kv_lens,
-    bool probs_are_path_probs) const {
+    const std::vector<double>& per_seq_kv_lens) const {
   CHECK(selected_probs_by_step.defined())
       << "adaptive pruning requires draft selected probabilities";
   CHECK_EQ(selected_probs_by_step.dim(), 2)
@@ -101,21 +99,15 @@ AdaptiveSpeculativeController::select_pruned_prefix_lengths(
          ++token_idx) {
       const double step_prob =
           prob_data[seq_id * num_speculative_tokens + token_idx];
-      // For MTP / DFlash sample-gathered probs each column is a per-step
-      // conditional accept probability, so we cumulatively multiply via chain
-      // rule to get path prob a_{r,j} = ∏ c_i (paper Section 3.2.2 Algorithm
-      // 1). For DSpark's ConfidenceHead the column already encodes P(accept
-      // prefix of length k+1) — we consume it directly. `probs_are_path_probs`
-      // selects between the two semantics.
-      if (probs_are_path_probs) {
-        path_prob = std::clamp(step_prob, 0.0, 1.0);
-      } else {
-        path_prob *= step_prob;
-        if (!std::isfinite(path_prob)) {
-          path_prob = 0.0;
-        }
-        path_prob = std::clamp(path_prob, 0.0, 1.0);
+      // Chain rule cumulative product: a_{r,j} = ∏ c_i (paper Section 3.2.2
+      // Algorithm 1). Works for MTP / DFlash sample-gathered probs and for
+      // DSpark ConfidenceHead c_k alike; both are per-step conditional
+      // probabilities.
+      path_prob *= step_prob;
+      if (!std::isfinite(path_prob)) {
+        path_prob = 0.0;
       }
+      path_prob = std::clamp(path_prob, 0.0, 1.0);
       path_probs[static_cast<size_t>(seq_id) *
                      static_cast<size_t>(num_speculative_tokens) +
                  static_cast<size_t>(token_idx)] = path_prob;

--- a/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
+++ b/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
@@ -101,9 +101,13 @@ AdaptiveSpeculativeController::select_pruned_prefix_lengths(
          ++token_idx) {
       const double step_prob =
           prob_data[seq_id * num_speculative_tokens + token_idx];
+      // For MTP / DFlash sample-gathered probs each column is a per-step
+      // conditional accept probability, so we cumulatively multiply via chain
+      // rule to get path prob a_{r,j} = ∏ c_i (paper Section 3.2.2 Algorithm
+      // 1). For DSpark's ConfidenceHead the column already encodes P(accept
+      // prefix of length k+1) — we consume it directly. `probs_are_path_probs`
+      // selects between the two semantics.
       if (probs_are_path_probs) {
-        // Column already encodes P(accept prefix of length k+1) — do not
-        // multiply. Clamp for safety in case of upstream numerical drift.
         path_prob = std::clamp(step_prob, 0.0, 1.0);
       } else {
         path_prob *= step_prob;

--- a/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
+++ b/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
@@ -67,7 +67,8 @@ std::vector<int32_t>
 AdaptiveSpeculativeController::select_pruned_prefix_lengths(
     const torch::Tensor& selected_probs_by_step,
     double full_draft_time_ms,
-    const std::vector<double>& per_seq_kv_lens) const {
+    const std::vector<double>& per_seq_kv_lens,
+    bool probs_are_path_probs) const {
   CHECK(selected_probs_by_step.defined())
       << "adaptive pruning requires draft selected probabilities";
   CHECK_EQ(selected_probs_by_step.dim(), 2)
@@ -98,11 +99,19 @@ AdaptiveSpeculativeController::select_pruned_prefix_lengths(
     double path_prob = 1.0;
     for (int32_t token_idx = 0; token_idx < num_speculative_tokens;
          ++token_idx) {
-      path_prob *= prob_data[seq_id * num_speculative_tokens + token_idx];
-      if (!std::isfinite(path_prob)) {
-        path_prob = 0.0;
+      const double step_prob =
+          prob_data[seq_id * num_speculative_tokens + token_idx];
+      if (probs_are_path_probs) {
+        // Column already encodes P(accept prefix of length k+1) — do not
+        // multiply. Clamp for safety in case of upstream numerical drift.
+        path_prob = std::clamp(step_prob, 0.0, 1.0);
+      } else {
+        path_prob *= step_prob;
+        if (!std::isfinite(path_prob)) {
+          path_prob = 0.0;
+        }
+        path_prob = std::clamp(path_prob, 0.0, 1.0);
       }
-      path_prob = std::clamp(path_prob, 0.0, 1.0);
       path_probs[static_cast<size_t>(seq_id) *
                      static_cast<size_t>(num_speculative_tokens) +
                  static_cast<size_t>(token_idx)] = path_prob;

--- a/xllm/core/framework/speculative/adaptive_speculative_controller.h
+++ b/xllm/core/framework/speculative/adaptive_speculative_controller.h
@@ -36,14 +36,15 @@ class AdaptiveSpeculativeController final {
   // Each column of `selected_probs_by_step` is a per-step conditional accept
   // probability. For MTP / DFlash sample-gathered probs this is P(sampled
   // token | step logits). For DSpark ConfidenceHead this is c_k = P(step k
-  // accepted | prefix accepted). The controller multiplies them cumulatively
-  // via the chain rule (paper Section 3.2.2, Algorithm 1 line 2) to obtain
-  // path acceptance probabilities a_{r,j} = ∏_{i<=j} c_i used for scheduling.
+  // accepted | prefix accepted) from a trained head that replaces the
+  // proposal prob as a better estimator of the same quantity. The controller
+  // multiplies them cumulatively via the chain rule (paper Section 3.2.2,
+  // Algorithm 1 line 2) to obtain path acceptance probabilities
+  // a_{r,j} = ∏_{i<=j} c_i used for scheduling.
   std::vector<int32_t> select_pruned_prefix_lengths(
       const torch::Tensor& selected_probs_by_step,
       double full_draft_time_ms,
-      const std::vector<double>& per_seq_kv_lens,
-      bool probs_are_path_probs = false) const;
+      const std::vector<double>& per_seq_kv_lens) const;
 
  private:
   bool enabled_ = false;

--- a/xllm/core/framework/speculative/adaptive_speculative_controller.h
+++ b/xllm/core/framework/speculative/adaptive_speculative_controller.h
@@ -33,10 +33,19 @@ class AdaptiveSpeculativeController final {
   ~AdaptiveSpeculativeController() = default;
 
   bool enabled() const;
+  // `probs_are_path_probs=false` (default): each column of
+  // `selected_probs_by_step` is a per-step conditional accept probability (as
+  // MTP / DFlash sample-gathered probs are). The controller multiplies them
+  // cumulatively to obtain the path probability of accepting the first k
+  // tokens. `probs_are_path_probs=true`: each column *already is* the path
+  // acceptance probability at that step (e.g. DSpark's ConfidenceHead which is
+  // trained to predict "P(accept up to this token)"). The controller consumes
+  // the column directly without multiplying.
   std::vector<int32_t> select_pruned_prefix_lengths(
       const torch::Tensor& selected_probs_by_step,
       double full_draft_time_ms,
-      const std::vector<double>& per_seq_kv_lens) const;
+      const std::vector<double>& per_seq_kv_lens,
+      bool probs_are_path_probs = false) const;
 
  private:
   bool enabled_ = false;

--- a/xllm/core/framework/speculative/adaptive_speculative_controller.h
+++ b/xllm/core/framework/speculative/adaptive_speculative_controller.h
@@ -33,14 +33,12 @@ class AdaptiveSpeculativeController final {
   ~AdaptiveSpeculativeController() = default;
 
   bool enabled() const;
-  // `probs_are_path_probs=false` (default): each column of
-  // `selected_probs_by_step` is a per-step conditional accept probability (as
-  // MTP / DFlash sample-gathered probs are). The controller multiplies them
-  // cumulatively to obtain the path probability of accepting the first k
-  // tokens. `probs_are_path_probs=true`: each column *already is* the path
-  // acceptance probability at that step (e.g. DSpark's ConfidenceHead which is
-  // trained to predict "P(accept up to this token)"). The controller consumes
-  // the column directly without multiplying.
+  // Each column of `selected_probs_by_step` is a per-step conditional accept
+  // probability. For MTP / DFlash sample-gathered probs this is P(sampled
+  // token | step logits). For DSpark ConfidenceHead this is c_k = P(step k
+  // accepted | prefix accepted). The controller multiplies them cumulatively
+  // via the chain rule (paper Section 3.2.2, Algorithm 1 line 2) to obtain
+  // path acceptance probabilities a_{r,j} = ∏_{i<=j} c_i used for scheduling.
   std::vector<int32_t> select_pruned_prefix_lengths(
       const torch::Tensor& selected_probs_by_step,
       double full_draft_time_ms,

--- a/xllm/core/runtime/dflash_worker_impl.cpp
+++ b/xllm/core/runtime/dflash_worker_impl.cpp
@@ -916,10 +916,17 @@ std::optional<ForwardOutput> DFlashWorkerImpl::run_validate(
               timer.elapsed_seconds());
 
   // Scatter varlen target output back to dense [B, max_val_tokens] layout so
-  // the rejection sampler (dense API) can consume it.
+  // the rejection sampler (dense API) can consume it. Pad next_tokens with -1
+  // (reject marker), not 0: Qwen id 0 is "!", and a padded slot must not
+  // surface a real token if any downstream consumer reads it before
+  // apply_pruned_prefix_lengths masks trailing positions to -1.
   if (did_prune) {
-    scatter_varlen_target_output_to_dense(
-        target_output, per_seq_val_tokens, batch_size, max_val_tokens);
+    adaptive_pruning::scatter_varlen_target_output_to_dense(
+        target_output,
+        per_seq_val_tokens,
+        batch_size,
+        max_val_tokens,
+        /*next_token_pad_value=*/-1);
   }
 
   timer.reset();
@@ -1498,144 +1505,6 @@ void DFlashWorkerImpl::apply_per_seq_varlen_prune(
   new_validate.input_params.embedding.input_embedding = torch::Tensor();
   record_metadata_ready_event(*prepare_stream_, new_validate);
   validate_input = std::move(new_validate);
-}
-
-void DFlashWorkerImpl::scatter_varlen_target_output_to_dense(
-    ForwardOutput& target_output,
-    const std::vector<int32_t>& per_seq_val_tokens,
-    int32_t batch_size,
-    int32_t max_val_tokens) {
-  CHECK(target_output.logits.defined())
-      << "target logits must be defined for varlen->dense scatter";
-  const int32_t total_tokens =
-      static_cast<int32_t>(target_output.logits.size(0));
-  const int64_t padded_total =
-      static_cast<int64_t>(batch_size) * max_val_tokens;
-  if (total_tokens == static_cast<int32_t>(padded_total)) {
-    // Already uniform max width; no scatter needed.
-    return;
-  }
-  const int32_t vocab_size =
-      static_cast<int32_t>(target_output.logits.size(-1));
-
-  // Pure order-preserving scatter: seq i's varlen rows [cu_offset,
-  // cu_offset + seq_tokens) map to dense cols [0, seq_tokens). Row j is the
-  // target's prediction after seeing anchor + draft[0..j-1]:
-  //   dense col 0            → predicts draft[0] (anchor row)
-  //   dense col j            → predicts draft[j] given first j accepted
-  //   dense col seq_tokens-1 → bonus (all seq_tokens-1 drafts accepted)
-  // Trailing cols [seq_tokens, max_val_tokens) stay as the caller's -inf
-  // logits / 0 tokens. This matches MTP's varlen->dense scatter exactly; the
-  // per-seq bonus therefore lands at col (seq_tokens - 1), NOT the fixed last
-  // column, so validate()/apply_pruned_prefix_lengths must read the bonus and
-  // cut position per-seq (see per_seq_val_tokens plumbing below).
-  std::vector<int64_t> src_indices_vec;
-  std::vector<int64_t> dst_indices_vec;
-  src_indices_vec.reserve(static_cast<size_t>(total_tokens));
-  dst_indices_vec.reserve(static_cast<size_t>(total_tokens));
-  int64_t cu_offset = 0;
-  for (int32_t i = 0; i < batch_size; ++i) {
-    const int32_t seq_tokens = per_seq_val_tokens[static_cast<size_t>(i)];
-    for (int32_t j = 0; j < seq_tokens; ++j) {
-      src_indices_vec.push_back(cu_offset + j);
-      dst_indices_vec.push_back(static_cast<int64_t>(i) * max_val_tokens + j);
-    }
-    cu_offset += seq_tokens;
-  }
-  torch::Tensor src_indices =
-      torch::tensor(src_indices_vec,
-                    torch::TensorOptions()
-                        .dtype(torch::kLong)
-                        .device(target_output.logits.device()));
-  torch::Tensor dst_indices =
-      torch::tensor(dst_indices_vec,
-                    torch::TensorOptions()
-                        .dtype(torch::kLong)
-                        .device(target_output.logits.device()));
-
-  // Logits: pad to [B*max_val_tokens, V] filled with -inf so any col we do
-  // not explicitly write remains a strictly-rejecting distribution.
-  torch::Tensor padded_logits = torch::full(
-      {padded_total, vocab_size}, -1e9, target_output.logits.options());
-  padded_logits.index_copy_(
-      /*dim=*/0,
-      dst_indices,
-      target_output.logits.index_select(/*dim=*/0, src_indices));
-  target_output.logits = padded_logits;
-
-  if (target_output.sample_output.next_tokens.defined()) {
-    // Pad next_tokens with -1 (reject marker) rather than 0. Qwen tokenizer
-    // token id 0 is "!" — if any downstream consumer picks up a padded slot
-    // (e.g. sync_pruned_boundary_outputs reads target_next_tokens at the
-    // cut position `per_seq_val_tokens[i]-1`, which for a pruned seq is a
-    // padded slot since we only fill dense positions [0, seq_tokens-2] and
-    // move the bonus to `max_val_tokens-1`), it must not emit garbage
-    // tokens. apply_pruned_prefix_lengths downstream masks drop_mask to -1
-    // anyway, so -1 propagates cleanly through the rest of the pipeline.
-    torch::Tensor padded_next_tokens =
-        torch::full({padded_total},
-                    static_cast<int64_t>(-1),
-                    target_output.sample_output.next_tokens.options());
-    padded_next_tokens.index_copy_(
-        /*dim=*/0,
-        dst_indices,
-        target_output.sample_output.next_tokens.index_select(/*dim=*/0,
-                                                             src_indices));
-    target_output.sample_output.next_tokens = padded_next_tokens;
-  }
-  if (target_output.sample_output.embeddings.defined()) {
-    const int32_t hidden_size =
-        static_cast<int32_t>(target_output.sample_output.embeddings.size(-1));
-    torch::Tensor padded_embeddings =
-        torch::zeros({padded_total, hidden_size},
-                     target_output.sample_output.embeddings.options());
-    padded_embeddings.index_copy_(
-        /*dim=*/0,
-        dst_indices,
-        target_output.sample_output.embeddings.index_select(/*dim=*/0,
-                                                            src_indices));
-    target_output.sample_output.embeddings = padded_embeddings;
-  }
-
-  // Pad sampled logprobs / top_tokens / top_logprobs into the same dense
-  // [B*max_val_tokens, ...] layout. sync_pruned_boundary_{logprobs,
-  // top_logprobs} CHECK_EQ these against B*max_val_tokens and view them as
-  // [batch, max_val_tokens, ...]; leaving them varlen aborts on any actually-
-  // pruned adaptive step whenever the request set logprobs/top_logprobs.
-  if (target_output.sample_output.logprobs.defined()) {
-    torch::Tensor padded_logprobs = torch::zeros(
-        {padded_total}, target_output.sample_output.logprobs.options());
-    padded_logprobs.index_copy_(
-        /*dim=*/0,
-        dst_indices,
-        target_output.sample_output.logprobs.index_select(/*dim=*/0,
-                                                          src_indices));
-    target_output.sample_output.logprobs = padded_logprobs;
-  }
-  if (target_output.sample_output.top_tokens.defined()) {
-    const int64_t top_k = target_output.sample_output.top_tokens.size(-1);
-    torch::Tensor padded_top_tokens =
-        torch::zeros({padded_total, top_k},
-                     target_output.sample_output.top_tokens.options());
-    padded_top_tokens.index_copy_(
-        /*dim=*/0,
-        dst_indices,
-        target_output.sample_output.top_tokens.index_select(/*dim=*/0,
-                                                            src_indices));
-    target_output.sample_output.top_tokens = padded_top_tokens;
-  }
-  if (target_output.sample_output.top_logprobs.defined()) {
-    const int64_t top_k = target_output.sample_output.top_logprobs.size(-1);
-    torch::Tensor padded_top_logprobs =
-        torch::zeros({padded_total, top_k},
-                     target_output.sample_output.top_logprobs.options());
-    padded_top_logprobs.index_copy_(
-        /*dim=*/0,
-        dst_indices,
-        target_output.sample_output.top_logprobs.index_select(/*dim=*/0,
-                                                              src_indices));
-    target_output.sample_output.top_logprobs = padded_top_logprobs;
-  }
 }
 
 void DFlashWorkerImpl::record_validate_metrics(

--- a/xllm/core/runtime/dflash_worker_impl.cpp
+++ b/xllm/core/runtime/dflash_worker_impl.cpp
@@ -1431,7 +1431,7 @@ std::vector<int32_t> DFlashWorkerImpl::compute_adaptive_prefix_lengths(
 
   std::vector<int32_t> prefix_lengths =
       adaptive_spec_controller_->select_pruned_prefix_lengths(
-          probs_for_controller.to(torch::kCPU).to(torch::kFloat64),
+          probs_for_controller,
           /*full_draft_time_ms=*/0.0,
           per_seq_kv_lens);
   return prefix_lengths;
@@ -1488,11 +1488,15 @@ void DFlashWorkerImpl::apply_adaptive_prune_to_draft(
   torch::Tensor probs = draft_block.probs;
   torch::Tensor keep_cols_device =
       cpu_int_vec_to_device(keep_cols_vec, device_);
-  torch::Tensor col_idx = torch::arange(
-      num_speculative_tokens,
-      torch::TensorOptions().dtype(torch::kInt).device(probs.device()));
+  if (!prune_col_idx_cache_.defined() ||
+      prune_col_idx_cache_.numel() != num_speculative_tokens ||
+      prune_col_idx_cache_.device() != probs.device()) {
+    prune_col_idx_cache_ = torch::arange(
+        num_speculative_tokens,
+        torch::TensorOptions().dtype(torch::kInt).device(probs.device()));
+  }
   torch::Tensor keep_mask =
-      col_idx.unsqueeze(0).lt(keep_cols_device.unsqueeze(1));
+      prune_col_idx_cache_.unsqueeze(0).lt(keep_cols_device.unsqueeze(1));
   probs.masked_fill_(~keep_mask, 0);
   LOG_EVERY_N(INFO, 32) << "[dflash_dspark_adaptive] batch=" << batch_size
                         << " pruned_seqs=" << pruned_seqs

--- a/xllm/core/runtime/dflash_worker_impl.cpp
+++ b/xllm/core/runtime/dflash_worker_impl.cpp
@@ -726,9 +726,13 @@ DFlashWorkerImpl::DraftBlock DFlashWorkerImpl::run_decode_draft(
 void DFlashWorkerImpl::fill_validate_input_from_draft_outputs(
     const DraftBlock& draft_block,
     ForwardInput& validate_input,
-    Stream& compute_stream) {
+    Stream& compute_stream,
+    int32_t effective_val_tokens) {
   const int32_t num_speculative_tokens = options_.num_speculative_tokens();
-  const int32_t num_val_tokens = num_speculative_tokens + 1;
+  const int32_t num_val_tokens = effective_val_tokens;
+  const int32_t effective_speculative_tokens = effective_val_tokens - 1;
+  CHECK_GE(effective_speculative_tokens, 0);
+  CHECK_LE(effective_speculative_tokens, num_speculative_tokens);
   CHECK(draft_block.token_ids.defined())
       << "DFlash draft token_ids must be defined for validate token fill";
   CHECK_EQ(draft_block.token_ids.dim(), 2)
@@ -753,14 +757,24 @@ void DFlashWorkerImpl::fill_validate_input_from_draft_outputs(
       validate_input.token_ids.view({num_sequences, num_val_tokens});
 
   validate_input.device_tensors_ready = false;
-  // Column 0 keeps the real input token; the draft block fills columns
-  // [1, num_val_tokens) in one copy rather than per-step.
-  torch::Tensor draft_tokens =
-      safe_to(draft_block.token_ids, token_options, /*non_blocking=*/true);
-  using ISlice = torch::indexing::Slice;
-  validate_token_rows.index({ISlice(), ISlice(1, num_val_tokens)})
-      .copy_(draft_tokens, /*non_blocking=*/true);
-  validate_input.device_tensors_ready = true;
+  if (effective_speculative_tokens == 0) {
+    // Controller pruned every seq's speculation down to zero; nothing to fill
+    // beyond the anchor column that already holds the real token.
+    validate_input.device_tensors_ready = true;
+    // still need to publish the compute-stream write below.
+  } else {
+    using ISlice = torch::indexing::Slice;
+    torch::Tensor draft_slice =
+        draft_block.token_ids
+            .index({ISlice(),
+                    ISlice(/*start=*/0, /*end=*/effective_speculative_tokens)})
+            .contiguous();
+    torch::Tensor draft_tokens =
+        safe_to(draft_slice, token_options, /*non_blocking=*/true);
+    validate_token_rows.index({ISlice(), ISlice(1, num_val_tokens)})
+        .copy_(draft_tokens, /*non_blocking=*/true);
+    validate_input.device_tensors_ready = true;
+  }
   // Publish this compute-stream write so the target's prepare stage (which
   // consumes validate_input.token_ids under ACL-graph double buffering) waits
   // for the copy to complete before staging into the graph's persistent
@@ -773,19 +787,26 @@ std::optional<ForwardOutput> DFlashWorkerImpl::run_validate(
     const DraftBlock& draft_block_in,
     ForwardInput& validate_input) {
   Timer timer;
-  // v1 adaptive pruning: keep the dense N+1 validate layout but zero out the
-  // per-seq draft probs beyond the controller-selected prefix. The rejection
-  // sampler naturally rejects those positions (draft_prob=0), so throughput
-  // and acceptance rate reflect the controller decision without touching the
-  // chunked_prefill metadata rebuild path.
+  // Adaptive-speculative hard batch-max pruning:
+  // 1. controller decides per-seq prefix_lengths from confidence/proposal
+  //    probs.
+  // 2. we shrink the target validate width to max(prefix_lengths)+1 and
+  //    rebuild the dense validate_input at that width — target forward truly
+  //    consumes less compute for pruned steps.
+  // 3. we still soft-mask draft probs beyond each seq's prefix_len so the
+  //    rejection sampler only accepts draft tokens the controller endorsed
+  //    (per-seq granularity within the batch-max window).
   DraftBlock draft_block = draft_block_in;
   std::vector<int32_t> prefix_lengths =
       compute_adaptive_prefix_lengths(draft_block, input);
+  int32_t effective_val_tokens = options_.num_speculative_tokens() + 1;
   if (!prefix_lengths.empty()) {
     apply_adaptive_prune_to_draft(draft_block, prefix_lengths);
+    effective_val_tokens =
+        apply_batch_max_hard_prune(input, validate_input, prefix_lengths);
   }
   fill_validate_input_from_draft_outputs(
-      draft_block, validate_input, *compute_stream_);
+      draft_block, validate_input, *compute_stream_, effective_val_tokens);
   ForwardOutput target_output =
       run_llm_no_sync_impl(
           *impl_, validate_input, *prepare_stream_, *compute_stream_)
@@ -794,8 +815,8 @@ std::optional<ForwardOutput> DFlashWorkerImpl::run_validate(
               timer.elapsed_seconds());
 
   timer.reset();
-  SampleOutput val_output =
-      validate(input.sampling_params, draft_block, target_output);
+  SampleOutput val_output = validate(
+      input.sampling_params, draft_block, target_output, effective_val_tokens);
   COUNTER_ADD(speculative_execution_latency_seconds_validation,
               timer.elapsed_seconds());
 
@@ -818,7 +839,8 @@ std::optional<ForwardOutput> DFlashWorkerImpl::run_validate(
 SampleOutput DFlashWorkerImpl::validate(
     const SamplingParameters& sampling_params,
     const DraftBlock& draft_block,
-    const ForwardOutput& target_output) {
+    const ForwardOutput& target_output,
+    int32_t effective_val_tokens) {
   // Draft already emits the whole block [batch, num_speculative_tokens]; feed
   // it straight to the verifier without the per-step select/view/cat round
   // trip. The shared rejection sampler uses MTP's dense contract, so
@@ -827,21 +849,40 @@ SampleOutput DFlashWorkerImpl::validate(
       static_cast<int32_t>(target_output.logits.size(/*dim=*/-1));
   const bool enable_opt_validate_probs =
       ::xllm::SpeculativeConfig::get_instance().enable_opt_validate_probs();
+  // Slice draft block down to the effective validate width; the rejection
+  // sampler only sees the tokens the target actually validated.
+  const int32_t effective_speculative_tokens = effective_val_tokens - 1;
+  using ISlice = torch::indexing::Slice;
+  torch::Tensor pruned_token_ids =
+      draft_block.token_ids
+          .index({ISlice(),
+                  ISlice(/*start=*/0, /*end=*/effective_speculative_tokens)})
+          .contiguous();
+  torch::Tensor pruned_probs =
+      draft_block.probs
+          .index({ISlice(),
+                  ISlice(/*start=*/0, /*end=*/effective_speculative_tokens)})
+          .contiguous();
   auto [draft_token_ids, draft_probs] =
       specBuilder::draftProbs::build_validate_tensors_from_block(
-          draft_block.token_ids,
-          draft_block.probs,
+          pruned_token_ids,
+          pruned_probs,
           vocab_size,
           enable_opt_validate_probs);
-  return validate(sampling_params, draft_token_ids, draft_probs, target_output);
+  return validate(sampling_params,
+                  draft_token_ids,
+                  draft_probs,
+                  target_output,
+                  effective_val_tokens);
 }
 
 SampleOutput DFlashWorkerImpl::validate(
     const SamplingParameters& sampling_params,
     const torch::Tensor& draft_token_ids,
     const torch::Tensor& draft_probs,
-    const ForwardOutput& target_output) {
-  const int32_t num_val_tokens = options_.num_speculative_tokens() + 1;
+    const ForwardOutput& target_output,
+    int32_t effective_val_tokens) {
+  const int32_t num_val_tokens = effective_val_tokens;
   // Derive batch_size from the target logits rows rather than next_tokens so
   // the reshape stays valid regardless of how the target was sampled.
   const int32_t num_logits_rows =
@@ -1300,6 +1341,50 @@ void DFlashWorkerImpl::apply_adaptive_prune_to_draft(
                                 ? static_cast<double>(sum_kept) / batch_size
                                 : 0.0)
                         << " of " << num_speculative_tokens;
+}
+
+int32_t DFlashWorkerImpl::apply_batch_max_hard_prune(
+    const ForwardInput& input,
+    ForwardInput& validate_input,
+    const std::vector<int32_t>& prefix_lengths) {
+  const int32_t num_speculative_tokens = options_.num_speculative_tokens();
+  const int32_t default_val_tokens = num_speculative_tokens + 1;
+  if (prefix_lengths.empty()) return default_val_tokens;
+  int32_t max_prefix = 0;
+  for (int32_t p : prefix_lengths) {
+    max_prefix = std::max(max_prefix, std::clamp(p, 0, num_speculative_tokens));
+  }
+  const int32_t effective_val_tokens = max_prefix + 1;
+  // Guard: rejection sampler / validate pipeline needs at least one draft
+  // slot beyond the anchor. If controller says "prune all", keep 1 draft so
+  // static-like acceptance can still happen this step.
+  const int32_t effective_val_tokens_clamped =
+      std::max(effective_val_tokens, 2);
+  if (effective_val_tokens_clamped >= default_val_tokens)
+    return default_val_tokens;
+
+  // Rebuild validate_input as a dense per-seq width == effective_val_tokens by
+  // reusing the per-seq varlen builder with a uniform width. Because every
+  // entry equals effective_val_tokens, the resulting layout is dense but with
+  // a narrower target-forward block, so target compute drops linearly with
+  // (default - effective) / default.
+  const int32_t num_sequences = input.input_params.meta.num_sequences;
+  std::vector<int32_t> uniform_widths(static_cast<size_t>(num_sequences),
+                                      effective_val_tokens_clamped);
+  c10::StreamGuard stream_guard = prepare_stream_->set_stream_guard();
+  ForwardInput prepared_input = input;
+  prepared_input.metadata_ready_event.reset();
+  ForwardInput new_validate;
+  SpeculativeWorkerImpl::prepare_validate_inputs(
+      prepared_input, new_validate, uniform_widths);
+  new_validate.input_params.embedding.input_embedding = torch::Tensor();
+  record_metadata_ready_event(*prepare_stream_, new_validate);
+  validate_input = std::move(new_validate);
+  LOG_EVERY_N(INFO, 32) << "[dflash_dspark_hard_prune] batch=" << num_sequences
+                        << " effective_val_tokens="
+                        << effective_val_tokens_clamped << " (was "
+                        << default_val_tokens << ")";
+  return effective_val_tokens_clamped;
 }
 
 }  // namespace xllm

--- a/xllm/core/runtime/dflash_worker_impl.cpp
+++ b/xllm/core/runtime/dflash_worker_impl.cpp
@@ -1498,25 +1498,6 @@ void DFlashWorkerImpl::apply_per_seq_varlen_prune(
   new_validate.input_params.embedding.input_embedding = torch::Tensor();
   record_metadata_ready_event(*prepare_stream_, new_validate);
   validate_input = std::move(new_validate);
-
-  int32_t max_w = 0;
-  int32_t total_w = 0;
-  int32_t sum_kept_below_default = 0;
-  int32_t default_val_tokens = options_.num_speculative_tokens() + 1;
-  int32_t pruned_seqs = 0;
-  for (int32_t v : per_seq_val_tokens) {
-    max_w = std::max(max_w, v);
-    total_w += v;
-    if (v < default_val_tokens) {
-      ++pruned_seqs;
-      sum_kept_below_default += v;
-    }
-  }
-  LOG_EVERY_N(INFO, 32) << "[dflash_dspark_varlen_prune] batch="
-                        << num_sequences << " total_val_tokens=" << total_w
-                        << " max_val_tokens=" << max_w << " (was "
-                        << (num_sequences * default_val_tokens) << ")"
-                        << " pruned_seqs=" << pruned_seqs;
 }
 
 void DFlashWorkerImpl::scatter_varlen_target_output_to_dense(

--- a/xllm/core/runtime/dflash_worker_impl.cpp
+++ b/xllm/core/runtime/dflash_worker_impl.cpp
@@ -1596,6 +1596,46 @@ void DFlashWorkerImpl::scatter_varlen_target_output_to_dense(
                                                             src_indices));
     target_output.sample_output.embeddings = padded_embeddings;
   }
+
+  // Pad sampled logprobs / top_tokens / top_logprobs into the same dense
+  // [B*max_val_tokens, ...] layout. sync_pruned_boundary_{logprobs,
+  // top_logprobs} CHECK_EQ these against B*max_val_tokens and view them as
+  // [batch, max_val_tokens, ...]; leaving them varlen aborts on any actually-
+  // pruned adaptive step whenever the request set logprobs/top_logprobs.
+  if (target_output.sample_output.logprobs.defined()) {
+    torch::Tensor padded_logprobs = torch::zeros(
+        {padded_total}, target_output.sample_output.logprobs.options());
+    padded_logprobs.index_copy_(
+        /*dim=*/0,
+        dst_indices,
+        target_output.sample_output.logprobs.index_select(/*dim=*/0,
+                                                          src_indices));
+    target_output.sample_output.logprobs = padded_logprobs;
+  }
+  if (target_output.sample_output.top_tokens.defined()) {
+    const int64_t top_k = target_output.sample_output.top_tokens.size(-1);
+    torch::Tensor padded_top_tokens =
+        torch::zeros({padded_total, top_k},
+                     target_output.sample_output.top_tokens.options());
+    padded_top_tokens.index_copy_(
+        /*dim=*/0,
+        dst_indices,
+        target_output.sample_output.top_tokens.index_select(/*dim=*/0,
+                                                            src_indices));
+    target_output.sample_output.top_tokens = padded_top_tokens;
+  }
+  if (target_output.sample_output.top_logprobs.defined()) {
+    const int64_t top_k = target_output.sample_output.top_logprobs.size(-1);
+    torch::Tensor padded_top_logprobs =
+        torch::zeros({padded_total, top_k},
+                     target_output.sample_output.top_logprobs.options());
+    padded_top_logprobs.index_copy_(
+        /*dim=*/0,
+        dst_indices,
+        target_output.sample_output.top_logprobs.index_select(/*dim=*/0,
+                                                              src_indices));
+    target_output.sample_output.top_logprobs = padded_top_logprobs;
+  }
 }
 
 void DFlashWorkerImpl::record_validate_metrics(
@@ -1632,8 +1672,12 @@ void DFlashWorkerImpl::record_validate_metrics(
     // the full dense width.
     int32_t seq_width = width;
     if (have_per_seq) {
+      // lo=1: a controller prefix=0 decision yields per_seq_val_tokens[i]==1
+      // (bonus only, zero drafts). Clamping to 1 gives prefix_len=0 so a
+      // fully-pruned seq contributes no draft/accept counts; clamping to 2
+      // would fabricate one phantom draft + one phantom accept.
       seq_width = std::clamp(per_seq_val_tokens[static_cast<size_t>(seq_id)],
-                             /*lo=*/2,
+                             /*lo=*/1,
                              /*hi=*/width);
     }
     // Drafts attempted for this seq = seq_width - 1 (bonus column excluded).

--- a/xllm/core/runtime/dflash_worker_impl.cpp
+++ b/xllm/core/runtime/dflash_worker_impl.cpp
@@ -809,6 +809,12 @@ void DFlashWorkerImpl::fill_validate_input_from_draft_outputs_varlen(
   // [cu_offset[i] + 1, cu_offset[i] + per_seq_val_tokens[i]).
   std::vector<int64_t> dst_idx_vec;
   std::vector<int64_t> src_idx_vec;
+  // Upper bound: each seq contributes at most num_speculative_tokens draft
+  // rows (seq_val_tokens - 1 <= num_speculative_tokens).
+  const size_t max_draft_rows =
+      static_cast<size_t>(num_sequences) * num_speculative_tokens;
+  dst_idx_vec.reserve(max_draft_rows);
+  src_idx_vec.reserve(max_draft_rows);
   int64_t cu_offset = 0;
   for (int64_t seq_id = 0; seq_id < num_sequences; ++seq_id) {
     const int32_t seq_val_tokens =

--- a/xllm/core/runtime/dflash_worker_impl.cpp
+++ b/xllm/core/runtime/dflash_worker_impl.cpp
@@ -873,16 +873,25 @@ std::optional<ForwardOutput> DFlashWorkerImpl::run_validate(
   bool did_prune = false;
   int32_t max_val_tokens = default_val_tokens;
   if (!prefix_lengths.empty()) {
-    apply_adaptive_prune_to_draft(draft_block, prefix_lengths);
+    // Note: we intentionally do NOT mask draft_block.probs beyond each seq's
+    // prefix_len. The varlen validate path only sends prefix_lengths[i] draft
+    // tokens per seq to target; and apply_pruned_prefix_lengths downstream
+    // overwrites all pruned rejection-sampler outputs (via cut_mask + drop
+    // mask). So the sampler's decision on pruned draft slots is irrelevant
+    // to the emitted tokens — no need to touch draft_probs on the hot path.
     per_seq_val_tokens.resize(batch_size);
     max_val_tokens = 0;
     for (int32_t i = 0; i < batch_size; ++i) {
       int32_t p = std::clamp(prefix_lengths[static_cast<size_t>(i)],
                              /*min=*/0,
                              /*max=*/num_speculative_tokens);
-      // Require at least one draft slot beyond the anchor so the rejection
-      // sampler always sees a non-empty per-seq block.
-      int32_t width = std::max(p + 1, 2);
+      // Per-seq validate width = accepted-draft-count + 1 bonus. When the
+      // controller decides prefix=0 (don't speculate this step), the seq
+      // still must verify its bonus token, so the minimum is 1 slot — not
+      // 2. A previous floor to 2 forced a phantom "draft slot" at position
+      // 0 that leaked whatever the sampler emitted there past the intended
+      // prefix, showing up as duplicate/garbage tokens in adaptive output.
+      const int32_t width = p + 1;
       per_seq_val_tokens[static_cast<size_t>(i)] = width;
       max_val_tokens = std::max(max_val_tokens, width);
       if (width < default_val_tokens) {
@@ -914,18 +923,27 @@ std::optional<ForwardOutput> DFlashWorkerImpl::run_validate(
   }
 
   timer.reset();
-  SampleOutput val_output = validate(
-      input.sampling_params, draft_block, target_output, max_val_tokens);
+  SampleOutput val_output =
+      validate(input.sampling_params,
+               draft_block,
+               target_output,
+               max_val_tokens,
+               did_prune ? per_seq_val_tokens : std::vector<int32_t>{});
   // Post-process: mask sampler output beyond each seq's prefix_len so seq
   // accepted counts respect the per-seq decision even under batch-max
   // dense rejection sampling.
   if (did_prune) {
-    // Convert per_seq_val_tokens[i] back to prefix_len[i] =
-    // per_seq_val_tokens[i]-1.
+    // effective_prefix[i] mirrors the controller's decision (0-based, clamped
+    // to [0, num_speculative_tokens]). Since per_seq_val_tokens[i] is exactly
+    // prefix_lengths[i] + 1 now (bonus slot only when prefix=0), we could
+    // equivalently write per_seq_val_tokens[i] - 1; keeping the raw
+    // prefix_lengths read here documents the semantic and stays robust if the
+    // width calculation grows another guard later.
     std::vector<int32_t> effective_prefix(batch_size);
     for (int32_t i = 0; i < batch_size; ++i) {
+      int32_t p = prefix_lengths[static_cast<size_t>(i)];
       effective_prefix[static_cast<size_t>(i)] =
-          per_seq_val_tokens[static_cast<size_t>(i)] - 1;
+          std::clamp(p, 0, options_.num_speculative_tokens());
     }
     adaptive_pruning::PrunedPrefixMasks masks =
         adaptive_pruning::build_pruned_prefix_masks(
@@ -974,7 +992,8 @@ SampleOutput DFlashWorkerImpl::validate(
     const SamplingParameters& sampling_params,
     const DraftBlock& draft_block,
     const ForwardOutput& target_output,
-    int32_t effective_val_tokens) {
+    int32_t effective_val_tokens,
+    const std::vector<int32_t>& per_seq_val_tokens) {
   // Draft already emits the whole block [batch, num_speculative_tokens]; feed
   // it straight to the verifier without the per-step select/view/cat round
   // trip. The shared rejection sampler uses MTP's dense contract, so
@@ -1007,7 +1026,8 @@ SampleOutput DFlashWorkerImpl::validate(
                   draft_token_ids,
                   draft_probs,
                   target_output,
-                  effective_val_tokens);
+                  effective_val_tokens,
+                  per_seq_val_tokens);
 }
 
 SampleOutput DFlashWorkerImpl::validate(
@@ -1015,7 +1035,8 @@ SampleOutput DFlashWorkerImpl::validate(
     const torch::Tensor& draft_token_ids,
     const torch::Tensor& draft_probs,
     const ForwardOutput& target_output,
-    int32_t effective_val_tokens) {
+    int32_t effective_val_tokens,
+    const std::vector<int32_t>& per_seq_val_tokens) {
   const int32_t num_val_tokens = effective_val_tokens;
   // Derive batch_size from the target logits rows rather than next_tokens so
   // the reshape stays valid regardless of how the target was sampled.
@@ -1030,10 +1051,35 @@ SampleOutput DFlashWorkerImpl::validate(
 
   using torch::indexing::None;
   using ISlice = torch::indexing::Slice;
-  torch::Tensor bonus_token_ids =
-      target_output.sample_output.next_tokens
-          .index({"...", ISlice(num_val_tokens - 1, None, num_val_tokens)})
-          .view({-1, 1});
+  torch::Tensor target_next_tokens_2d =
+      target_output.sample_output.next_tokens.view(
+          {batch_size, num_val_tokens});
+  torch::Tensor bonus_token_ids;
+  if (per_seq_val_tokens.empty()) {
+    // Uniform batch-max width: bonus is at the fixed last column.
+    bonus_token_ids = target_next_tokens_2d
+                          .index({ISlice(), ISlice(num_val_tokens - 1, None)})
+                          .view({-1, 1});
+  } else {
+    // Per-seq varlen: seq i's bonus lives at dense col
+    // (per_seq_val_tokens[i] - 1) because the varlen->dense scatter placed
+    // the seq's rows order-preserved at cols [0, per_seq_val_tokens[i]).
+    CHECK_EQ(static_cast<int32_t>(per_seq_val_tokens.size()), batch_size)
+        << "per_seq_val_tokens size must match validate batch";
+    std::vector<int64_t> bonus_cols(static_cast<size_t>(batch_size));
+    for (int32_t i = 0; i < batch_size; ++i) {
+      const int32_t w = per_seq_val_tokens[static_cast<size_t>(i)];
+      bonus_cols[static_cast<size_t>(i)] = std::max(w - 1, 0);
+    }
+    torch::Tensor bonus_idx =
+        torch::tensor(bonus_cols,
+                      torch::TensorOptions()
+                          .dtype(torch::kLong)
+                          .device(target_next_tokens_2d.device()))
+            .view({batch_size, 1});
+    bonus_token_ids =
+        target_next_tokens_2d.gather(/*dim=*/1, bonus_idx).view({-1, 1});
+  }
 
   torch::Tensor target_logits =
       target_output.logits.view({batch_size, num_val_tokens, vocab_size});
@@ -1437,76 +1483,6 @@ std::vector<int32_t> DFlashWorkerImpl::compute_adaptive_prefix_lengths(
   return prefix_lengths;
 }
 
-void DFlashWorkerImpl::apply_adaptive_prune_to_draft(
-    DraftBlock& draft_block,
-    const std::vector<int32_t>& prefix_lengths) {
-  const int32_t num_speculative_tokens = options_.num_speculative_tokens();
-  const int64_t batch_size = draft_block.probs.size(0);
-  CHECK_EQ(static_cast<int64_t>(prefix_lengths.size()), batch_size)
-      << "adaptive prefix_lengths size must match draft batch";
-
-  // Cheap host-side pass: compute per-seq keep_cols and the logging stats in
-  // one loop before any device work, so we can early-return when nothing gets
-  // pruned without touching the device.
-  //
-  // Preserve raw draft prob at position 0 when controller pruned to zero
-  // (`keep_cols = max(k, 1)`). If we zeroed position 0 too, the rejection
-  // sampler would see draft_prob=0 there and target/draft = +inf would
-  // unconditionally accept the token the controller wanted rejected;
-  // apply_pruned_prefix_lengths later masks the extra slot to -1 so the
-  // spurious accept never reaches the user.
-  std::vector<int32_t> keep_cols_vec(static_cast<size_t>(batch_size));
-  bool any_prune = false;
-  int64_t pruned_seqs = 0;
-  int32_t max_kept = 0;
-  int32_t sum_kept = 0;
-  for (int64_t i = 0; i < batch_size; ++i) {
-    int32_t k = prefix_lengths[static_cast<size_t>(i)];
-    k = std::clamp(k, 0, num_speculative_tokens);
-    keep_cols_vec[static_cast<size_t>(i)] = std::max(k, 1);
-    sum_kept += k;
-    if (k > max_kept) {
-      max_kept = k;
-    }
-    if (k < num_speculative_tokens) {
-      any_prune = true;
-      ++pruned_seqs;
-    }
-  }
-  if (!any_prune) {
-    return;
-  }
-
-  // draft_block.probs is a no-sync tensor produced on compute_stream_ (see
-  // run_decode_draft), so read/write ops here must be scheduled on the same
-  // stream to avoid a cross-stream data race with the draft forward.
-  c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
-
-  // Vectorised keep-mask: single H2D upload of keep_cols + broadcast lt over
-  // an arange row. Replaces the previous per-row index_put_ loop that
-  // launched `batch_size` device kernels per adaptive step.
-  torch::Tensor probs = draft_block.probs;
-  torch::Tensor keep_cols_device =
-      cpu_int_vec_to_device(keep_cols_vec, device_);
-  if (!prune_col_idx_cache_.defined() ||
-      prune_col_idx_cache_.numel() != num_speculative_tokens ||
-      prune_col_idx_cache_.device() != probs.device()) {
-    prune_col_idx_cache_ = torch::arange(
-        num_speculative_tokens,
-        torch::TensorOptions().dtype(torch::kInt).device(probs.device()));
-  }
-  torch::Tensor keep_mask =
-      prune_col_idx_cache_.unsqueeze(0).lt(keep_cols_device.unsqueeze(1));
-  probs.masked_fill_(~keep_mask, 0);
-  LOG_EVERY_N(INFO, 32) << "[dflash_dspark_adaptive] batch=" << batch_size
-                        << " pruned_seqs=" << pruned_seqs
-                        << " max_kept=" << max_kept << " avg_kept="
-                        << (batch_size > 0
-                                ? static_cast<double>(sum_kept) / batch_size
-                                : 0.0)
-                        << " of " << num_speculative_tokens;
-}
-
 void DFlashWorkerImpl::apply_per_seq_varlen_prune(
     const ForwardInput& input,
     ForwardInput& validate_input,
@@ -1561,34 +1537,69 @@ void DFlashWorkerImpl::scatter_varlen_target_output_to_dense(
   const int32_t vocab_size =
       static_cast<int32_t>(target_output.logits.size(-1));
 
+  // Pure order-preserving scatter: seq i's varlen rows [cu_offset,
+  // cu_offset + seq_tokens) map to dense cols [0, seq_tokens). Row j is the
+  // target's prediction after seeing anchor + draft[0..j-1]:
+  //   dense col 0            → predicts draft[0] (anchor row)
+  //   dense col j            → predicts draft[j] given first j accepted
+  //   dense col seq_tokens-1 → bonus (all seq_tokens-1 drafts accepted)
+  // Trailing cols [seq_tokens, max_val_tokens) stay as the caller's -inf
+  // logits / 0 tokens. This matches MTP's varlen->dense scatter exactly; the
+  // per-seq bonus therefore lands at col (seq_tokens - 1), NOT the fixed last
+  // column, so validate()/apply_pruned_prefix_lengths must read the bonus and
+  // cut position per-seq (see per_seq_val_tokens plumbing below).
+  std::vector<int64_t> src_indices_vec;
   std::vector<int64_t> dst_indices_vec;
+  src_indices_vec.reserve(static_cast<size_t>(total_tokens));
   dst_indices_vec.reserve(static_cast<size_t>(total_tokens));
+  int64_t cu_offset = 0;
   for (int32_t i = 0; i < batch_size; ++i) {
     const int32_t seq_tokens = per_seq_val_tokens[static_cast<size_t>(i)];
     for (int32_t j = 0; j < seq_tokens; ++j) {
+      src_indices_vec.push_back(cu_offset + j);
       dst_indices_vec.push_back(static_cast<int64_t>(i) * max_val_tokens + j);
     }
+    cu_offset += seq_tokens;
   }
+  torch::Tensor src_indices =
+      torch::tensor(src_indices_vec,
+                    torch::TensorOptions()
+                        .dtype(torch::kLong)
+                        .device(target_output.logits.device()));
   torch::Tensor dst_indices =
       torch::tensor(dst_indices_vec,
                     torch::TensorOptions()
                         .dtype(torch::kLong)
                         .device(target_output.logits.device()));
 
-  // Logits: pad to [B*max_val_tokens, V] filled with -inf so rejection sampler
-  // sees a strictly rejecting distribution at padded positions.
+  // Logits: pad to [B*max_val_tokens, V] filled with -inf so any col we do
+  // not explicitly write remains a strictly-rejecting distribution.
   torch::Tensor padded_logits = torch::full(
       {padded_total, vocab_size}, -1e9, target_output.logits.options());
-  padded_logits.index_copy_(/*dim=*/0, dst_indices, target_output.logits);
+  padded_logits.index_copy_(
+      /*dim=*/0,
+      dst_indices,
+      target_output.logits.index_select(/*dim=*/0, src_indices));
   target_output.logits = padded_logits;
 
-  // next_tokens: pad with zeros; apply_pruned_prefix_lengths will mask beyond
-  // per-seq prefix in the sampler output anyway.
   if (target_output.sample_output.next_tokens.defined()) {
-    torch::Tensor padded_next_tokens = torch::zeros(
-        {padded_total}, target_output.sample_output.next_tokens.options());
+    // Pad next_tokens with -1 (reject marker) rather than 0. Qwen tokenizer
+    // token id 0 is "!" — if any downstream consumer picks up a padded slot
+    // (e.g. sync_pruned_boundary_outputs reads target_next_tokens at the
+    // cut position `per_seq_val_tokens[i]-1`, which for a pruned seq is a
+    // padded slot since we only fill dense positions [0, seq_tokens-2] and
+    // move the bonus to `max_val_tokens-1`), it must not emit garbage
+    // tokens. apply_pruned_prefix_lengths downstream masks drop_mask to -1
+    // anyway, so -1 propagates cleanly through the rest of the pipeline.
+    torch::Tensor padded_next_tokens =
+        torch::full({padded_total},
+                    static_cast<int64_t>(-1),
+                    target_output.sample_output.next_tokens.options());
     padded_next_tokens.index_copy_(
-        /*dim=*/0, dst_indices, target_output.sample_output.next_tokens);
+        /*dim=*/0,
+        dst_indices,
+        target_output.sample_output.next_tokens.index_select(/*dim=*/0,
+                                                             src_indices));
     target_output.sample_output.next_tokens = padded_next_tokens;
   }
   if (target_output.sample_output.embeddings.defined()) {
@@ -1598,7 +1609,10 @@ void DFlashWorkerImpl::scatter_varlen_target_output_to_dense(
         torch::zeros({padded_total, hidden_size},
                      target_output.sample_output.embeddings.options());
     padded_embeddings.index_copy_(
-        /*dim=*/0, dst_indices, target_output.sample_output.embeddings);
+        /*dim=*/0,
+        dst_indices,
+        target_output.sample_output.embeddings.index_select(/*dim=*/0,
+                                                            src_indices));
     target_output.sample_output.embeddings = padded_embeddings;
   }
 }

--- a/xllm/core/runtime/dflash_worker_impl.cpp
+++ b/xllm/core/runtime/dflash_worker_impl.cpp
@@ -954,6 +954,12 @@ std::optional<ForwardOutput> DFlashWorkerImpl::run_validate(
   maybe_broadcast_spec_tokens(val_output.next_tokens);
   compute_stream_->synchronize();
   val_output.next_tokens = val_output.next_tokens.to(torch::kCPU);
+  // Precise adaptive-aware metrics on the already-CPU tensor: static path
+  // passes an empty per_seq_val_tokens and every row counts full width;
+  // adaptive passes the per-seq widths so padded tail slots aren't counted
+  // as rejections. Zero extra device sync — we're already on CPU.
+  record_validate_metrics(
+      val_output, did_prune ? per_seq_val_tokens : std::vector<int32_t>{});
   write_target_context_to_cache(input, val_output);
 
   if (!enable_schedule_overlap() && !driver_ && !dp_driver_) {
@@ -1591,6 +1597,66 @@ void DFlashWorkerImpl::scatter_varlen_target_output_to_dense(
         /*dim=*/0, dst_indices, target_output.sample_output.embeddings);
     target_output.sample_output.embeddings = padded_embeddings;
   }
+}
+
+void DFlashWorkerImpl::record_validate_metrics(
+    const SampleOutput& val_output,
+    const std::vector<int32_t>& per_seq_val_tokens) const {
+  if (!val_output.next_tokens.defined() || val_output.next_tokens.dim() != 2 ||
+      val_output.next_tokens.numel() == 0) {
+    return;
+  }
+  const int32_t batch_size =
+      static_cast<int32_t>(val_output.next_tokens.size(0));
+  const int32_t width = static_cast<int32_t>(val_output.next_tokens.size(1));
+  const int32_t num_speculative_tokens = options_.num_speculative_tokens();
+  if (num_speculative_tokens <= 0 || width < 2) {
+    return;
+  }
+  CHECK(val_output.next_tokens.device().is_cpu())
+      << "record_validate_metrics expects next_tokens already on CPU to avoid "
+         "a blocking device sync on the hot path";
+  const bool have_per_seq = !per_seq_val_tokens.empty();
+  if (have_per_seq) {
+    CHECK_EQ(per_seq_val_tokens.size(), static_cast<size_t>(batch_size))
+        << "per_seq_val_tokens size mismatch with next_tokens batch";
+  }
+
+  torch::Tensor next_tokens_cpu =
+      val_output.next_tokens.to(torch::kInt64).contiguous();
+  const int64_t* token_data = next_tokens_cpu.const_data_ptr<int64_t>();
+  int64_t num_draft_tokens = 0;
+  int64_t accepted_count = 0;
+  for (int32_t seq_id = 0; seq_id < batch_size; ++seq_id) {
+    // seq_width = target-side validate width for this seq (anchor + drafts).
+    // Under adaptive per-seq varlen prune it is per_seq_val_tokens[i], else
+    // the full dense width.
+    int32_t seq_width = width;
+    if (have_per_seq) {
+      seq_width = std::clamp(per_seq_val_tokens[static_cast<size_t>(seq_id)],
+                             /*lo=*/2,
+                             /*hi=*/width);
+    }
+    // Drafts attempted for this seq = seq_width - 1 (bonus column excluded).
+    const int32_t prefix_len = seq_width - 1;
+    num_draft_tokens += prefix_len;
+
+    // Count accepted drafts by walking columns [0, prefix_len) — the first
+    // -1 marks the boundary where the sampler rejected. Padding tail past
+    // prefix_len is ignored so it never counts as rejection.
+    const int64_t row_offset =
+        static_cast<int64_t>(seq_id) * static_cast<int64_t>(width);
+    int32_t emitted = 0;
+    for (int32_t token_idx = 0; token_idx < prefix_len; ++token_idx) {
+      if (token_data[row_offset + token_idx] < 0) {
+        break;
+      }
+      ++emitted;
+    }
+    accepted_count += emitted;
+  }
+  COUNTER_ADD(speculative_num_draft_tokens_total, num_draft_tokens);
+  COUNTER_ADD(speculative_num_accepted_tokens_total, accepted_count);
 }
 
 }  // namespace xllm

--- a/xllm/core/runtime/dflash_worker_impl.cpp
+++ b/xllm/core/runtime/dflash_worker_impl.cpp
@@ -784,6 +784,66 @@ void DFlashWorkerImpl::fill_validate_input_from_draft_outputs(
   record_metadata_ready_event(compute_stream, validate_input);
 }
 
+void DFlashWorkerImpl::fill_validate_input_from_draft_outputs_varlen(
+    const DraftBlock& draft_block,
+    ForwardInput& validate_input,
+    Stream& compute_stream,
+    const std::vector<int32_t>& per_seq_val_tokens) {
+  const int32_t num_speculative_tokens = options_.num_speculative_tokens();
+  const int64_t num_sequences = static_cast<int64_t>(per_seq_val_tokens.size());
+  CHECK(draft_block.token_ids.defined())
+      << "DFlash draft token_ids must be defined for varlen validate fill";
+  CHECK_EQ(draft_block.token_ids.dim(), 2);
+  CHECK_EQ(draft_block.token_ids.size(0), num_sequences);
+  CHECK_EQ(draft_block.token_ids.size(1), num_speculative_tokens);
+  CHECK(validate_input.token_ids.defined());
+  CHECK_EQ(validate_input.token_ids.dim(), 1);
+
+  const torch::TensorOptions token_options = validate_input.token_ids.options();
+  c10::StreamGuard stream_guard = compute_stream.set_stream_guard();
+  wait_metadata_ready_event(validate_input, compute_stream);
+
+  validate_input.device_tensors_ready = false;
+
+  // Compute destination offsets: seq i's draft tokens go at
+  // [cu_offset[i] + 1, cu_offset[i] + per_seq_val_tokens[i]).
+  std::vector<int64_t> dst_idx_vec;
+  std::vector<int64_t> src_idx_vec;
+  int64_t cu_offset = 0;
+  for (int64_t seq_id = 0; seq_id < num_sequences; ++seq_id) {
+    const int32_t seq_val_tokens =
+        per_seq_val_tokens[static_cast<size_t>(seq_id)];
+    for (int32_t j = 0; j < seq_val_tokens - 1; ++j) {
+      dst_idx_vec.push_back(cu_offset + 1 + j);
+      src_idx_vec.push_back(seq_id * num_speculative_tokens + j);
+    }
+    cu_offset += seq_val_tokens;
+  }
+
+  if (!dst_idx_vec.empty()) {
+    const torch::TensorOptions long_dev_opts =
+        torch::TensorOptions()
+            .dtype(torch::kLong)
+            .device(validate_input.token_ids.device());
+    torch::Tensor dst_idx = safe_to(
+        torch::tensor(dst_idx_vec, torch::TensorOptions().dtype(torch::kLong)),
+        long_dev_opts,
+        /*non_blocking=*/true);
+    torch::Tensor src_idx = safe_to(
+        torch::tensor(src_idx_vec, torch::TensorOptions().dtype(torch::kLong)),
+        long_dev_opts,
+        /*non_blocking=*/true);
+    // Flatten [B, N] -> [B*N] and gather via src_idx.
+    torch::Tensor draft_flat = draft_block.token_ids.view({-1});
+    torch::Tensor draft_selected = draft_flat.index_select(/*dim=*/0, src_idx);
+    torch::Tensor draft_tokens =
+        safe_to(draft_selected, token_options, /*non_blocking=*/true);
+    validate_input.token_ids.index_copy_(/*dim=*/0, dst_idx, draft_tokens);
+  }
+  validate_input.device_tensors_ready = true;
+  record_metadata_ready_event(compute_stream, validate_input);
+}
+
 std::optional<ForwardOutput> DFlashWorkerImpl::run_validate(
     const ForwardInput& input,
     const DraftBlock& draft_block_in,
@@ -831,9 +891,12 @@ std::optional<ForwardOutput> DFlashWorkerImpl::run_validate(
 
   if (did_prune) {
     apply_per_seq_varlen_prune(input, validate_input, per_seq_val_tokens);
+    fill_validate_input_from_draft_outputs_varlen(
+        draft_block, validate_input, *compute_stream_, per_seq_val_tokens);
+  } else {
+    fill_validate_input_from_draft_outputs(
+        draft_block, validate_input, *compute_stream_, max_val_tokens);
   }
-  fill_validate_input_from_draft_outputs(
-      draft_block, validate_input, *compute_stream_, max_val_tokens);
   ForwardOutput target_output =
       run_llm_no_sync_impl(
           *impl_, validate_input, *prepare_stream_, *compute_stream_)

--- a/xllm/core/runtime/dflash_worker_impl.cpp
+++ b/xllm/core/runtime/dflash_worker_impl.cpp
@@ -925,11 +925,16 @@ std::optional<ForwardOutput> DFlashWorkerImpl::run_validate(
       effective_prefix[static_cast<size_t>(i)] =
           per_seq_val_tokens[static_cast<size_t>(i)] - 1;
     }
+    adaptive_pruning::PrunedPrefixMasks masks =
+        adaptive_pruning::build_pruned_prefix_masks(
+            effective_prefix,
+            max_val_tokens - 1,
+            val_output.next_tokens.device());
     adaptive_pruning::apply_pruned_prefix_lengths(
         val_output,
         target_output.sample_output.next_tokens,
         max_val_tokens - 1,
-        effective_prefix);
+        masks);
   }
   COUNTER_ADD(speculative_execution_latency_seconds_validation,
               timer.elapsed_seconds());
@@ -1368,14 +1373,16 @@ std::vector<int32_t> DFlashWorkerImpl::compute_adaptive_prefix_lengths(
       !adaptive_spec_controller_->enabled()) {
     return {};
   }
-  // Prefer the trained ConfidenceHead output when present (DSpark);
-  // otherwise fall back to sampler-gathered proposal probs (DFlash / DSpark
-  // without a confidence head).
+  // Prefer the trained ConfidenceHead output when present (DSpark); otherwise
+  // fall back to sampler-gathered proposal probs (DFlash / DSpark without a
+  // confidence head).
   //
-  // Both signals are per-step conditional accept probabilities per the
-  // DSpark paper (Section 3.2.1) and the classical spec-decode setup: c_k =
-  // P(step k accepted | prefix accepted). The controller multiplies them via
-  // chain rule to obtain path probs a_{r,j} = ∏ c_i.
+  // Both signals are per-step conditional accept probabilities: c_k =
+  // P(step k accepted | prefix accepted). ConfidenceHead simply replaces
+  // proposal probs as a better-trained estimator of the same quantity. The
+  // controller chain-rule multiplies them to obtain path probs
+  // a_{r,j} = ∏ c_i (paper Section 3.2.2 Algorithm 1). Same code path for
+  // both signal sources.
   //
   // Note (DSpark v1): the ConfidenceHead is loaded from the released
   // checkpoint but is *not* STS-calibrated yet (paper Section 3.2.1 "Post-hoc
@@ -1407,24 +1414,10 @@ std::vector<int32_t> DFlashWorkerImpl::compute_adaptive_prefix_lengths(
         specBuilder::calc_kv_len(kv_seq_lens, i, /*offset=*/0));
   }
 
-  double target_step_time_ms = 1.0;
-  SpeculativeProfileRegistry& registry =
-      SpeculativeProfileRegistry::get_instance();
-  auto predictor = registry.validate_time_predictor();
-  if (predictor.has_value()) {
-    const double q = static_cast<double>(num_speculative_tokens + 1);
-    double t = predictor->intercept_ms;
-    for (double kv : per_seq_kv_lens) {
-      t += predictor->query_token_ms * q + predictor->query_prefix_ms * q * kv;
-    }
-    target_step_time_ms = std::max(t, 1.0);
-  }
-
   std::vector<int32_t> prefix_lengths =
       adaptive_spec_controller_->select_pruned_prefix_lengths(
           probs_for_controller.to(torch::kCPU).to(torch::kFloat64),
           /*full_draft_time_ms=*/0.0,
-          target_step_time_ms,
           per_seq_kv_lens);
   return prefix_lengths;
 }

--- a/xllm/core/runtime/dflash_worker_impl.cpp
+++ b/xllm/core/runtime/dflash_worker_impl.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 #include <glog/logging.h>
 
 #include <algorithm>
+#include <cstdlib>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -1257,9 +1258,23 @@ std::vector<int32_t> DFlashWorkerImpl::compute_adaptive_prefix_lengths(
   // Prefer the trained ConfidenceHead output when present (DSpark);
   // otherwise fall back to sampler-gathered proposal probs (DFlash / DSpark
   // without a confidence head).
-  torch::Tensor probs_for_controller = draft_block.confidence_probs.defined()
-                                           ? draft_block.confidence_probs
-                                           : draft_block.probs;
+  //
+  // Per the DSpark paper (Section 3.2.1), c_k is a *conditional* probability
+  // and the joint prefix survival prob is ∏ c_i — so the controller's chain
+  // rule multiplication is technically correct. In practice however our
+  // ConfidenceHead is not STS-calibrated (paper Section 3.2.1 "Post-hoc
+  // Calibration"), and empirically raw c is overconfident enough that direct
+  // multiplication crashes DSpark throughput at higher block sizes. As a
+  // stop-gap knob, DSPARK_TREAT_CONFIDENCE_AS_PATH_PROB=1 tells the
+  // controller to consume each c_k as an already-cumulative path prob (i.e.
+  // skip chain-rule multiplication for the confidence tensor).
+  const bool use_confidence = draft_block.confidence_probs.defined();
+  static const bool treat_confidence_as_path_prob = [] {
+    const char* s = std::getenv("DSPARK_TREAT_CONFIDENCE_AS_PATH_PROB");
+    return s != nullptr && std::atoi(s) != 0;
+  }();
+  torch::Tensor probs_for_controller =
+      use_confidence ? draft_block.confidence_probs : draft_block.probs;
   if (!probs_for_controller.defined()) {
     return {};
   }
@@ -1298,7 +1313,9 @@ std::vector<int32_t> DFlashWorkerImpl::compute_adaptive_prefix_lengths(
           probs_for_controller.to(torch::kCPU).to(torch::kFloat64),
           /*full_draft_time_ms=*/0.0,
           target_step_time_ms,
-          per_seq_kv_lens);
+          per_seq_kv_lens,
+          /*probs_are_path_probs=*/
+          (use_confidence && treat_confidence_as_path_prob));
   return prefix_lengths;
 }
 

--- a/xllm/core/runtime/dflash_worker_impl.cpp
+++ b/xllm/core/runtime/dflash_worker_impl.cpp
@@ -28,6 +28,7 @@ limitations under the License.
 #include "core/framework/config/kernel_config.h"
 #include "core/framework/config/scheduler_config.h"
 #include "core/framework/config/speculative_config.h"
+#include "core/framework/speculative/speculative_profile_registry.h"
 #include "framework/model/model_args.h"
 #include "framework/parallel_state/process_group.h"
 #include "framework/sampling/rejection_sampler.h"
@@ -288,6 +289,21 @@ DFlashWorkerImpl::DFlashWorkerImpl(const ParallelArgs& parallel_args,
          "parallelism (cp_size > 1).";
   draft_impl_ = std::make_unique<LLMWorkerImpl>(
       parallel_args, device, draft_options(options));
+
+  // Adaptive per-seq validate pruning. Same DP/EP-parallel guard as MTP.
+  const bool enable_adaptive = options.enable_adaptive_speculative_decode() &&
+                               options.num_speculative_tokens() > 1;
+  const bool enable_parallel_adaptive_sl =
+      parallel_args.dp_size() <= 1 && parallel_args.ep_size() <= 1;
+  if (enable_adaptive && enable_parallel_adaptive_sl) {
+    adaptive_spec_controller_ =
+        std::make_unique<AdaptiveSpeculativeController>(options);
+  } else if (enable_adaptive) {
+    LOG(WARNING) << "DFlash/DSpark adaptive speculative decode disabled under "
+                 << "DP/EP parallelism (v1). dp_size="
+                 << parallel_args.dp_size()
+                 << ", ep_size=" << parallel_args.ep_size();
+  }
 }
 
 bool DFlashWorkerImpl::init_model(const std::string& model_weights_path,
@@ -754,9 +770,20 @@ void DFlashWorkerImpl::fill_validate_input_from_draft_outputs(
 
 std::optional<ForwardOutput> DFlashWorkerImpl::run_validate(
     const ForwardInput& input,
-    const DraftBlock& draft_block,
+    const DraftBlock& draft_block_in,
     ForwardInput& validate_input) {
   Timer timer;
+  // v1 adaptive pruning: keep the dense N+1 validate layout but zero out the
+  // per-seq draft probs beyond the controller-selected prefix. The rejection
+  // sampler naturally rejects those positions (draft_prob=0), so throughput
+  // and acceptance rate reflect the controller decision without touching the
+  // chunked_prefill metadata rebuild path.
+  DraftBlock draft_block = draft_block_in;
+  std::vector<int32_t> prefix_lengths =
+      compute_adaptive_prefix_lengths(draft_block, input);
+  if (!prefix_lengths.empty()) {
+    apply_adaptive_prune_to_draft(draft_block, prefix_lengths);
+  }
   fill_validate_input_from_draft_outputs(
       draft_block, validate_input, *compute_stream_);
   ForwardOutput target_output =
@@ -1172,6 +1199,107 @@ void DFlashWorkerImpl::write_target_context_to_cache(
       validate_output.next_tokens,
       validate_output.embeddings,
       options_.num_speculative_tokens());
+}
+
+// -----------------------------------------------------------------------------
+// Adaptive-speculative helpers (DFlash + DSpark).
+// -----------------------------------------------------------------------------
+
+std::vector<int32_t> DFlashWorkerImpl::compute_adaptive_prefix_lengths(
+    const DraftBlock& draft_block,
+    const ForwardInput& input) {
+  const int32_t num_speculative_tokens = options_.num_speculative_tokens();
+  if (adaptive_spec_controller_ == nullptr ||
+      !adaptive_spec_controller_->enabled()) {
+    return {};
+  }
+  // Prefer the trained ConfidenceHead output when present (DSpark);
+  // otherwise fall back to sampler-gathered proposal probs (DFlash / DSpark
+  // without a confidence head).
+  torch::Tensor probs_for_controller = draft_block.confidence_probs.defined()
+                                           ? draft_block.confidence_probs
+                                           : draft_block.probs;
+  if (!probs_for_controller.defined()) {
+    return {};
+  }
+  if (probs_for_controller.dim() != 2 ||
+      probs_for_controller.size(1) != num_speculative_tokens) {
+    LOG(WARNING) << "Adaptive: unexpected probs shape "
+                 << probs_for_controller.sizes()
+                 << " — falling back to full width.";
+    return {};
+  }
+
+  const int32_t batch_size = input.input_params.meta.num_sequences;
+  std::vector<double> per_seq_kv_lens(static_cast<size_t>(batch_size), 0.0);
+  const Slice<int32_t> kv_seq_lens =
+      input.input_params.attention.host.kv_seq_lens;
+  for (int32_t i = 0; i < batch_size; ++i) {
+    per_seq_kv_lens[static_cast<size_t>(i)] = static_cast<double>(
+        specBuilder::calc_kv_len(kv_seq_lens, i, /*offset=*/0));
+  }
+
+  double target_step_time_ms = 1.0;
+  SpeculativeProfileRegistry& registry =
+      SpeculativeProfileRegistry::get_instance();
+  auto predictor = registry.validate_time_predictor();
+  if (predictor.has_value()) {
+    const double q = static_cast<double>(num_speculative_tokens + 1);
+    double t = predictor->intercept_ms;
+    for (double kv : per_seq_kv_lens) {
+      t += predictor->query_token_ms * q + predictor->query_prefix_ms * q * kv;
+    }
+    target_step_time_ms = std::max(t, 1.0);
+  }
+
+  std::vector<int32_t> prefix_lengths =
+      adaptive_spec_controller_->select_pruned_prefix_lengths(
+          probs_for_controller.to(torch::kCPU).to(torch::kFloat64),
+          /*full_draft_time_ms=*/0.0,
+          target_step_time_ms,
+          per_seq_kv_lens);
+  return prefix_lengths;
+}
+
+void DFlashWorkerImpl::apply_adaptive_prune_to_draft(
+    DraftBlock& draft_block,
+    const std::vector<int32_t>& prefix_lengths) {
+  const int32_t num_speculative_tokens = options_.num_speculative_tokens();
+  const int64_t batch_size = draft_block.probs.size(0);
+  CHECK_EQ(static_cast<int64_t>(prefix_lengths.size()), batch_size)
+      << "adaptive prefix_lengths size must match draft batch";
+
+  // Build a [B, N] mask on the same device/dtype as probs.
+  torch::Tensor probs = draft_block.probs;
+  torch::Tensor mask = torch::zeros_like(probs);
+  bool any_prune = false;
+  bool trace_first = false;
+  int64_t pruned_seqs = 0;
+  int32_t max_kept = 0;
+  int32_t sum_kept = 0;
+  for (int64_t i = 0; i < batch_size; ++i) {
+    int32_t k = prefix_lengths[static_cast<size_t>(i)];
+    k = std::clamp(k, 0, num_speculative_tokens);
+    if (k > 0) {
+      mask.index_put_({i, torch::indexing::Slice(0, k)}, 1.0);
+    }
+    sum_kept += k;
+    if (k > max_kept) max_kept = k;
+    if (k < num_speculative_tokens) {
+      any_prune = true;
+      ++pruned_seqs;
+    }
+    if (!trace_first) trace_first = true;
+  }
+  if (!any_prune) return;
+  draft_block.probs = probs * mask;
+  LOG_EVERY_N(INFO, 32) << "[dflash_dspark_adaptive] batch=" << batch_size
+                        << " pruned_seqs=" << pruned_seqs
+                        << " max_kept=" << max_kept << " avg_kept="
+                        << (batch_size > 0
+                                ? static_cast<double>(sum_kept) / batch_size
+                                : 0.0)
+                        << " of " << num_speculative_tokens;
 }
 
 }  // namespace xllm

--- a/xllm/core/runtime/dflash_worker_impl.cpp
+++ b/xllm/core/runtime/dflash_worker_impl.cpp
@@ -29,6 +29,7 @@ limitations under the License.
 #include "core/framework/config/kernel_config.h"
 #include "core/framework/config/scheduler_config.h"
 #include "core/framework/config/speculative_config.h"
+#include "core/framework/speculative/adaptive_pruning_helpers.h"
 #include "core/framework/speculative/speculative_profile_registry.h"
 #include "framework/model/model_args.h"
 #include "framework/parallel_state/process_group.h"
@@ -788,26 +789,51 @@ std::optional<ForwardOutput> DFlashWorkerImpl::run_validate(
     const DraftBlock& draft_block_in,
     ForwardInput& validate_input) {
   Timer timer;
-  // Adaptive-speculative hard batch-max pruning:
+  // Adaptive-speculative per-seq varlen validate:
   // 1. controller decides per-seq prefix_lengths from confidence/proposal
   //    probs.
-  // 2. we shrink the target validate width to max(prefix_lengths)+1 and
-  //    rebuild the dense validate_input at that width — target forward truly
-  //    consumes less compute for pruned steps.
-  // 3. we still soft-mask draft probs beyond each seq's prefix_len so the
-  //    rejection sampler only accepts draft tokens the controller endorsed
-  //    (per-seq granularity within the batch-max window).
+  // 2. we rebuild validate_input as a *true varlen* [Σ (prefix_i+1), ...]
+  //    batch — target forward runs only Σ (prefix_i+1) tokens, so batches with
+  //    even a single high-confidence seq do not force the whole batch to full
+  //    N+1 width (the batch-max regression from v1). MTP already scatters
+  //    varlen target output back into padded dense before rejection sampling
+  //    — we do the same here.
+  // 3. rejection sampler is dense-only; scatter varlen target output into
+  //    [B, N+1, ...] with -inf at padded positions.
+  // 4. apply_pruned_prefix_lengths clips the sampler output at each seq's
+  //    prefix_len so the accepted_token_ids beyond prefix_i become -1.
+  const int32_t num_speculative_tokens = options_.num_speculative_tokens();
+  const int32_t default_val_tokens = num_speculative_tokens + 1;
+  const int32_t batch_size = input.input_params.meta.num_sequences;
+
   DraftBlock draft_block = draft_block_in;
   std::vector<int32_t> prefix_lengths =
       compute_adaptive_prefix_lengths(draft_block, input);
-  int32_t effective_val_tokens = options_.num_speculative_tokens() + 1;
+  std::vector<int32_t> per_seq_val_tokens;
+  bool did_prune = false;
+  int32_t max_val_tokens = default_val_tokens;
   if (!prefix_lengths.empty()) {
     apply_adaptive_prune_to_draft(draft_block, prefix_lengths);
-    effective_val_tokens =
-        apply_batch_max_hard_prune(input, validate_input, prefix_lengths);
+    per_seq_val_tokens.resize(batch_size);
+    max_val_tokens = 0;
+    for (int32_t i = 0; i < batch_size; ++i) {
+      int32_t p = std::clamp(prefix_lengths[static_cast<size_t>(i)],
+                             /*min=*/0,
+                             /*max=*/num_speculative_tokens);
+      // Require at least one draft slot beyond the anchor so the rejection
+      // sampler always sees a non-empty per-seq block.
+      int32_t width = std::max(p + 1, 2);
+      per_seq_val_tokens[static_cast<size_t>(i)] = width;
+      max_val_tokens = std::max(max_val_tokens, width);
+      if (width < default_val_tokens) did_prune = true;
+    }
+  }
+
+  if (did_prune) {
+    apply_per_seq_varlen_prune(input, validate_input, per_seq_val_tokens);
   }
   fill_validate_input_from_draft_outputs(
-      draft_block, validate_input, *compute_stream_, effective_val_tokens);
+      draft_block, validate_input, *compute_stream_, max_val_tokens);
   ForwardOutput target_output =
       run_llm_no_sync_impl(
           *impl_, validate_input, *prepare_stream_, *compute_stream_)
@@ -815,9 +841,33 @@ std::optional<ForwardOutput> DFlashWorkerImpl::run_validate(
   COUNTER_ADD(speculative_execution_latency_seconds_target,
               timer.elapsed_seconds());
 
+  // Scatter varlen target output back to dense [B, max_val_tokens] layout so
+  // the rejection sampler (dense API) can consume it.
+  if (did_prune) {
+    scatter_varlen_target_output_to_dense(
+        target_output, per_seq_val_tokens, batch_size, max_val_tokens);
+  }
+
   timer.reset();
   SampleOutput val_output = validate(
-      input.sampling_params, draft_block, target_output, effective_val_tokens);
+      input.sampling_params, draft_block, target_output, max_val_tokens);
+  // Post-process: mask sampler output beyond each seq's prefix_len so seq
+  // accepted counts respect the per-seq decision even under batch-max
+  // dense rejection sampling.
+  if (did_prune) {
+    // Convert per_seq_val_tokens[i] back to prefix_len[i] =
+    // per_seq_val_tokens[i]-1.
+    std::vector<int32_t> effective_prefix(batch_size);
+    for (int32_t i = 0; i < batch_size; ++i) {
+      effective_prefix[static_cast<size_t>(i)] =
+          per_seq_val_tokens[static_cast<size_t>(i)] - 1;
+    }
+    adaptive_pruning::apply_pruned_prefix_lengths(
+        val_output,
+        target_output.sample_output.next_tokens,
+        max_val_tokens - 1,
+        effective_prefix);
+  }
   COUNTER_ADD(speculative_execution_latency_seconds_validation,
               timer.elapsed_seconds());
 
@@ -1402,6 +1452,102 @@ int32_t DFlashWorkerImpl::apply_batch_max_hard_prune(
                         << effective_val_tokens_clamped << " (was "
                         << default_val_tokens << ")";
   return effective_val_tokens_clamped;
+}
+
+void DFlashWorkerImpl::apply_per_seq_varlen_prune(
+    const ForwardInput& input,
+    ForwardInput& validate_input,
+    const std::vector<int32_t>& per_seq_val_tokens) {
+  const int32_t num_sequences = input.input_params.meta.num_sequences;
+  CHECK_EQ(static_cast<int32_t>(per_seq_val_tokens.size()), num_sequences);
+  c10::StreamGuard stream_guard = prepare_stream_->set_stream_guard();
+  ForwardInput prepared_input = input;
+  prepared_input.metadata_ready_event.reset();
+  ForwardInput new_validate;
+  SpeculativeWorkerImpl::prepare_validate_inputs(
+      prepared_input, new_validate, per_seq_val_tokens);
+  new_validate.input_params.embedding.input_embedding = torch::Tensor();
+  record_metadata_ready_event(*prepare_stream_, new_validate);
+  validate_input = std::move(new_validate);
+
+  int32_t max_w = 0;
+  int32_t total_w = 0;
+  int32_t sum_kept_below_default = 0;
+  int32_t default_val_tokens = options_.num_speculative_tokens() + 1;
+  int32_t pruned_seqs = 0;
+  for (int32_t v : per_seq_val_tokens) {
+    max_w = std::max(max_w, v);
+    total_w += v;
+    if (v < default_val_tokens) {
+      ++pruned_seqs;
+      sum_kept_below_default += v;
+    }
+  }
+  LOG_EVERY_N(INFO, 32) << "[dflash_dspark_varlen_prune] batch="
+                        << num_sequences << " total_val_tokens=" << total_w
+                        << " max_val_tokens=" << max_w << " (was "
+                        << (num_sequences * default_val_tokens) << ")"
+                        << " pruned_seqs=" << pruned_seqs;
+}
+
+void DFlashWorkerImpl::scatter_varlen_target_output_to_dense(
+    ForwardOutput& target_output,
+    const std::vector<int32_t>& per_seq_val_tokens,
+    int32_t batch_size,
+    int32_t max_val_tokens) {
+  CHECK(target_output.logits.defined())
+      << "target logits must be defined for varlen->dense scatter";
+  const int32_t total_tokens =
+      static_cast<int32_t>(target_output.logits.size(0));
+  const int64_t padded_total =
+      static_cast<int64_t>(batch_size) * max_val_tokens;
+  if (total_tokens == static_cast<int32_t>(padded_total)) {
+    // Already uniform max width; no scatter needed.
+    return;
+  }
+  const int32_t vocab_size =
+      static_cast<int32_t>(target_output.logits.size(-1));
+
+  std::vector<int64_t> dst_indices_vec;
+  dst_indices_vec.reserve(static_cast<size_t>(total_tokens));
+  for (int32_t i = 0; i < batch_size; ++i) {
+    const int32_t seq_tokens = per_seq_val_tokens[static_cast<size_t>(i)];
+    for (int32_t j = 0; j < seq_tokens; ++j) {
+      dst_indices_vec.push_back(static_cast<int64_t>(i) * max_val_tokens + j);
+    }
+  }
+  torch::Tensor dst_indices =
+      torch::tensor(dst_indices_vec,
+                    torch::TensorOptions()
+                        .dtype(torch::kLong)
+                        .device(target_output.logits.device()));
+
+  // Logits: pad to [B*max_val_tokens, V] filled with -inf so rejection sampler
+  // sees a strictly rejecting distribution at padded positions.
+  torch::Tensor padded_logits = torch::full(
+      {padded_total, vocab_size}, -1e9, target_output.logits.options());
+  padded_logits.index_copy_(/*dim=*/0, dst_indices, target_output.logits);
+  target_output.logits = padded_logits;
+
+  // next_tokens: pad with zeros; apply_pruned_prefix_lengths will mask beyond
+  // per-seq prefix in the sampler output anyway.
+  if (target_output.sample_output.next_tokens.defined()) {
+    torch::Tensor padded_next_tokens = torch::zeros(
+        {padded_total}, target_output.sample_output.next_tokens.options());
+    padded_next_tokens.index_copy_(
+        /*dim=*/0, dst_indices, target_output.sample_output.next_tokens);
+    target_output.sample_output.next_tokens = padded_next_tokens;
+  }
+  if (target_output.sample_output.embeddings.defined()) {
+    const int32_t hidden_size =
+        static_cast<int32_t>(target_output.sample_output.embeddings.size(-1));
+    torch::Tensor padded_embeddings =
+        torch::zeros({padded_total, hidden_size},
+                     target_output.sample_output.embeddings.options());
+    padded_embeddings.index_copy_(
+        /*dim=*/0, dst_indices, target_output.sample_output.embeddings);
+    target_output.sample_output.embeddings = padded_embeddings;
+  }
 }
 
 }  // namespace xllm

--- a/xllm/core/runtime/dflash_worker_impl.cpp
+++ b/xllm/core/runtime/dflash_worker_impl.cpp
@@ -1259,22 +1259,21 @@ std::vector<int32_t> DFlashWorkerImpl::compute_adaptive_prefix_lengths(
   // otherwise fall back to sampler-gathered proposal probs (DFlash / DSpark
   // without a confidence head).
   //
-  // Per the DSpark paper (Section 3.2.1), c_k is a *conditional* probability
-  // and the joint prefix survival prob is ∏ c_i — so the controller's chain
-  // rule multiplication is technically correct. In practice however our
-  // ConfidenceHead is not STS-calibrated (paper Section 3.2.1 "Post-hoc
-  // Calibration"), and empirically raw c is overconfident enough that direct
-  // multiplication crashes DSpark throughput at higher block sizes. As a
-  // stop-gap knob, DSPARK_TREAT_CONFIDENCE_AS_PATH_PROB=1 tells the
-  // controller to consume each c_k as an already-cumulative path prob (i.e.
-  // skip chain-rule multiplication for the confidence tensor).
-  const bool use_confidence = draft_block.confidence_probs.defined();
-  static const bool treat_confidence_as_path_prob = [] {
-    const char* s = std::getenv("DSPARK_TREAT_CONFIDENCE_AS_PATH_PROB");
-    return s != nullptr && std::atoi(s) != 0;
-  }();
-  torch::Tensor probs_for_controller =
-      use_confidence ? draft_block.confidence_probs : draft_block.probs;
+  // Both signals are per-step conditional accept probabilities per the
+  // DSpark paper (Section 3.2.1) and the classical spec-decode setup: c_k =
+  // P(step k accepted | prefix accepted). The controller multiplies them via
+  // chain rule to obtain path probs a_{r,j} = ∏ c_i.
+  //
+  // Note (DSpark v1): the ConfidenceHead is loaded from the released
+  // checkpoint but is *not* STS-calibrated yet (paper Section 3.2.1 "Post-hoc
+  // Calibration"). Raw sigmoid confidence is overconfident, so the cumulative
+  // product decays incorrectly at longer block sizes and can over-prune.
+  // DSPARK_CONFIDENCE_TEMPERATURE (see qwen3_dspark.h) offers a single
+  // temperature knob to approximate STS until we ship a proper offline
+  // per-position calibration table.
+  torch::Tensor probs_for_controller = draft_block.confidence_probs.defined()
+                                           ? draft_block.confidence_probs
+                                           : draft_block.probs;
   if (!probs_for_controller.defined()) {
     return {};
   }
@@ -1313,9 +1312,7 @@ std::vector<int32_t> DFlashWorkerImpl::compute_adaptive_prefix_lengths(
           probs_for_controller.to(torch::kCPU).to(torch::kFloat64),
           /*full_draft_time_ms=*/0.0,
           target_step_time_ms,
-          per_seq_kv_lens,
-          /*probs_are_path_probs=*/
-          (use_confidence && treat_confidence_as_path_prob));
+          per_seq_kv_lens);
   return prefix_lengths;
 }
 
@@ -1327,11 +1324,15 @@ void DFlashWorkerImpl::apply_adaptive_prune_to_draft(
   CHECK_EQ(static_cast<int64_t>(prefix_lengths.size()), batch_size)
       << "adaptive prefix_lengths size must match draft batch";
 
+  // draft_block.probs is a no-sync tensor produced on compute_stream_ (see
+  // run_decode_draft), so read/write ops here must be scheduled on the same
+  // stream to avoid a cross-stream data race with the draft forward.
+  c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
+
   // Build a [B, N] mask on the same device/dtype as probs.
   torch::Tensor probs = draft_block.probs;
   torch::Tensor mask = torch::zeros_like(probs);
   bool any_prune = false;
-  bool trace_first = false;
   int64_t pruned_seqs = 0;
   int32_t max_kept = 0;
   int32_t sum_kept = 0;
@@ -1347,7 +1348,6 @@ void DFlashWorkerImpl::apply_adaptive_prune_to_draft(
       any_prune = true;
       ++pruned_seqs;
     }
-    if (!trace_first) trace_first = true;
   }
   if (!any_prune) return;
   draft_block.probs = probs * mask;

--- a/xllm/core/runtime/dflash_worker_impl.cpp
+++ b/xllm/core/runtime/dflash_worker_impl.cpp
@@ -885,7 +885,9 @@ std::optional<ForwardOutput> DFlashWorkerImpl::run_validate(
       int32_t width = std::max(p + 1, 2);
       per_seq_val_tokens[static_cast<size_t>(i)] = width;
       max_val_tokens = std::max(max_val_tokens, width);
-      if (width < default_val_tokens) did_prune = true;
+      if (width < default_val_tokens) {
+        did_prune = true;
+      }
     }
   }
 
@@ -930,6 +932,13 @@ std::optional<ForwardOutput> DFlashWorkerImpl::run_validate(
             effective_prefix,
             max_val_tokens - 1,
             val_output.next_tokens.device());
+    // Sync logprob/top-logprob at each seq's cut position with the target's
+    // resampled token (paper Section 3.2: cut-position token switches from
+    // the rejected draft to a target resample; its logprob has to switch
+    // too). Skipping this leaves logprobs pointing at the draft token when
+    // logprobs=true in the sampling request.
+    adaptive_pruning::sync_pruned_boundary_outputs(
+        val_output, target_output, batch_size, max_val_tokens, masks);
     adaptive_pruning::apply_pruned_prefix_lengths(
         val_output,
         target_output.sample_output.next_tokens,
@@ -1430,14 +1439,17 @@ void DFlashWorkerImpl::apply_adaptive_prune_to_draft(
   CHECK_EQ(static_cast<int64_t>(prefix_lengths.size()), batch_size)
       << "adaptive prefix_lengths size must match draft batch";
 
-  // draft_block.probs is a no-sync tensor produced on compute_stream_ (see
-  // run_decode_draft), so read/write ops here must be scheduled on the same
-  // stream to avoid a cross-stream data race with the draft forward.
-  c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
-
-  // Build a [B, N] mask on the same device/dtype as probs.
-  torch::Tensor probs = draft_block.probs;
-  torch::Tensor mask = torch::zeros_like(probs);
+  // Cheap host-side pass: compute per-seq keep_cols and the logging stats in
+  // one loop before any device work, so we can early-return when nothing gets
+  // pruned without touching the device.
+  //
+  // Preserve raw draft prob at position 0 when controller pruned to zero
+  // (`keep_cols = max(k, 1)`). If we zeroed position 0 too, the rejection
+  // sampler would see draft_prob=0 there and target/draft = +inf would
+  // unconditionally accept the token the controller wanted rejected;
+  // apply_pruned_prefix_lengths later masks the extra slot to -1 so the
+  // spurious accept never reaches the user.
+  std::vector<int32_t> keep_cols_vec(static_cast<size_t>(batch_size));
   bool any_prune = false;
   int64_t pruned_seqs = 0;
   int32_t max_kept = 0;
@@ -1445,18 +1457,37 @@ void DFlashWorkerImpl::apply_adaptive_prune_to_draft(
   for (int64_t i = 0; i < batch_size; ++i) {
     int32_t k = prefix_lengths[static_cast<size_t>(i)];
     k = std::clamp(k, 0, num_speculative_tokens);
-    if (k > 0) {
-      mask.index_put_({i, torch::indexing::Slice(0, k)}, 1.0);
-    }
+    keep_cols_vec[static_cast<size_t>(i)] = std::max(k, 1);
     sum_kept += k;
-    if (k > max_kept) max_kept = k;
+    if (k > max_kept) {
+      max_kept = k;
+    }
     if (k < num_speculative_tokens) {
       any_prune = true;
       ++pruned_seqs;
     }
   }
-  if (!any_prune) return;
-  draft_block.probs = probs * mask;
+  if (!any_prune) {
+    return;
+  }
+
+  // draft_block.probs is a no-sync tensor produced on compute_stream_ (see
+  // run_decode_draft), so read/write ops here must be scheduled on the same
+  // stream to avoid a cross-stream data race with the draft forward.
+  c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
+
+  // Vectorised keep-mask: single H2D upload of keep_cols + broadcast lt over
+  // an arange row. Replaces the previous per-row index_put_ loop that
+  // launched `batch_size` device kernels per adaptive step.
+  torch::Tensor probs = draft_block.probs;
+  torch::Tensor keep_cols_device =
+      cpu_int_vec_to_device(keep_cols_vec, device_);
+  torch::Tensor col_idx = torch::arange(
+      num_speculative_tokens,
+      torch::TensorOptions().dtype(torch::kInt).device(probs.device()));
+  torch::Tensor keep_mask =
+      col_idx.unsqueeze(0).lt(keep_cols_device.unsqueeze(1));
+  probs.masked_fill_(~keep_mask, 0);
   LOG_EVERY_N(INFO, 32) << "[dflash_dspark_adaptive] batch=" << batch_size
                         << " pruned_seqs=" << pruned_seqs
                         << " max_kept=" << max_kept << " avg_kept="
@@ -1464,50 +1495,6 @@ void DFlashWorkerImpl::apply_adaptive_prune_to_draft(
                                 ? static_cast<double>(sum_kept) / batch_size
                                 : 0.0)
                         << " of " << num_speculative_tokens;
-}
-
-int32_t DFlashWorkerImpl::apply_batch_max_hard_prune(
-    const ForwardInput& input,
-    ForwardInput& validate_input,
-    const std::vector<int32_t>& prefix_lengths) {
-  const int32_t num_speculative_tokens = options_.num_speculative_tokens();
-  const int32_t default_val_tokens = num_speculative_tokens + 1;
-  if (prefix_lengths.empty()) return default_val_tokens;
-  int32_t max_prefix = 0;
-  for (int32_t p : prefix_lengths) {
-    max_prefix = std::max(max_prefix, std::clamp(p, 0, num_speculative_tokens));
-  }
-  const int32_t effective_val_tokens = max_prefix + 1;
-  // Guard: rejection sampler / validate pipeline needs at least one draft
-  // slot beyond the anchor. If controller says "prune all", keep 1 draft so
-  // static-like acceptance can still happen this step.
-  const int32_t effective_val_tokens_clamped =
-      std::max(effective_val_tokens, 2);
-  if (effective_val_tokens_clamped >= default_val_tokens)
-    return default_val_tokens;
-
-  // Rebuild validate_input as a dense per-seq width == effective_val_tokens by
-  // reusing the per-seq varlen builder with a uniform width. Because every
-  // entry equals effective_val_tokens, the resulting layout is dense but with
-  // a narrower target-forward block, so target compute drops linearly with
-  // (default - effective) / default.
-  const int32_t num_sequences = input.input_params.meta.num_sequences;
-  std::vector<int32_t> uniform_widths(static_cast<size_t>(num_sequences),
-                                      effective_val_tokens_clamped);
-  c10::StreamGuard stream_guard = prepare_stream_->set_stream_guard();
-  ForwardInput prepared_input = input;
-  prepared_input.metadata_ready_event.reset();
-  ForwardInput new_validate;
-  SpeculativeWorkerImpl::prepare_validate_inputs(
-      prepared_input, new_validate, uniform_widths);
-  new_validate.input_params.embedding.input_embedding = torch::Tensor();
-  record_metadata_ready_event(*prepare_stream_, new_validate);
-  validate_input = std::move(new_validate);
-  LOG_EVERY_N(INFO, 32) << "[dflash_dspark_hard_prune] batch=" << num_sequences
-                        << " effective_val_tokens="
-                        << effective_val_tokens_clamped << " (was "
-                        << default_val_tokens << ")";
-  return effective_val_tokens_clamped;
 }
 
 void DFlashWorkerImpl::apply_per_seq_varlen_prune(

--- a/xllm/core/runtime/dflash_worker_impl.h
+++ b/xllm/core/runtime/dflash_worker_impl.h
@@ -140,15 +140,6 @@ class DFlashWorkerImpl : public SpeculativeWorkerImpl {
       DraftBlock& draft_block,
       const std::vector<int32_t>& prefix_lengths);
 
-  // Hard batch-max prune: shrink validate_input's dense per-seq width from
-  // (num_speculative_tokens + 1) to effective_val_tokens = max(prefix)+1 so
-  // the target forward truly runs a narrower block. Returns
-  // effective_val_tokens; equals the default when no shrink happens.
-  int32_t apply_batch_max_hard_prune(
-      const ForwardInput& input,
-      ForwardInput& validate_input,
-      const std::vector<int32_t>& prefix_lengths);
-
   // Per-seq varlen prune: rebuild validate_input as a true varlen
   // [Σ per_seq_val_tokens[i], ...] batch so target forward only spends
   // compute on tokens each seq's prefix_len actually needs. Reuses the base

--- a/xllm/core/runtime/dflash_worker_impl.h
+++ b/xllm/core/runtime/dflash_worker_impl.h
@@ -159,6 +159,15 @@ class DFlashWorkerImpl : public SpeculativeWorkerImpl {
       int32_t batch_size,
       int32_t max_val_tokens);
 
+  // Record precise (draft, accepted) counters. Padded -1 slots at positions
+  // past per_seq_val_tokens[i]-1 are excluded — the count only walks each
+  // row up to its per-seq width. Passing an empty vector treats every row
+  // as full width (static). Caller must ensure val_output.next_tokens is on
+  // CPU (avoids a blocking device sync on the hot path).
+  void record_validate_metrics(
+      const SampleOutput& val_output,
+      const std::vector<int32_t>& per_seq_val_tokens) const;
+
   void process_draft_sample_output(SampleOutput& sample_output);
 
   // Mirrors sampled tokens to rank 0 under schedule-overlap so every rank

--- a/xllm/core/runtime/dflash_worker_impl.h
+++ b/xllm/core/runtime/dflash_worker_impl.h
@@ -112,16 +112,23 @@ class DFlashWorkerImpl : public SpeculativeWorkerImpl {
                                             const DraftBlock& draft_block,
                                             ForwardInput& validate_input);
 
+  // `per_seq_val_tokens` (optional): when non-empty, the target output was
+  // scattered from a per-seq varlen batch and each seq's bonus lives at
+  // dense col (per_seq_val_tokens[i] - 1), not the fixed last column. Passing
+  // it lets validate() gather the bonus token per-seq. Empty = uniform
+  // batch-max width (bonus at col effective_val_tokens - 1 for every seq).
   SampleOutput validate(const SamplingParameters& sampling_params,
                         const DraftBlock& draft_block,
                         const ForwardOutput& target_output,
-                        int32_t effective_val_tokens);
+                        int32_t effective_val_tokens,
+                        const std::vector<int32_t>& per_seq_val_tokens);
 
   SampleOutput validate(const SamplingParameters& sampling_params,
                         const torch::Tensor& draft_token_ids,
                         const torch::Tensor& draft_probs,
                         const ForwardOutput& target_output,
-                        int32_t effective_val_tokens);
+                        int32_t effective_val_tokens,
+                        const std::vector<int32_t>& per_seq_val_tokens);
 
   // Adaptive-speculative helper: run controller on draft acceptance
   // probabilities (ConfidenceHead output if available, sampler-gathered probs
@@ -133,13 +140,6 @@ class DFlashWorkerImpl : public SpeculativeWorkerImpl {
       const ForwardInput& input);
 
   // Zero out draft probs beyond each sequence's prefix_len so the rejection
-  // sampler naturally rejects those draft tokens.
-  // draft_block is modified in place. Called only when adaptive is enabled
-  // and controller produced non-uniform prefixes.
-  void apply_adaptive_prune_to_draft(
-      DraftBlock& draft_block,
-      const std::vector<int32_t>& prefix_lengths);
-
   // Per-seq varlen prune: rebuild validate_input as a true varlen
   // [Σ per_seq_val_tokens[i], ...] batch so target forward only spends
   // compute on tokens each seq's prefix_len actually needs. Reuses the base
@@ -194,12 +194,6 @@ class DFlashWorkerImpl : public SpeculativeWorkerImpl {
 #endif
   int32_t mask_token_id_ = -1;
   int64_t expected_context_hidden_size_ = 0;
-
-  // Cached device tensor holding [0, 1, ..., num_speculative_tokens-1] as
-  // int32. apply_adaptive_prune_to_draft broadcasts this against a per-seq
-  // keep_cols vector every adaptive step; hoisting the arange out of the hot
-  // path saves an allocation + H2D per step.
-  mutable torch::Tensor prune_col_idx_cache_;
 };
 
 }  // namespace xllm

--- a/xllm/core/runtime/dflash_worker_impl.h
+++ b/xllm/core/runtime/dflash_worker_impl.h
@@ -149,16 +149,6 @@ class DFlashWorkerImpl : public SpeculativeWorkerImpl {
       ForwardInput& validate_input,
       const std::vector<int32_t>& per_seq_val_tokens);
 
-  // After target forward on a varlen validate_input, scatter the flat
-  // [Σ per_seq_val_tokens, V] logits into a padded [B, max_val_tokens, V]
-  // layout so the dense rejection sampler API can consume it. Padded
-  // positions are filled with -inf on logits and 0 on next_tokens/embeddings.
-  void scatter_varlen_target_output_to_dense(
-      ForwardOutput& target_output,
-      const std::vector<int32_t>& per_seq_val_tokens,
-      int32_t batch_size,
-      int32_t max_val_tokens);
-
   // Record precise (draft, accepted) counters. Padded -1 slots at positions
   // past per_seq_val_tokens[i]-1 are excluded — the count only walks each
   // row up to its per-seq width. Passing an empty vector treats every row

--- a/xllm/core/runtime/dflash_worker_impl.h
+++ b/xllm/core/runtime/dflash_worker_impl.h
@@ -140,6 +140,25 @@ class DFlashWorkerImpl : public SpeculativeWorkerImpl {
       ForwardInput& validate_input,
       const std::vector<int32_t>& prefix_lengths);
 
+  // Per-seq varlen prune: rebuild validate_input as a true varlen
+  // [Σ per_seq_val_tokens[i], ...] batch so target forward only spends
+  // compute on tokens each seq's prefix_len actually needs. Reuses the base
+  // SpeculativeWorkerImpl per-seq builder.
+  void apply_per_seq_varlen_prune(
+      const ForwardInput& input,
+      ForwardInput& validate_input,
+      const std::vector<int32_t>& per_seq_val_tokens);
+
+  // After target forward on a varlen validate_input, scatter the flat
+  // [Σ per_seq_val_tokens, V] logits into a padded [B, max_val_tokens, V]
+  // layout so the dense rejection sampler API can consume it. Padded
+  // positions are filled with -inf on logits and 0 on next_tokens/embeddings.
+  void scatter_varlen_target_output_to_dense(
+      ForwardOutput& target_output,
+      const std::vector<int32_t>& per_seq_val_tokens,
+      int32_t batch_size,
+      int32_t max_val_tokens);
+
   void process_draft_sample_output(SampleOutput& sample_output);
 
   // Mirrors sampled tokens to rank 0 under schedule-overlap so every rank

--- a/xllm/core/runtime/dflash_worker_impl.h
+++ b/xllm/core/runtime/dflash_worker_impl.h
@@ -194,6 +194,12 @@ class DFlashWorkerImpl : public SpeculativeWorkerImpl {
 #endif
   int32_t mask_token_id_ = -1;
   int64_t expected_context_hidden_size_ = 0;
+
+  // Cached device tensor holding [0, 1, ..., num_speculative_tokens-1] as
+  // int32. apply_adaptive_prune_to_draft broadcasts this against a per-seq
+  // keep_cols vector every adaptive step; hoisting the arange out of the hot
+  // path saves an allocation + H2D per step.
+  mutable torch::Tensor prune_col_idx_cache_;
 };
 
 }  // namespace xllm

--- a/xllm/core/runtime/dflash_worker_impl.h
+++ b/xllm/core/runtime/dflash_worker_impl.h
@@ -96,7 +96,8 @@ class DFlashWorkerImpl : public SpeculativeWorkerImpl {
  private:
   void fill_validate_input_from_draft_outputs(const DraftBlock& draft_block,
                                               ForwardInput& validate_input,
-                                              Stream& compute_stream);
+                                              Stream& compute_stream,
+                                              int32_t effective_val_tokens);
 
   std::optional<ForwardOutput> run_validate(const ForwardInput& input,
                                             const DraftBlock& draft_block,
@@ -104,12 +105,14 @@ class DFlashWorkerImpl : public SpeculativeWorkerImpl {
 
   SampleOutput validate(const SamplingParameters& sampling_params,
                         const DraftBlock& draft_block,
-                        const ForwardOutput& target_output);
+                        const ForwardOutput& target_output,
+                        int32_t effective_val_tokens);
 
   SampleOutput validate(const SamplingParameters& sampling_params,
                         const torch::Tensor& draft_token_ids,
                         const torch::Tensor& draft_probs,
-                        const ForwardOutput& target_output);
+                        const ForwardOutput& target_output,
+                        int32_t effective_val_tokens);
 
   // Adaptive-speculative helper: run controller on draft acceptance
   // probabilities (ConfidenceHead output if available, sampler-gathered probs
@@ -126,6 +129,15 @@ class DFlashWorkerImpl : public SpeculativeWorkerImpl {
   // and controller produced non-uniform prefixes.
   void apply_adaptive_prune_to_draft(
       DraftBlock& draft_block,
+      const std::vector<int32_t>& prefix_lengths);
+
+  // Hard batch-max prune: shrink validate_input's dense per-seq width from
+  // (num_speculative_tokens + 1) to effective_val_tokens = max(prefix)+1 so
+  // the target forward truly runs a narrower block. Returns
+  // effective_val_tokens; equals the default when no shrink happens.
+  int32_t apply_batch_max_hard_prune(
+      const ForwardInput& input,
+      ForwardInput& validate_input,
       const std::vector<int32_t>& prefix_lengths);
 
   void process_draft_sample_output(SampleOutput& sample_output);

--- a/xllm/core/runtime/dflash_worker_impl.h
+++ b/xllm/core/runtime/dflash_worker_impl.h
@@ -99,6 +99,15 @@ class DFlashWorkerImpl : public SpeculativeWorkerImpl {
                                               Stream& compute_stream,
                                               int32_t effective_val_tokens);
 
+  // Per-seq varlen variant. Handles the case where validate_input.token_ids
+  // is a flat [Σ per_seq_val_tokens] layout (i.e. the base per_seq builder
+  // produced it), copying draft tokens into the varlen slots per seq.
+  void fill_validate_input_from_draft_outputs_varlen(
+      const DraftBlock& draft_block,
+      ForwardInput& validate_input,
+      Stream& compute_stream,
+      const std::vector<int32_t>& per_seq_val_tokens);
+
   std::optional<ForwardOutput> run_validate(const ForwardInput& input,
                                             const DraftBlock& draft_block,
                                             ForwardInput& validate_input);

--- a/xllm/core/runtime/dflash_worker_impl.h
+++ b/xllm/core/runtime/dflash_worker_impl.h
@@ -64,6 +64,11 @@ class DFlashWorkerImpl : public SpeculativeWorkerImpl {
   struct DraftBlock {
     torch::Tensor token_ids;
     torch::Tensor probs;
+    // Optional acceptance-probability estimate, [batch, num_speculative_tokens]
+    // fp32 in [0, 1]. Populated by DSpark's ConfidenceHead when available;
+    // consumed by the adaptive-speculative pruning controller. When undefined,
+    // the controller falls back to `probs` (sampler-gathered softmax scores).
+    torch::Tensor confidence_probs;
     // No-sync draft inputs must outlive validation's stream sync.
     std::vector<std::shared_ptr<ForwardInput>> retained_inputs;
   };
@@ -105,6 +110,23 @@ class DFlashWorkerImpl : public SpeculativeWorkerImpl {
                         const torch::Tensor& draft_token_ids,
                         const torch::Tensor& draft_probs,
                         const ForwardOutput& target_output);
+
+  // Adaptive-speculative helper: run controller on draft acceptance
+  // probabilities (ConfidenceHead output if available, sampler-gathered probs
+  // otherwise) and return per-seq prefix_len vector (each entry in
+  // [0, num_speculative_tokens]). Returns empty vector when adaptive is off,
+  // in which case the caller keeps the full draft block.
+  std::vector<int32_t> compute_adaptive_prefix_lengths(
+      const DraftBlock& draft_block,
+      const ForwardInput& input);
+
+  // Zero out draft probs beyond each sequence's prefix_len so the rejection
+  // sampler naturally rejects those draft tokens.
+  // draft_block is modified in place. Called only when adaptive is enabled
+  // and controller produced non-uniform prefixes.
+  void apply_adaptive_prune_to_draft(
+      DraftBlock& draft_block,
+      const std::vector<int32_t>& prefix_lengths);
 
   void process_draft_sample_output(SampleOutput& sample_output);
 

--- a/xllm/core/runtime/dspark_worker_impl.cpp
+++ b/xllm/core/runtime/dspark_worker_impl.cpp
@@ -60,6 +60,10 @@ DSparkWorkerImpl::DraftBlock DSparkWorkerImpl::run_decode_draft(
       << "DSpark requires num_speculative_tokens > 0.";
   ForwardInput logits_input = query_input;
   logits_input.skip_sampling_for_logits_only = true;
+  // Request pre-lm_head hidden alongside logits so ConfidenceHead can consume
+  // the same [num_reqs*num_spec, hidden] rows without a second projection.
+  const bool want_confidence = draft_impl_->has_dspark_confidence_head();
+  logits_input.return_selected_hidden = want_confidence;
 
   ForwardInput processed_input;
   draft_impl_->prepare_work_before_execute_on_stream(
@@ -85,19 +89,37 @@ DSparkWorkerImpl::DraftBlock DSparkWorkerImpl::run_decode_draft(
       << "DSpark draft logits batch must match the decode batch.";
   torch::Tensor base_logits = draft_output->logits.view(
       {batch_size, num_speculative_tokens, draft_output->logits.size(-1)});
+  torch::Tensor last_hidden;
+  if (want_confidence) {
+    if (draft_output->selected_hidden.defined() &&
+        draft_output->selected_hidden.size(0) == num_rows) {
+      last_hidden = draft_output->selected_hidden.view(
+          {batch_size,
+           num_speculative_tokens,
+           draft_output->selected_hidden.size(-1)});
+    } else {
+      // The current lm_head backend did not surface selected_hidden. Fall
+      // back to sampler-gathered probs as the adaptive signal — ConfidenceHead
+      // stays a nice-to-have; adaptive pruning still works (a little coarser).
+      LOG_FIRST_N(WARNING, 1)
+          << "DSpark: draft did not expose selected_hidden; ConfidenceHead "
+          << "disabled for adaptive pruning, using proposal probs.";
+    }
+  }
 
   BlockSampleOutput sample_output;
   {
     c10::StreamGuard stream_guard = compute_stream_->set_stream_guard();
     SamplingParameters sampling_params_on_device = input.sampling_params.to(
         base_logits.device(), base_logits.scalar_type());
-    sample_output =
-        sample_block(base_logits, anchor_token_ids, sampling_params_on_device);
+    sample_output = sample_block(
+        base_logits, last_hidden, anchor_token_ids, sampling_params_on_device);
   }
 
   DraftBlock draft_block;
   draft_block.token_ids = std::move(sample_output.token_ids);
   draft_block.probs = std::move(sample_output.probs);
+  draft_block.confidence_probs = std::move(sample_output.confidence_probs);
   draft_block.retained_inputs = take_retained_inputs(*draft_output);
 
   COUNTER_ADD(speculative_execution_latency_seconds_draft,
@@ -107,6 +129,7 @@ DSparkWorkerImpl::DraftBlock DSparkWorkerImpl::run_decode_draft(
 
 DSparkWorkerImpl::BlockSampleOutput DSparkWorkerImpl::sample_block(
     const torch::Tensor& base_logits,
+    const torch::Tensor& last_hidden,
     const torch::Tensor& anchor_token_ids,
     const SamplingParameters& sampling_params) const {
   CHECK_EQ(base_logits.dim(), 3)
@@ -123,6 +146,16 @@ DSparkWorkerImpl::BlockSampleOutput DSparkWorkerImpl::sample_block(
   const int64_t num_reqs = base_logits.size(/*dim=*/0);
   const int64_t num_speculative_tokens = base_logits.size(/*dim=*/1);
   const int64_t draft_vocab_size = base_logits.size(/*dim=*/2);
+  const bool with_confidence =
+      last_hidden.defined() && draft_impl_->has_dspark_confidence_head();
+  if (with_confidence) {
+    CHECK_EQ(last_hidden.dim(), 3)
+        << "DSpark last_hidden must be [num_reqs, n_spec, hidden_size].";
+    CHECK_EQ(last_hidden.size(0), num_reqs)
+        << "DSpark last_hidden batch mismatch.";
+    CHECK_EQ(last_hidden.size(1), num_speculative_tokens)
+        << "DSpark last_hidden n_spec mismatch.";
+  }
   SamplingParameters step_sampling_params = sampling_params;
   const torch::TensorOptions index_options =
       torch::TensorOptions().dtype(torch::kInt).device(base_logits.device());
@@ -141,6 +174,13 @@ DSparkWorkerImpl::BlockSampleOutput DSparkWorkerImpl::sample_block(
                    torch::TensorOptions()
                        .dtype(torch::kFloat32)
                        .device(base_logits.device()));
+  torch::Tensor confidence_probs;
+  if (with_confidence) {
+    confidence_probs = torch::empty({num_reqs, num_speculative_tokens},
+                                    torch::TensorOptions()
+                                        .dtype(torch::kFloat32)
+                                        .device(base_logits.device()));
+  }
 
   using ISlice = torch::indexing::Slice;
   Sampler sampler;
@@ -155,6 +195,19 @@ DSparkWorkerImpl::BlockSampleOutput DSparkWorkerImpl::sample_block(
     CHECK_EQ(markov_bias.size(1), draft_vocab_size)
         << "DSpark reduced-vocab drafts need draft-to-target remapping, not "
            "yet implemented.";
+
+    // ConfidenceHead is applied on this step's hidden and the previous token
+    // (anchor for step 0, sampled draft for later steps). Compute BEFORE
+    // sampling so that on greedy path we don't wait on the argmax result.
+    if (with_confidence) {
+      torch::Tensor step_hidden =
+          last_hidden.select(/*dim=*/1, /*index=*/token_idx);
+      torch::Tensor conf =
+          draft_impl_->dspark_confidence_probs(step_hidden, previous_token_ids);
+      CHECK_EQ(conf.dim(), 1) << "confidence probs must be [num_reqs]";
+      CHECK_EQ(conf.size(0), num_reqs) << "confidence probs batch mismatch";
+      confidence_probs.index_put_({ISlice(), token_idx}, conf);
+    }
 
     torch::Tensor step_logits =
         base_logits.select(/*dim=*/1, /*index=*/token_idx) + markov_bias;
@@ -190,7 +243,8 @@ DSparkWorkerImpl::BlockSampleOutput DSparkWorkerImpl::sample_block(
   }
 
   return {.token_ids = std::move(token_ids),
-          .probs = std::move(proposal_probs)};
+          .probs = std::move(proposal_probs),
+          .confidence_probs = std::move(confidence_probs)};
 }
 
 void DSparkWorkerImpl::synchronize_sampled_token_ids(

--- a/xllm/core/runtime/dspark_worker_impl.cpp
+++ b/xllm/core/runtime/dspark_worker_impl.cpp
@@ -62,7 +62,13 @@ DSparkWorkerImpl::DraftBlock DSparkWorkerImpl::run_decode_draft(
   logits_input.skip_sampling_for_logits_only = true;
   // Request pre-lm_head hidden alongside logits so ConfidenceHead can consume
   // the same [num_reqs*num_spec, hidden] rows without a second projection.
-  const bool want_confidence = draft_impl_->has_dspark_confidence_head();
+  // Only pay the cost when adaptive pruning is actually enabled — static
+  // sampling doesn't consume confidence, and asking for selected_hidden
+  // triggers a target-side gather and a downstream linear+sigmoid every
+  // step.
+  const bool want_confidence = draft_impl_->has_dspark_confidence_head() &&
+                               adaptive_spec_controller_ != nullptr &&
+                               adaptive_spec_controller_->enabled();
   logits_input.return_selected_hidden = want_confidence;
 
   ForwardInput processed_input;

--- a/xllm/core/runtime/dspark_worker_impl.cpp
+++ b/xllm/core/runtime/dspark_worker_impl.cpp
@@ -180,13 +180,9 @@ DSparkWorkerImpl::BlockSampleOutput DSparkWorkerImpl::sample_block(
                    torch::TensorOptions()
                        .dtype(torch::kFloat32)
                        .device(base_logits.device()));
+  // Filled after the sample loop by a single batched ConfidenceHead call; stays
+  // undefined when confidence is disabled.
   torch::Tensor confidence_probs;
-  if (with_confidence) {
-    confidence_probs = torch::empty({num_reqs, num_speculative_tokens},
-                                    torch::TensorOptions()
-                                        .dtype(torch::kFloat32)
-                                        .device(base_logits.device()));
-  }
 
   using ISlice = torch::indexing::Slice;
   Sampler sampler;
@@ -201,19 +197,6 @@ DSparkWorkerImpl::BlockSampleOutput DSparkWorkerImpl::sample_block(
     CHECK_EQ(markov_bias.size(1), draft_vocab_size)
         << "DSpark reduced-vocab drafts need draft-to-target remapping, not "
            "yet implemented.";
-
-    // ConfidenceHead is applied on this step's hidden and the previous token
-    // (anchor for step 0, sampled draft for later steps). Compute BEFORE
-    // sampling so that on greedy path we don't wait on the argmax result.
-    if (with_confidence) {
-      torch::Tensor step_hidden =
-          last_hidden.select(/*dim=*/1, /*index=*/token_idx);
-      torch::Tensor conf =
-          draft_impl_->dspark_confidence_probs(step_hidden, previous_token_ids);
-      CHECK_EQ(conf.dim(), 1) << "confidence probs must be [num_reqs]";
-      CHECK_EQ(conf.size(0), num_reqs) << "confidence probs batch mismatch";
-      confidence_probs.index_put_({ISlice(), token_idx}, conf);
-    }
 
     torch::Tensor step_logits =
         base_logits.select(/*dim=*/1, /*index=*/token_idx) + markov_bias;
@@ -246,6 +229,26 @@ DSparkWorkerImpl::BlockSampleOutput DSparkWorkerImpl::sample_block(
     token_ids.index_put_({ISlice(), token_idx}, sampled_token_ids);
     proposal_probs.index_put_({ISlice(), token_idx}, selected_proposal_probs);
     previous_token_ids = sampled_token_ids;
+  }
+
+  // ConfidenceHead over the whole block, batched. Equivalent to computing it
+  // per step inside the loop on (last_hidden[:, k], prev_k) — prev_k is the
+  // anchor for step 0 and the draft token sampled at step k-1 otherwise — but
+  // as a single linear+sigmoid instead of gamma small kernel launches. The
+  // inputs don't depend on the sampling of the same step, so hoisting is exact.
+  if (with_confidence) {
+    torch::Tensor prev_matrix = torch::cat(
+        {anchor_token_ids.view({num_reqs, 1}),
+         token_ids.slice(/*dim=*/1, /*start=*/0, num_speculative_tokens - 1)},
+        /*dim=*/1);  // [num_reqs, num_spec]
+    confidence_probs =
+        draft_impl_->dspark_confidence_probs_batched(last_hidden, prev_matrix);
+    CHECK_EQ(confidence_probs.dim(), 2)
+        << "batched confidence probs must be [num_reqs, num_spec]";
+    CHECK_EQ(confidence_probs.size(0), num_reqs)
+        << "batched confidence probs batch mismatch";
+    CHECK_EQ(confidence_probs.size(1), num_speculative_tokens)
+        << "batched confidence probs n_spec mismatch";
   }
 
   return {.token_ids = std::move(token_ids),

--- a/xllm/core/runtime/dspark_worker_impl.h
+++ b/xllm/core/runtime/dspark_worker_impl.h
@@ -52,10 +52,16 @@ class DSparkWorkerImpl final : public DFlashWorkerImpl {
   struct BlockSampleOutput {
     torch::Tensor token_ids;
     torch::Tensor probs;
+    // [num_reqs, num_speculative_tokens], fp32 in [0, 1]. Only defined when the
+    // draft model carries a trained ConfidenceHead; consumed by the adaptive
+    // pruning controller in place of `probs` (which is only a sampler-gathered
+    // softmax score, not a true acceptance probability).
+    torch::Tensor confidence_probs;
   };
 
   BlockSampleOutput sample_block(
       const torch::Tensor& base_logits,
+      const torch::Tensor& last_hidden,
       const torch::Tensor& anchor_token_ids,
       const SamplingParameters& sampling_params) const;
 

--- a/xllm/core/runtime/forward_params.h
+++ b/xllm/core/runtime/forward_params.h
@@ -531,6 +531,7 @@ struct ForwardInput {
     inputs.transfer_kv_infos = transfer_kv_infos;
     inputs.step_decode = step_decode;
     inputs.skip_sampling_for_logits_only = skip_sampling_for_logits_only;
+    inputs.return_selected_hidden = return_selected_hidden;
     inputs.kv_slot_layout = kv_slot_layout;
     inputs.metadata_ready_event = metadata_ready_event;
     inputs.retained_device_tensors = retained_device_tensors;
@@ -593,6 +594,10 @@ struct ForwardInput {
   std::optional<StepDecodeMeta> step_decode;
   // If true, skip sampler forward and only keep logits.
   bool skip_sampling_for_logits_only = false;
+  // If true, populate ForwardOutput.selected_hidden with hidden states matching
+  // the `logits` selection layout. Used by DSpark ConfidenceHead which needs
+  // pre-lm_head hidden states of the draft tokens.
+  bool return_selected_hidden = false;
 
   // kv info for disaggregated prefill/decode
   std::vector<TransferKVInfo> transfer_kv_infos;
@@ -639,6 +644,11 @@ struct ForwardOutput {
   StreamEventPtr ready_event;
   torch::Tensor logits;
   torch::Tensor embedding;
+  // Selected hidden states matching `logits` layout: [num_selected,
+  // hidden_dim]. Populated when a speculative worker asks for the pre-lm_head
+  // hidden (e.g. DSpark's ConfidenceHead needs the draft-step hidden). Only
+  // computed when `input.return_selected_hidden` is true.
+  torch::Tensor selected_hidden;
   // Backend-neutral state for the next MTP draft step.
   MtpTopkStatePtr mtp_topk_state;
 

--- a/xllm/core/runtime/llm_worker_impl.cpp
+++ b/xllm/core/runtime/llm_worker_impl.cpp
@@ -321,6 +321,7 @@ std::optional<ForwardOutput> LLMWorkerImpl::step_internal(
   }
 
   torch::Tensor logits;
+  torch::Tensor selected_hidden;
   if (sampling_params.selected_token_idxes.defined()) {
     torch::Tensor selected_token_idxes = sampling_params.selected_token_idxes;
     if (model_output.hidden_states.defined() &&
@@ -330,7 +331,14 @@ std::optional<ForwardOutput> LLMWorkerImpl::step_internal(
                                      /*non_blocking=*/false)
                                  .contiguous();
     }
-    logits = model_->logits(model_output.hidden_states, selected_token_idxes);
+    if (input.return_selected_hidden) {
+      // Emit both selected hidden and logits from a single lm_head pass so the
+      // ConfidenceHead can consume hidden without a second projection.
+      logits = model_->logits(
+          model_output.hidden_states, selected_token_idxes, selected_hidden);
+    } else {
+      logits = model_->logits(model_output.hidden_states, selected_token_idxes);
+    }
   }
 
   ForwardOutput output;
@@ -359,6 +367,7 @@ std::optional<ForwardOutput> LLMWorkerImpl::step_internal(
   // driver prepare model output
   if (sampling_params.selected_token_idxes.defined()) {
     output.logits = logits;
+    output.selected_hidden = selected_hidden;
     output.do_sample = sampling_params.do_sample;
     output.logprobs = sampling_params.logprobs;
     output.max_top_logprobs = sampling_params.max_top_logprobs;

--- a/xllm/core/runtime/llm_worker_impl.cpp
+++ b/xllm/core/runtime/llm_worker_impl.cpp
@@ -336,6 +336,12 @@ std::optional<ForwardOutput> LLMWorkerImpl::step_internal(
       // ConfidenceHead can consume hidden without a second projection.
       logits = model_->logits(
           model_output.hidden_states, selected_token_idxes, selected_hidden);
+      if (!selected_hidden.defined() && model_output.hidden_states.defined()) {
+        // ATB lm_head backend does not expose a second output tensor; gather
+        // the hidden ourselves so ConfidenceHead is not silently disabled.
+        selected_hidden = model_output.hidden_states.index_select(
+            /*dim=*/0, selected_token_idxes.to(torch::kLong));
+      }
     } else {
       logits = model_->logits(model_output.hidden_states, selected_token_idxes);
     }

--- a/xllm/core/runtime/llm_worker_impl.cpp
+++ b/xllm/core/runtime/llm_worker_impl.cpp
@@ -337,10 +337,21 @@ std::optional<ForwardOutput> LLMWorkerImpl::step_internal(
       logits = model_->logits(
           model_output.hidden_states, selected_token_idxes, selected_hidden);
       if (!selected_hidden.defined() && model_output.hidden_states.defined()) {
-        // ATB lm_head backend does not expose a second output tensor; gather
-        // the hidden ourselves so ConfidenceHead is not silently disabled.
-        selected_hidden = model_output.hidden_states.index_select(
-            /*dim=*/0, selected_token_idxes.to(torch::kLong));
+        // ATB lm_head backend does not expose a second output tensor
+        // (LmHeadParam::outputHidden is false), so we surface the hidden here.
+        // return_selected_hidden is a DSpark-only request, and DSpark selects
+        // every draft row in order (sample_from_anchor keeps slot 0), i.e. the
+        // idxes are the identity 0..N-1. In that case index_select is a full
+        // redundant copy — alias the hidden directly. The numel guard is exact:
+        // it only fires when the selection covers all rows, which for DSpark's
+        // in-order construction is the identity permutation.
+        if (selected_token_idxes.numel() ==
+            model_output.hidden_states.size(0)) {
+          selected_hidden = model_output.hidden_states;
+        } else {
+          selected_hidden = model_output.hidden_states.index_select(
+              /*dim=*/0, selected_token_idxes.to(torch::kLong));
+        }
       }
     } else {
       logits = model_->logits(model_output.hidden_states, selected_token_idxes);

--- a/xllm/core/runtime/llm_worker_impl.cpp
+++ b/xllm/core/runtime/llm_worker_impl.cpp
@@ -339,19 +339,16 @@ std::optional<ForwardOutput> LLMWorkerImpl::step_internal(
       if (!selected_hidden.defined() && model_output.hidden_states.defined()) {
         // ATB lm_head backend does not expose a second output tensor
         // (LmHeadParam::outputHidden is false), so we surface the hidden here.
-        // return_selected_hidden is a DSpark-only request, and DSpark selects
-        // every draft row in order (sample_from_anchor keeps slot 0), i.e. the
-        // idxes are the identity 0..N-1. In that case index_select is a full
-        // redundant copy — alias the hidden directly. The numel guard is exact:
-        // it only fires when the selection covers all rows, which for DSpark's
-        // in-order construction is the identity permutation.
-        if (selected_token_idxes.numel() ==
-            model_output.hidden_states.size(0)) {
-          selected_hidden = model_output.hidden_states;
-        } else {
-          selected_hidden = model_output.hidden_states.index_select(
-              /*dim=*/0, selected_token_idxes.to(torch::kLong));
-        }
+        // selected_hidden must align row-for-row with `logits`, which is
+        // produced in selected_token_idxes order. index_select reproduces that
+        // order for any selection. We deliberately do NOT alias the full
+        // hidden_states on a numel match: equal row count does not imply the
+        // idxes are the identity permutation, and a full-but-reordered
+        // selection would silently misalign hidden against logits. The gather
+        // is one [num_selected, hidden] copy per decode step (not per layer),
+        // negligible next to the forward.
+        selected_hidden = model_output.hidden_states.index_select(
+            /*dim=*/0, selected_token_idxes.to(torch::kLong));
       }
     } else {
       logits = model_->logits(model_output.hidden_states, selected_token_idxes);

--- a/xllm/core/runtime/llm_worker_impl.h
+++ b/xllm/core/runtime/llm_worker_impl.h
@@ -109,6 +109,11 @@ class LLMWorkerImpl : public WorkerImpl {
       const torch::Tensor& previous_token_ids) {
     return model_->dspark_confidence_probs(hidden, previous_token_ids);
   }
+  torch::Tensor dspark_confidence_probs_batched(
+      const torch::Tensor& hidden_all,
+      const torch::Tensor& prev_matrix) {
+    return model_->dspark_confidence_probs_batched(hidden_all, prev_matrix);
+  }
   bool has_dspark_confidence_head() const {
     return model_->has_dspark_confidence_head();
   }

--- a/xllm/core/runtime/llm_worker_impl.h
+++ b/xllm/core/runtime/llm_worker_impl.h
@@ -104,6 +104,15 @@ class LLMWorkerImpl : public WorkerImpl {
     return model_->dspark_markov_bias(previous_token_ids);
   }
 
+  torch::Tensor dspark_confidence_probs(
+      const torch::Tensor& hidden,
+      const torch::Tensor& previous_token_ids) {
+    return model_->dspark_confidence_probs(hidden, previous_token_ids);
+  }
+  bool has_dspark_confidence_head() const {
+    return model_->has_dspark_confidence_head();
+  }
+
   bool share_weights_from(LLMWorkerImpl& source) {
     return model_->share_weights_from(*source.model_);
   }

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -1899,98 +1899,16 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
   const bool needs_padding =
       (total_tokens != static_cast<int32_t>(padded_total));
   if (needs_padding) {
-    // Slow path: per-seq variable-length, scatter into padded layout.
+    // Slow path: per-seq variable-length, scatter into padded layout. Pad
+    // next_tokens with 0 (MTP's established padding); trailing pads are masked
+    // to -1 by apply_pruned_prefix_lengths downstream regardless.
     padded_target_output_slow.emplace(target_output);
-    ForwardOutput& padded_target_output = *padded_target_output_slow;
-    std::vector<int64_t> dst_indices_vec;
-    dst_indices_vec.reserve(static_cast<size_t>(total_tokens));
-    for (int32_t i = 0; i < batch_size; ++i) {
-      const int32_t seq_tokens = per_seq_val_tokens[static_cast<size_t>(i)];
-      for (int32_t j = 0; j < seq_tokens; ++j) {
-        dst_indices_vec.push_back(static_cast<int64_t>(i) * max_val_tokens + j);
-      }
-    }
-    torch::Tensor dst_indices =
-        torch::tensor(dst_indices_vec,
-                      torch::TensorOptions()
-                          .dtype(torch::kLong)
-                          .device(target_output.logits.device()));
-
-    // Only the padding rows need the -inf sentinel; using empty + a targeted
-    // index_fill_ over the complement of dst_indices avoids paying vocab_size
-    // × padded_total writes when most rows will be overwritten by index_copy_.
-    torch::Tensor padded_logits = torch::empty({padded_total, vocab_size},
-                                               target_output.logits.options());
-    if (dst_indices_vec.size() < static_cast<size_t>(padded_total)) {
-      std::vector<bool> valid(static_cast<size_t>(padded_total), false);
-      for (int64_t idx : dst_indices_vec) {
-        valid[static_cast<size_t>(idx)] = true;
-      }
-      std::vector<int64_t> pad_indices_vec;
-      pad_indices_vec.reserve(static_cast<size_t>(padded_total) -
-                              dst_indices_vec.size());
-      for (int64_t i = 0; i < padded_total; ++i) {
-        if (!valid[static_cast<size_t>(i)]) {
-          pad_indices_vec.push_back(i);
-        }
-      }
-      torch::Tensor pad_indices =
-          torch::tensor(pad_indices_vec,
-                        torch::TensorOptions()
-                            .dtype(torch::kLong)
-                            .device(target_output.logits.device()));
-      padded_logits.index_fill_(/*dim=*/0, pad_indices, -1e9);
-    }
-    padded_logits.index_copy_(/*dim=*/0, dst_indices, target_output.logits);
-    padded_target_output.logits = padded_logits;
-
-    torch::Tensor padded_next_tokens = torch::zeros(
-        {padded_total}, target_output.sample_output.next_tokens.options());
-    padded_next_tokens.index_copy_(
-        /*dim=*/0, dst_indices, target_output.sample_output.next_tokens);
-    padded_target_output.sample_output.next_tokens = padded_next_tokens;
-
-    if (target_output.sample_output.embeddings.defined()) {
-      const int32_t hidden_size =
-          static_cast<int32_t>(target_output.sample_output.embeddings.size(-1));
-      torch::Tensor padded_embeddings =
-          torch::zeros({padded_total, hidden_size},
-                       target_output.sample_output.embeddings.options());
-      padded_embeddings.index_copy_(
-          /*dim=*/0, dst_indices, target_output.sample_output.embeddings);
-      padded_target_output.sample_output.embeddings = padded_embeddings;
-    }
-
-    // Pad sampled logprobs / top_tokens / top_logprobs to [padded_total, ...]
-    // so downstream sync_pruned_boundary_{logprobs,top_logprobs} can safely
-    // view them as [batch, max_val_tokens]. Without this the shape CHECKs
-    // in the helpers abort on any actually-pruned adaptive step when the
-    // target sampler produced logprobs (non-Qwen3.5 targets + logprobs on).
-    if (target_output.sample_output.logprobs.defined()) {
-      torch::Tensor padded_logprobs = torch::zeros(
-          {padded_total}, target_output.sample_output.logprobs.options());
-      padded_logprobs.index_copy_(
-          /*dim=*/0, dst_indices, target_output.sample_output.logprobs);
-      padded_target_output.sample_output.logprobs = padded_logprobs;
-    }
-    if (target_output.sample_output.top_tokens.defined()) {
-      const int64_t top_k = target_output.sample_output.top_tokens.size(-1);
-      torch::Tensor padded_top_tokens =
-          torch::zeros({padded_total, top_k},
-                       target_output.sample_output.top_tokens.options());
-      padded_top_tokens.index_copy_(
-          /*dim=*/0, dst_indices, target_output.sample_output.top_tokens);
-      padded_target_output.sample_output.top_tokens = padded_top_tokens;
-    }
-    if (target_output.sample_output.top_logprobs.defined()) {
-      const int64_t top_k = target_output.sample_output.top_logprobs.size(-1);
-      torch::Tensor padded_top_logprobs =
-          torch::zeros({padded_total, top_k},
-                       target_output.sample_output.top_logprobs.options());
-      padded_top_logprobs.index_copy_(
-          /*dim=*/0, dst_indices, target_output.sample_output.top_logprobs);
-      padded_target_output.sample_output.top_logprobs = padded_top_logprobs;
-    }
+    adaptive_pruning::scatter_varlen_target_output_to_dense(
+        *padded_target_output_slow,
+        per_seq_val_tokens,
+        batch_size,
+        max_val_tokens,
+        /*next_token_pad_value=*/0);
   }
   // Uniform fast path uses a scoped local ForwardOutput whose only diff is
   // logits viewed to [padded_total, vocab]; slow path uses the materialized

--- a/xllm/core/runtime/mtp_worker_impl.h
+++ b/xllm/core/runtime/mtp_worker_impl.h
@@ -277,7 +277,7 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
   // Whether validation directly uses selected-only draft_probs [B, S].
   // If false, selected-only cache values are restored to dense [B, S, V].
   bool enable_opt_validate_probs_ = false;
-  std::unique_ptr<AdaptiveSpeculativeController> adaptive_spec_controller_;
+  // adaptive_spec_controller_ now lives on SpeculativeWorkerImpl (base class).
 
   // Classified once when the corresponding models are loaded. Decode-path
   // decisions only read these closed policies.

--- a/xllm/core/runtime/speculative_worker_impl.cpp
+++ b/xllm/core/runtime/speculative_worker_impl.cpp
@@ -404,7 +404,9 @@ void SpeculativeWorkerImpl::prepare_validate_inputs(
     CHECK_LE(v, num_speculative_tokens + 1)
         << "per_seq_val_tokens must be <= num_speculative_tokens + 1";
     total_num_val_tokens += v;
-    if (v > max_val_tokens) max_val_tokens = v;
+    if (v > max_val_tokens) {
+      max_val_tokens = v;
+    }
   }
   const int32_t block_size = options_.block_size();
   specBuilder::DecodeRowContext row_ctx =

--- a/xllm/core/runtime/speculative_worker_impl.cpp
+++ b/xllm/core/runtime/speculative_worker_impl.cpp
@@ -378,4 +378,116 @@ void SpeculativeWorkerImpl::prepare_work_before_execute(
     ForwardInput& processed_input) {
   WorkerImpl::prepare_work_before_execute(input, processed_input);
 }
+
+// Per-seq adaptive validate builder: each sequence contributes
+// per_seq_val_tokens[i] rows instead of a uniform N+1. Only implements the
+// chunked-prefill (non-atb_spec_kernel) path since DFlash/DSpark require
+// --enable_chunked_prefill=true anyway.
+void SpeculativeWorkerImpl::prepare_validate_inputs(
+    const ForwardInput& input,
+    ForwardInput& validate_input,
+    const std::vector<int32_t>& per_seq_val_tokens) {
+  validate_input = input.to(device_, dtype_);
+  validate_input.device_tensors_ready = false;
+  auto& input_params = validate_input.input_params;
+  torch::TensorOptions token_options = validate_input.token_ids.options();
+  torch::TensorOptions position_options = validate_input.positions.options();
+
+  const int32_t num_speculative_tokens = options_.num_speculative_tokens();
+  const int32_t num_sequences = input_params.meta.num_sequences;
+  CHECK_EQ(static_cast<int32_t>(per_seq_val_tokens.size()), num_sequences)
+      << "per_seq_val_tokens size must match num_sequences";
+  int32_t total_num_val_tokens = 0;
+  int32_t max_val_tokens = 0;
+  for (int32_t v : per_seq_val_tokens) {
+    CHECK_GE(v, 1) << "per_seq_val_tokens must be >= 1";
+    CHECK_LE(v, num_speculative_tokens + 1)
+        << "per_seq_val_tokens must be <= num_speculative_tokens + 1";
+    total_num_val_tokens += v;
+    if (v > max_val_tokens) max_val_tokens = v;
+  }
+  const int32_t block_size = options_.block_size();
+  specBuilder::DecodeRowContext row_ctx =
+      specBuilder::make_decode_row_context(input);
+
+  Slice<int32_t> token_ids = tensor_slice(input.token_ids_host);
+  Slice<int32_t> positions = tensor_slice(input.positions_host);
+  Slice<int32_t> kv_seq_lens = input.input_params.attention.host.kv_seq_lens;
+  specBuilder::DecodeBuildBuffers buf;
+  buf.out_token_ids.reserve(total_num_val_tokens);
+  buf.out_positions.reserve(total_num_val_tokens);
+  buf.out_new_cache_slots.reserve(total_num_val_tokens);
+  buf.out_kv_seq_lens.reserve(total_num_val_tokens);
+  buf.out_q_seq_lens.reserve(total_num_val_tokens);
+  buf.out_q_cu_seq_lens.reserve(total_num_val_tokens);
+  buf.out_block_tables.reserve(static_cast<size_t>(total_num_val_tokens) *
+                               row_ctx.block_table_stride);
+
+  for (int32_t seq_id = 0; seq_id < num_sequences; ++seq_id) {
+    int32_t start_position = positions[seq_id];
+    int32_t kv_len =
+        specBuilder::calc_kv_len(kv_seq_lens, seq_id, /*offset=*/0);
+    CHECK_EQ(start_position + 1, kv_len)
+        << "validate position/kv_len mismatch, seq_id=" << seq_id
+        << ", start_position=" << start_position << ", kv_len=" << kv_len;
+    const int32_t seq_val_tokens =
+        per_seq_val_tokens[static_cast<size_t>(seq_id)];
+
+    for (int32_t val_idx = 0; val_idx < seq_val_tokens; ++val_idx) {
+      specBuilder::RowSpec row;
+      row.seq_id = seq_id;
+      if (val_idx == 0) {
+        row.token_id = token_ids[seq_id];
+      } else {
+        row.token_id = -val_idx;
+      }
+      row.position_offset = val_idx;
+      row.append_kv_len = true;
+      row.append_q_len_one = true;
+      row.append_block_table = true;
+      specBuilder::append_decode_row(row_ctx, row, block_size, buf);
+    }
+  }
+
+  CHECK_EQ(buf.out_new_cache_slots.size(), buf.out_token_ids.size())
+      << "validate kv slots/tokens mismatch";
+  CHECK_EQ(buf.out_positions.size(), buf.out_token_ids.size())
+      << "validate positions/tokens mismatch";
+
+  specBuilder::set_token_position_tensors(validate_input,
+                                          buf.out_token_ids,
+                                          buf.out_positions,
+                                          token_options,
+                                          position_options);
+  input_params.meta.num_sequences = num_sequences;
+  input_params.meta.q_max_seq_len = max_val_tokens;
+  input_params.meta.batch_forward_type = BatchForwardType::CHUNKED_PREFILL;
+  specBuilder::update_input_params(input_params,
+                                   buf,
+                                   /*val_tokens_per_seq=*/max_val_tokens,
+                                   std::move(buf.out_q_seq_lens),
+                                   std::move(buf.out_q_cu_seq_lens),
+                                   buf.meta.kv_max_seq_len,
+                                   std::move(buf.out_kv_seq_lens),
+                                   /*update_block_tables=*/true);
+  input_params.attention.rebuild_device_buffer(device_);
+
+  // update sampling params using the per-seq width.
+  update_sampling_params(
+      validate_input.sampling_params, per_seq_val_tokens, total_num_val_tokens);
+
+  // dp/ep parallel token counts: use the actual total, not batch * width.
+  const int32_t dense_baseline = num_sequences * (num_speculative_tokens + 1);
+  const double scale = dense_baseline > 0
+                           ? static_cast<double>(total_num_val_tokens) /
+                                 static_cast<double>(dense_baseline)
+                           : 1.0;
+  for (auto& it : input_params.parallel.dp_global_token_nums) {
+    it = static_cast<int32_t>(std::round(it * scale));
+  }
+  for (auto& it : input_params.parallel.raw_dp_global_token_nums) {
+    it = static_cast<int32_t>(std::round(it * scale));
+  }
+  validate_input.device_tensors_ready = true;
+}
 }  // namespace xllm

--- a/xllm/core/runtime/speculative_worker_impl.cpp
+++ b/xllm/core/runtime/speculative_worker_impl.cpp
@@ -476,17 +476,20 @@ void SpeculativeWorkerImpl::prepare_validate_inputs(
   update_sampling_params(
       validate_input.sampling_params, per_seq_val_tokens, total_num_val_tokens);
 
-  // dp/ep parallel token counts: use the actual total, not batch * width.
-  const int32_t dense_baseline = num_sequences * (num_speculative_tokens + 1);
-  const double scale = dense_baseline > 0
-                           ? static_cast<double>(total_num_val_tokens) /
-                                 static_cast<double>(dense_baseline)
-                           : 1.0;
+  // dp/ep parallel token counts: dense variant multiplies by num_val_tokens
+  // because each seq expands into that many validate rows. Here per-seq width
+  // varies, so scale by the average width = total_num_val_tokens /
+  // num_sequences so raw_dp_global_token_nums reflects the actual number of
+  // rows a rank owns.
+  const double avg_width =
+      num_sequences > 0
+          ? static_cast<double>(total_num_val_tokens) / num_sequences
+          : 1.0;
   for (auto& it : input_params.parallel.dp_global_token_nums) {
-    it = static_cast<int32_t>(std::round(it * scale));
+    it = static_cast<int32_t>(std::round(it * avg_width));
   }
   for (auto& it : input_params.parallel.raw_dp_global_token_nums) {
-    it = static_cast<int32_t>(std::round(it * scale));
+    it = static_cast<int32_t>(std::round(it * avg_width));
   }
   validate_input.device_tensors_ready = true;
 }

--- a/xllm/core/runtime/speculative_worker_impl.cpp
+++ b/xllm/core/runtime/speculative_worker_impl.cpp
@@ -461,12 +461,21 @@ void SpeculativeWorkerImpl::prepare_validate_inputs(
                                           buf.out_positions,
                                           token_options,
                                           position_options);
-  input_params.meta.num_sequences = num_sequences;
-  input_params.meta.q_max_seq_len = max_val_tokens;
-  input_params.meta.batch_forward_type = BatchForwardType::CHUNKED_PREFILL;
+  // Match the dense (non-adaptive) validate path's DECODE-mode layout: each
+  // validate row is an independent q=1 decode step, and causal visibility
+  // across a seq's block comes from the per-row increasing kv_seq_lens (row j
+  // sees anchor_kv + j tokens), NOT from a chunked-prefill block mask. Using
+  // CHUNKED_PREFILL here (q_max_seq_len = max_val_tokens) gave the block a
+  // prefill-style mask under which col>=1 could not attend to the accepted
+  // draft tokens in col<j, so the target logits from col 1 onward diverged
+  // from the dense path and produced garbled adaptive output. Flatten to
+  // total_num_val_tokens q=1 rows exactly like the dense builder.
+  input_params.meta.num_sequences = total_num_val_tokens;
+  input_params.meta.q_max_seq_len = 1;
+  input_params.meta.batch_forward_type = BatchForwardType::DECODE;
   specBuilder::update_input_params(input_params,
                                    buf,
-                                   /*val_tokens_per_seq=*/max_val_tokens,
+                                   /*val_tokens_per_seq=*/1,
                                    std::move(buf.out_q_seq_lens),
                                    std::move(buf.out_q_cu_seq_lens),
                                    buf.meta.kv_max_seq_len,

--- a/xllm/core/runtime/speculative_worker_impl.h
+++ b/xllm/core/runtime/speculative_worker_impl.h
@@ -137,6 +137,13 @@ class SpeculativeWorkerImpl : public WorkerImpl {
   // prepare inputs for target model at Decode phase (validation).
   void prepare_validate_inputs(const ForwardInput& inputs,
                                ForwardInput& validate_inputs);
+  // Per-seq variant used by adaptive-speculative pruning: each sequence's
+  // validate row width equals per_seq_val_tokens[i] (must be in [1, N+1]).
+  // The dense meta/token/position/kv-slot buffers are rebuilt as varlen with
+  // total_tokens = Σ per_seq_val_tokens.
+  void prepare_validate_inputs(const ForwardInput& inputs,
+                               ForwardInput& validate_inputs,
+                               const std::vector<int32_t>& per_seq_val_tokens);
 
  protected:
   // Target model worker

--- a/xllm/core/runtime/speculative_worker_impl.h
+++ b/xllm/core/runtime/speculative_worker_impl.h
@@ -15,9 +15,11 @@ limitations under the License.
 
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "common/macros.h"
+#include "core/framework/speculative/adaptive_speculative_controller.h"
 #include "framework/sampling/rejection_sampler.h"
 #include "runtime/llm_worker_impl.h"
 #include "runtime/options.h"
@@ -139,6 +141,12 @@ class SpeculativeWorkerImpl : public WorkerImpl {
  protected:
   // Target model worker
   std::unique_ptr<LLMWorkerImpl> impl_;
+
+  // Optional adaptive pruning controller. Subclasses create it in their ctor
+  // when the algorithm supports adaptive per-seq validate pruning (MTP,
+  // DFlash, DSpark). Left null otherwise. Held in the base so shared plumbing
+  // (predictor setter, profile hook) does not need per-subclass duplication.
+  std::unique_ptr<AdaptiveSpeculativeController> adaptive_spec_controller_;
 
   bool enable_fused_kernel_ = false;
   int32_t embedding_size_ = 0;

--- a/xllm/core/scheduler/profile/profile_manager.cpp
+++ b/xllm/core/scheduler/profile/profile_manager.cpp
@@ -21,7 +21,6 @@ limitations under the License.
 
 #include <Eigen/Dense>
 #include <algorithm>
-#include <cctype>
 #include <chrono>
 #include <cmath>
 #include <filesystem>
@@ -489,16 +488,11 @@ void ProfileManager::profile_speculative_validate_time() {
   // actually consume it: MTP/DFlash/DSpark with SL > 1 and adaptive
   // explicitly enabled. Otherwise this whole prefix/query/batch sweep is
   // wasted startup time.
-  std::string speculative_algorithm =
+  const std::string& speculative_algorithm =
       speculative_config.speculative_algorithm();
-  std::transform(
-      speculative_algorithm.begin(),
-      speculative_algorithm.end(),
-      speculative_algorithm.begin(),
-      [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
   const bool is_supported_algo =
       SpeculativeConfig::is_mtp_algorithm(speculative_algorithm) ||
-      speculative_algorithm == "dflash" || speculative_algorithm == "dspark";
+      SpeculativeConfig::is_block_diffusion_algorithm(speculative_algorithm);
   if (!speculative_config.enable_adaptive_speculative_decode() ||
       speculative_config.num_speculative_tokens() <= 1 || !is_supported_algo) {
     return;

--- a/xllm/core/scheduler/profile/profile_manager.cpp
+++ b/xllm/core/scheduler/profile/profile_manager.cpp
@@ -486,15 +486,26 @@ void ProfileManager::profile_speculative_validate_time() {
   const SpeculativeConfig& speculative_config =
       ::xllm::SpeculativeConfig::get_instance();
   // Only fit the validate-time predictor when the adaptive path can
-  // actually consume it: MTP with SL > 1 and adaptive explicitly enabled.
-  // Otherwise this whole prefix/query/batch sweep is wasted startup time.
+  // actually consume it: MTP/DFlash/DSpark with SL > 1 and adaptive
+  // explicitly enabled. Otherwise this whole prefix/query/batch sweep is
+  // wasted startup time.
+  std::string speculative_algorithm =
+      speculative_config.speculative_algorithm();
+  std::transform(
+      speculative_algorithm.begin(),
+      speculative_algorithm.end(),
+      speculative_algorithm.begin(),
+      [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  const bool is_supported_algo =
+      SpeculativeConfig::is_mtp_algorithm(speculative_algorithm) ||
+      speculative_algorithm == "dflash" || speculative_algorithm == "dspark";
   if (!speculative_config.enable_adaptive_speculative_decode() ||
       speculative_config.num_speculative_tokens() <= 1 ||
-      !SpeculativeConfig::is_mtp_algorithm(
-          speculative_config.speculative_algorithm())) {
+      !is_supported_algo) {
     return;
   }
-  LOG(INFO) << "Starting speculative validate profile for MTP, "
+  LOG(INFO) << "Starting speculative validate profile for "
+            << speculative_algorithm << ", "
             << "adaptive_enabled="
             << speculative_config.enable_adaptive_speculative_decode();
 

--- a/xllm/core/scheduler/profile/profile_manager.cpp
+++ b/xllm/core/scheduler/profile/profile_manager.cpp
@@ -500,8 +500,7 @@ void ProfileManager::profile_speculative_validate_time() {
       SpeculativeConfig::is_mtp_algorithm(speculative_algorithm) ||
       speculative_algorithm == "dflash" || speculative_algorithm == "dspark";
   if (!speculative_config.enable_adaptive_speculative_decode() ||
-      speculative_config.num_speculative_tokens() <= 1 ||
-      !is_supported_algo) {
+      speculative_config.num_speculative_tokens() <= 1 || !is_supported_algo) {
     return;
   }
   LOG(INFO) << "Starting speculative validate profile for "

--- a/xllm/models/llm/npu/qwen3.h
+++ b/xllm/models/llm/npu/qwen3.h
@@ -294,6 +294,9 @@ REGISTER_MODEL_ARGS_WITH_VARNAME(qwen3_atb, qwen3_atb, [&] {
   // DSpark: low-rank dim of the Markov head (top-level config key, like vLLM's
   // config.markov_rank). 0 = disabled (plain DFlash / non-DSpark models).
   LOAD_ARG_OR(markov_rank, "markov_rank", 0);
+  LOAD_ARG_OR(enable_confidence_head, "enable_confidence_head", false);
+  LOAD_ARG_OR(
+      confidence_head_with_markov, "confidence_head_with_markov", false);
 
   LOAD_ARG_OR_FUNC(head_dim, "head_dim", [&] {
     return args->hidden_size() / args->n_heads();

--- a/xllm/models/llm/npu/qwen3_dspark.h
+++ b/xllm/models/llm/npu/qwen3_dspark.h
@@ -204,24 +204,56 @@ class DSparkConfidenceHead final {
     }
     namespace F = torch::nn::functional;
     torch::Tensor logit = F::linear(input, proj_weight_, proj_bias_);
-    // Optional temperature scaling on the confidence logit before sigmoid.
-    // Raw neural confidence estimates are typically overconfident (Guo et al.
-    // 2017); the DSpark paper (Section 3.2.1 "Post-hoc Calibration") calls for
-    // Sequential Temperature Scaling to keep the cumulative product ∏ c_i
-    // aligned with the empirical acceptance rate. We approximate that with a
-    // single global temperature read from DSPARK_CONFIDENCE_TEMPERATURE
-    // (default 1.0 = no scaling). Higher T flattens confidence toward 0.5 so
-    // the cumulative product decays slower and the scheduler prunes less
-    // aggressively at long block lengths.
-    static const double temperature = [] {
-      const char* s = std::getenv("DSPARK_CONFIDENCE_TEMPERATURE");
-      double t = s != nullptr ? std::atof(s) : 1.0;
-      return t > 0.0 ? t : 1.0;
-    }();
+    const double temperature = confidence_temperature();
     if (temperature != 1.0) {
       logit = logit / temperature;
     }
     return torch::sigmoid(logit).squeeze(-1).to(torch::kFloat32);
+  }
+
+  // Batched over the whole draft block: applies the same head as `forward` to
+  // all gamma steps at once, so the sample loop pays one linear+sigmoid instead
+  // of gamma. Numerically identical to gamma per-step `forward` calls.
+  //   hidden_all:       [B, gamma, hidden_size]
+  //   markov_embed_all: [B, gamma, markov_rank]  (consumed only when
+  //   with_markov_)
+  // returns:            [B, gamma] float32 acceptance probabilities in [0, 1].
+  torch::Tensor forward_batched(const torch::Tensor& hidden_all,
+                                const torch::Tensor& markov_embed_all) const {
+    CHECK(defined()) << "DSpark ConfidenceHead weights are not initialized";
+    CHECK_EQ(hidden_all.dim(), 3)
+        << "ConfidenceHead hidden_all must be [B, gamma, H]";
+    CHECK_EQ(hidden_all.size(-1), hidden_size_)
+        << "ConfidenceHead hidden size mismatch";
+    const int64_t batch = hidden_all.size(0);
+    const int64_t gamma = hidden_all.size(1);
+    torch::Tensor input;
+    if (with_markov_) {
+      CHECK(markov_embed_all.defined())
+          << "ConfidenceHead with_markov requires markov_embed_all";
+      CHECK_EQ(markov_embed_all.dim(), 3)
+          << "ConfidenceHead markov_embed_all must be [B, gamma, rank]";
+      CHECK_EQ(markov_embed_all.size(0), batch)
+          << "ConfidenceHead markov_embed_all batch mismatch";
+      CHECK_EQ(markov_embed_all.size(1), gamma)
+          << "ConfidenceHead markov_embed_all gamma mismatch";
+      CHECK_EQ(markov_embed_all.size(-1), markov_rank_)
+          << "ConfidenceHead markov_embed_all rank mismatch";
+      input = torch::cat({hidden_all.to(proj_weight_.dtype()),
+                          markov_embed_all.to(proj_weight_.dtype())},
+                         /*dim=*/-1);
+    } else {
+      input = hidden_all.to(proj_weight_.dtype());
+    }
+    namespace F = torch::nn::functional;
+    torch::Tensor logit =
+        F::linear(input.reshape({batch * gamma, -1}), proj_weight_, proj_bias_)
+            .view({batch, gamma});
+    const double temperature = confidence_temperature();
+    if (temperature != 1.0) {
+      logit = logit / temperature;
+    }
+    return torch::sigmoid(logit).to(torch::kFloat32);
   }
 
   bool defined() const {
@@ -229,6 +261,25 @@ class DSparkConfidenceHead final {
   }
 
  private:
+  // Optional temperature scaling on the confidence logit before sigmoid, shared
+  // by both `forward` and `forward_batched` so the two paths stay numerically
+  // identical. Raw neural confidence estimates are typically overconfident (Guo
+  // et al. 2017); the DSpark paper (Section 3.2.1 "Post-hoc Calibration") calls
+  // for Sequential Temperature Scaling to keep the cumulative product ∏ c_i
+  // aligned with the empirical acceptance rate. We approximate that with a
+  // single global temperature read from DSPARK_CONFIDENCE_TEMPERATURE (default
+  // 1.0 = no scaling). Higher T flattens confidence toward 0.5 so the
+  // cumulative product decays slower and the scheduler prunes less aggressively
+  // at long block lengths.
+  static double confidence_temperature() {
+    static const double temperature = [] {
+      const char* s = std::getenv("DSPARK_CONFIDENCE_TEMPERATURE");
+      double t = s != nullptr ? std::atof(s) : 1.0;
+      return t > 0.0 ? t : 1.0;
+    }();
+    return temperature;
+  }
+
   torch::Tensor proj_weight_;  // [1, hidden_size (+ markov_rank)]
   torch::Tensor proj_bias_;    // [1]
   torch::TensorOptions tensor_options_;
@@ -284,6 +335,24 @@ class DSparkQwen3ForCausalLMImpl final
       markov_embed = markov_head_.markov_embed(previous_token_ids);
     }
     return confidence_head_.forward(hidden, markov_embed);
+  }
+
+  // Batched variant of dspark_confidence_probs over the whole draft block.
+  //   hidden_all:  [num_reqs, num_spec, hidden_size]
+  //   prev_matrix: [num_reqs, num_spec] int64 — column k is step k's "prev"
+  //                token (col 0 = anchor, col k = draft token sampled at k-1).
+  // Returns [num_reqs, num_spec] fp32 in [0, 1]. Defined only when
+  // enable_confidence_head.
+  torch::Tensor dspark_confidence_probs_batched(
+      const torch::Tensor& hidden_all,
+      const torch::Tensor& prev_matrix) const {
+    CHECK(confidence_head_.defined())
+        << "DSpark ConfidenceHead is not initialized (enable_confidence_head?)";
+    torch::Tensor markov_embed_all;
+    if (prev_matrix.defined()) {
+      markov_embed_all = markov_head_.markov_embed(prev_matrix);
+    }
+    return confidence_head_.forward_batched(hidden_all, markov_embed_all);
   }
 
   bool has_dspark_confidence_head() const { return confidence_head_.defined(); }

--- a/xllm/models/llm/npu/qwen3_dspark.h
+++ b/xllm/models/llm/npu/qwen3_dspark.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <torch/torch.h>
 
 #include <cstdint>
+#include <cstdlib>
 #include <memory>
 #include <string>
 #include <vector>
@@ -199,6 +200,23 @@ class DSparkConfidenceHead final {
     }
     namespace F = torch::nn::functional;
     torch::Tensor logit = F::linear(input, proj_weight_, proj_bias_);
+    // Optional temperature scaling on the confidence logit before sigmoid.
+    // Raw neural confidence estimates are typically overconfident (Guo et al.
+    // 2017); the DSpark paper (Section 3.2.1 "Post-hoc Calibration") calls for
+    // Sequential Temperature Scaling to keep the cumulative product ∏ c_i
+    // aligned with the empirical acceptance rate. We approximate that with a
+    // single global temperature read from DSPARK_CONFIDENCE_TEMPERATURE
+    // (default 1.0 = no scaling). Higher T flattens confidence toward 0.5 so
+    // the cumulative product decays slower and the scheduler prunes less
+    // aggressively at long block lengths.
+    static const double temperature = [] {
+      const char* s = std::getenv("DSPARK_CONFIDENCE_TEMPERATURE");
+      double t = s != nullptr ? std::atof(s) : 1.0;
+      return t > 0.0 ? t : 1.0;
+    }();
+    if (temperature != 1.0) {
+      logit = logit / temperature;
+    }
     return torch::sigmoid(logit).squeeze(-1).to(torch::kFloat32);
   }
 

--- a/xllm/models/llm/npu/qwen3_dspark.h
+++ b/xllm/models/llm/npu/qwen3_dspark.h
@@ -19,7 +19,6 @@ limitations under the License.
 #include <torch/torch.h>
 
 #include <cstdint>
-#include <cstdlib>
 #include <memory>
 #include <string>
 #include <vector>
@@ -266,19 +265,11 @@ class DSparkConfidenceHead final {
   // identical. Raw neural confidence estimates are typically overconfident (Guo
   // et al. 2017); the DSpark paper (Section 3.2.1 "Post-hoc Calibration") calls
   // for Sequential Temperature Scaling to keep the cumulative product ∏ c_i
-  // aligned with the empirical acceptance rate. We approximate that with a
-  // single global temperature read from DSPARK_CONFIDENCE_TEMPERATURE (default
-  // 1.0 = no scaling). Higher T flattens confidence toward 0.5 so the
-  // cumulative product decays slower and the scheduler prunes less aggressively
-  // at long block lengths.
-  static double confidence_temperature() {
-    static const double temperature = [] {
-      const char* s = std::getenv("DSPARK_CONFIDENCE_TEMPERATURE");
-      double t = s != nullptr ? std::atof(s) : 1.0;
-      return t > 0.0 ? t : 1.0;
-    }();
-    return temperature;
-  }
+  // aligned with the empirical acceptance rate, which higher T approximates by
+  // flattening confidence toward 0.5. The scaling path is kept for that future
+  // calibration, but T is fixed at 1.0 (no scaling) here; when it becomes
+  // tunable it should arrive as a ModelArgs field, not a process-global knob.
+  static constexpr double confidence_temperature() { return 1.0; }
 
   torch::Tensor proj_weight_;  // [1, hidden_size (+ markov_rank)]
   torch::Tensor proj_bias_;    // [1]

--- a/xllm/models/llm/npu/qwen3_dspark.h
+++ b/xllm/models/llm/npu/qwen3_dspark.h
@@ -145,6 +145,10 @@ class DSparkConfidenceHead final {
 
   // vLLM keys: confidence_head.proj.{weight,bias}
   void load_state_dict(const StateDict& state_dict) {
+    if (hidden_size_ <= 0) {
+      // Not initialized (enable_confidence_head=false); skip.
+      return;
+    }
     torch::Tensor w = state_dict.get_tensor("confidence_head.proj.weight");
     torch::Tensor b = state_dict.get_tensor("confidence_head.proj.bias");
     if (w.defined()) {

--- a/xllm/models/llm/npu/qwen3_dspark.h
+++ b/xllm/models/llm/npu/qwen3_dspark.h
@@ -92,6 +92,14 @@ class DSparkMarkovHead final {
     return F::linear(markov_embedding, markov_w2_);
   }
 
+  // Expose the shared markov_w1 embedding so ConfidenceHead can reuse the same
+  // rank-256 features without a redundant lookup table copy.
+  torch::Tensor markov_embed(const torch::Tensor& prev_token_ids) const {
+    CHECK(defined()) << "DSpark Markov head weights are not initialized.";
+    namespace F = torch::nn::functional;
+    return F::embedding(prev_token_ids, markov_w1_);
+  }
+
  private:
   bool defined() const { return markov_w1_.defined() && markov_w2_.defined(); }
 
@@ -99,6 +107,112 @@ class DSparkMarkovHead final {
   torch::Tensor markov_w2_;  // [draft_vocab_size, markov_rank]
   torch::TensorOptions tensor_options_;
   int64_t markov_rank_ = 0;
+};
+
+// DSpark ConfidenceHead: given a draft-step hidden state and the previous
+// token id, produces an acceptance-prob logit. When
+// confidence_head_with_markov=true (the standard config), the head is applied
+// on `concat(hidden, markov_embedding[prev])` — a low-rank Markov feature
+// that reuses markov_w1 (the same embedding table the MarkovHead uses).
+//
+// Weights (bias-less linear that xllm sees as `confidence_head.proj`):
+//   proj.weight: [1, hidden_size + markov_rank]  when with_markov=true
+//   proj.weight: [1, hidden_size]                 otherwise
+//   proj.bias:   [1]
+//
+// forward returns [num_reqs] float acceptance probabilities in [0, 1] (sigmoid
+// applied). The controller consumes them as per-step draft accept
+// probabilities.
+class DSparkConfidenceHead final {
+ public:
+  DSparkConfidenceHead() = default;
+
+  void initialize(const torch::TensorOptions& options,
+                  int64_t hidden_size,
+                  int64_t markov_rank,
+                  bool with_markov) {
+    tensor_options_ = options;
+    hidden_size_ = hidden_size;
+    markov_rank_ = markov_rank;
+    with_markov_ = with_markov;
+    CHECK_GT(hidden_size_, 0) << "DSpark ConfidenceHead requires hidden_size>0";
+    if (with_markov_) {
+      CHECK_GT(markov_rank_, 0)
+          << "DSpark ConfidenceHead with_markov requires markov_rank>0";
+    }
+  }
+
+  // vLLM keys: confidence_head.proj.{weight,bias}
+  void load_state_dict(const StateDict& state_dict) {
+    torch::Tensor w = state_dict.get_tensor("confidence_head.proj.weight");
+    torch::Tensor b = state_dict.get_tensor("confidence_head.proj.bias");
+    if (w.defined()) {
+      proj_weight_ = w.to(tensor_options_);
+    }
+    if (b.defined()) {
+      proj_bias_ = b.to(tensor_options_);
+    }
+  }
+
+  void verify_loaded_weights(const std::string& prefix) const {
+    CHECK(proj_weight_.defined())
+        << "Failed to find " << prefix << "confidence_head.proj.weight";
+    CHECK(proj_bias_.defined())
+        << "Failed to find " << prefix << "confidence_head.proj.bias";
+    CHECK_EQ(proj_weight_.dim(), 2)
+        << "confidence_head.proj.weight must be [1, in_dim]";
+    CHECK_EQ(proj_bias_.dim(), 1) << "confidence_head.proj.bias must be [1]";
+    CHECK_EQ(proj_weight_.size(0), 1)
+        << "confidence_head.proj.weight must output a single logit";
+    const int64_t expected_in =
+        with_markov_ ? hidden_size_ + markov_rank_ : hidden_size_;
+    CHECK_EQ(proj_weight_.size(1), expected_in)
+        << "confidence_head.proj.weight in_dim mismatch, expected "
+        << expected_in << " got " << proj_weight_.size(1);
+    CHECK_EQ(proj_bias_.size(0), 1)
+        << "confidence_head.proj.bias size mismatch";
+  }
+
+  // hidden: [num_reqs, hidden_size]
+  // markov_embed: [num_reqs, markov_rank] — from `markov_w1[prev_token_ids]`.
+  //   Only consumed when `with_markov_` is true.
+  // returns: [num_reqs] float32 acceptance probabilities in [0, 1].
+  torch::Tensor forward(const torch::Tensor& hidden,
+                        const torch::Tensor& markov_embed) const {
+    CHECK(defined()) << "DSpark ConfidenceHead weights are not initialized";
+    CHECK_EQ(hidden.dim(), 2) << "ConfidenceHead hidden must be [B, H]";
+    CHECK_EQ(hidden.size(-1), hidden_size_)
+        << "ConfidenceHead hidden size mismatch";
+    torch::Tensor input;
+    if (with_markov_) {
+      CHECK(markov_embed.defined())
+          << "ConfidenceHead with_markov requires markov_embed";
+      CHECK_EQ(markov_embed.size(0), hidden.size(0))
+          << "ConfidenceHead markov_embed batch mismatch";
+      CHECK_EQ(markov_embed.size(-1), markov_rank_)
+          << "ConfidenceHead markov_embed rank mismatch";
+      input = torch::cat({hidden.to(proj_weight_.dtype()),
+                          markov_embed.to(proj_weight_.dtype())},
+                         /*dim=*/-1);
+    } else {
+      input = hidden.to(proj_weight_.dtype());
+    }
+    namespace F = torch::nn::functional;
+    torch::Tensor logit = F::linear(input, proj_weight_, proj_bias_);
+    return torch::sigmoid(logit).squeeze(-1).to(torch::kFloat32);
+  }
+
+  bool defined() const {
+    return proj_weight_.defined() && proj_bias_.defined();
+  }
+
+ private:
+  torch::Tensor proj_weight_;  // [1, hidden_size (+ markov_rank)]
+  torch::Tensor proj_bias_;    // [1]
+  torch::TensorOptions tensor_options_;
+  int64_t hidden_size_ = 0;
+  int64_t markov_rank_ = 0;
+  bool with_markov_ = false;
 };
 
 // DSpark draft model = DFlash block-diffusion backbone (context-K/V injection,
@@ -120,12 +234,37 @@ class DSparkQwen3ForCausalLMImpl final
     const ModelArgs& model_args = context.get_model_args();
     markov_head_.initialize(context.get_tensor_options(),
                             model_args.markov_rank());
+    if (model_args.enable_confidence_head()) {
+      confidence_head_.initialize(context.get_tensor_options(),
+                                  model_args.hidden_size(),
+                                  model_args.markov_rank(),
+                                  model_args.confidence_head_with_markov());
+    }
   }
 
   torch::Tensor dspark_markov_bias(
       const torch::Tensor& previous_token_ids) const {
     return markov_head_.bias(previous_token_ids);
   }
+
+  // Compute per-request acceptance probability using the trained ConfidenceHead
+  // over the draft-step hidden state and the previous token embedding.
+  // hidden: [num_reqs, hidden_size], prev_token_ids: [num_reqs].
+  // Returns [num_reqs] fp32 in [0, 1]. Defined only when
+  // enable_confidence_head.
+  torch::Tensor dspark_confidence_probs(
+      const torch::Tensor& hidden,
+      const torch::Tensor& previous_token_ids) const {
+    CHECK(confidence_head_.defined())
+        << "DSpark ConfidenceHead is not initialized (enable_confidence_head?)";
+    torch::Tensor markov_embed;
+    if (previous_token_ids.defined()) {
+      markov_embed = markov_head_.markov_embed(previous_token_ids);
+    }
+    return confidence_head_.forward(hidden, markov_embed);
+  }
+
+  bool has_dspark_confidence_head() const { return confidence_head_.defined(); }
 
   void load_model(std::unique_ptr<ModelLoader> loader,
                   std::string prefix = "model.") override {
@@ -137,10 +276,14 @@ class DSparkQwen3ForCausalLMImpl final
       }
       model_->load_state_dict(sub_dict);
       markov_head_.load_state_dict(sub_dict);
+      confidence_head_.load_state_dict(sub_dict);
     }
     model_->verify_loaded_weights("");
     model_->merge_loaded_weights();
     markov_head_.verify_loaded_weights("");
+    if (confidence_head_.defined()) {
+      confidence_head_.verify_loaded_weights("");
+    }
   }
 
   ModelOutput write_context_kv(const torch::Tensor& target_hidden,
@@ -154,6 +297,7 @@ class DSparkQwen3ForCausalLMImpl final
 
  private:
   DSparkMarkovHead markov_head_;
+  DSparkConfidenceHead confidence_head_;
 };
 TORCH_MODULE(DSparkQwen3ForCausalLM);
 


### PR DESCRIPTION
## Description

Adaptive speculative decoding for **DFlash** and **DSpark** on NPU: a per-sequence
controller prunes draft tokens before target validation, so sequences whose drafts are
unlikely to be accepted spend less compute on wasted validation. DFlash prunes on draft
path-probability; DSpark uses its dedicated ConfidenceHead output.

Key pieces:
- Per-seq varlen target validate (each sequence validates `accepted + 1` tokens, not a
  batch-wide max), with correct per-seq bonus-token column alignment.
- DECODE-mode layout for the pruned validate step (flatten each seq into q=1 rows),
  matching the existing static path — fixes a garbled-output bug where the
  chunked-prefill mask blocked accepted draft tokens from being attended.
- DSpark ConfidenceHead batched over the whole draft block (one linear+sigmoid instead
  of gamma small kernel launches), plus a skip of the redundant identity hidden-gather.
- Adaptive-aware acceptance / draft-token metrics.

## Test

Qwen3-8B, single NPU, ShareGPT, concurrency=32, `min_gain=0` (most aggressive pruning).
Each (algo, SL) pair runs static and adaptive back-to-back on the same card/config.

| algo | SL | case | tput (tok/s) | mean TPOT (ms) | acc_rate | accepted | drafts |
|---|---|---|---|---|---|---|---|
| DFlash | 7  | static   | 750.8  | 21.2 | 0.441 | 8041 | 18249 |
| DFlash | 7  | adaptive | 846.0  | 18.8 | 0.886 | 6603 | 7450 |
| DFlash | 16 | static   | 764.9  | 24.7 | 0.229 | 8518 | 37216 |
| DFlash | 16 | adaptive | 970.7  | 17.4 | 0.861 | 7092 | 8236 |
| DSpark | 7  | static   | 994.6  | 20.5 | 0.534 | 8062 | 15092 |
| DSpark | 7  | adaptive | 890.0  | 18.2 | 0.801 | 7305 | 9119 |
| DSpark | 16 | static   | 791.7  | 26.1 | 0.244 | 8563 | 35104 |
| DSpark | 16 | adaptive | 1178.4 | 24.1 | 0.882 | 6918 | 7839 |

- Deep speculation is adaptive's biggest win. **DFlash SL16 +27% tput** (764.9 → 970.7),
  draft tokens **-78%** (37216 → 8236), acc_rate 0.229 → 0.861, TPOT 24.7 → 17.4 ms.
  **DSpark SL16 +49% tput** (791.7 → 1178.4), drafts **-78%** (35104 → 7839),
  acc_rate 0.244 → 0.882.
- Shallow SL7 trims drafts 40-59% and lowers TPOT. DFlash SL7 +13% tput; DSpark SL7
  throughput dips slightly as per-step controller overhead offsets the smaller
  draft-compute saving at low speculation length.
- Output text verified coherent (no garbling) at the most aggressive DSpark SL16
  adaptive setting.
- Numerical-parity unit test for the batched ConfidenceHead vs the per-step reference
  (`< 1e-5`).

## Notes

- A pre-existing, low-frequency crash in `BatchInputBuilder::process_single_sequence`
  (the `q_seq_len > 0` CHECK, `batch_input_builder.cpp`) was observed once under DFlash
  SL16 **static** (adaptive off) in an earlier run, and did not reproduce on the run
  above or in 4 subsequent SL16-static runs. It is **not** introduced by this PR — it
  lives in the generic batch builder and was hit on the static path. Likely cause: a
  scheduled decode seq can reach batch-build with zero new tokens when a spec validate
  step commits nothing. Tracked separately.

## Follow-ups (planned)

This PR lands the per-seq validate + DECODE-layout correctness fix and the DSpark
ConfidenceHead compute-path optimizations. The controller's decision *quality* is the
next axis of work, tracked separately:

- **Overlap-safe controller (Tier 1).** The adaptive prefix-length decision currently
  runs synchronously inside `run_validate`, so adaptive is mutually exclusive with
  schedule-overlap. Move the decision ahead of the target forward
  (`prepare_verify_budget`-style) so it overlaps draft compute. This is orthogonal to
  cost-model accuracy and is the highest-value next step.
- **Cost model + budget/top-k allocation (Tier 1).** The current linear regression
  (`intercept + q_tok + q_pref`) lacks a total-batch-tokens term and systematically
  over-prunes near GEMM latency knees; per-candidate greedy admit can miss a later
  position on the same seq. Replace with global top-k-over-budget allocation backed by a
  piecewise-linear SPS cost table.
- **Device-side per-request allocation (Tier 1).** Emit `prefix_lengths` as a device
  tensor (top-k on device) to drop the D2H sync and host vector rebuild; also a
  prerequisite for ragged verify.
- **Structured controller metrics (Tier 2).** Replace the `LOG_EVERY_N` text logging
  with an `AdaptiveDecision` struct (predicted vs actual step time, budget, θ) so
  controller decision quality can be measured and tuned online.
- **High-concurrency sweep.** Deep-speculation adaptive gains grow with batch
  saturation; add a concurrency 64/128/256 sweep to characterize the plateau region,
  where the throughput win is expected to be largest.
- **DSpark ConfidenceHead temperature calibration (STS).** The ConfidenceHead logit
  keeps a temperature-scaling path before the sigmoid, currently fixed at `T = 1.0`
  (no scaling). A follow-up will support Sequential Temperature Scaling (paper
  §3.2.1) so `T` can be calibrated per model, aligning the cumulative acceptance
  product `∏ c_k` with the empirical acceptance rate and sharpening the controller's
  prune decisions.

