### PR TITLE
bugfix: restore JSON grammar state before MTP dispatch.

### DIFF
--- a/tests/core/framework/batch/batch_packed_input_test.cpp
+++ b/tests/core/framework/batch/batch_packed_input_test.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 #include "core/framework/batch/batch_input_builder.h"
 #include "core/framework/block/block_manager_impl.h"
 #include "core/framework/request/stopping_checker.h"
+#include "core/framework/sampling/json_object_grammar.h"
 #include "core/runtime/forward_params.h"
 #include "core/runtime/params_utils.h"
 
@@ -114,6 +115,73 @@ TEST(BatchPackedInputTest, PackedProtoLazyUnpackRestoresSampleIdxes) {
   ASSERT_TRUE(unpacked_input.sampling_params.filter_bitmask.defined());
   EXPECT_TRUE(torch::equal(unpacked_input.sampling_params.filter_bitmask,
                            input.sampling_params.filter_bitmask));
+}
+
+TEST(BatchPackedInputTest, PackedProtoLazyToPreservesJsonMetadata) {
+  RequestSamplingParam sampling_param;
+  StoppingChecker stopping_checker;
+  stopping_checker.set_max_generated_tokens(4);
+
+  SequenceParams seq_params;
+  seq_params.seq_capacity = 32;
+  seq_params.stopping_checker = &stopping_checker;
+  seq_params.sampling_param = &sampling_param;
+  seq_params.enable_schedule_overlap = true;
+
+  MMData mm_data;
+  BlockManager::Options options;
+  options.num_blocks(2).block_size(4);
+  BlockManagerImpl manager(options);
+
+  IncrementalDecoder decoder("", 1, false, false);
+  Sequence sequence(/*index=*/0,
+                    /*token_ids=*/{1, 2, 3, 4},
+                    torch::Tensor(),
+                    mm_data,
+                    std::move(decoder),
+                    seq_params);
+  sequence.add_kv_blocks(manager.allocate(1));
+
+  std::vector<Sequence*> sequences = {&sequence};
+  std::vector<uint32_t> allowed_max_tokens = {4};
+  BatchInputBuilder builder(sequences,
+                            allowed_max_tokens,
+                            {},
+                            {},
+                            nullptr,
+                            /*batch_id=*/2,
+                            nullptr,
+                            BatchForwardType::DECODE);
+  ForwardInput input = builder.build_forward_input(
+      /*num_decoding_tokens=*/1, /*min_decoding_batch_size=*/0);
+
+  JsonObjectGrammar grammar({"{", "}", "stop"}, /*stop_token_ids=*/{2});
+  JsonObjectGrammarState state = grammar.initial_state();
+  ASSERT_TRUE(state.accept_token(/*open_object=*/0));
+  input.json_object_state_snapshots = {state.snapshot()};
+  input.sample_sequence_ids = {"req-json#0"};
+  input.sample_prior_output_rows = {-1};
+
+  proto::PackedForwardInput packed_input;
+  ASSERT_TRUE(forward_input_to_packed_proto(input, &packed_input));
+
+  ForwardInput lazy_input;
+  packed_proto_to_forward_input(
+      packed_input, lazy_input, torch::Device(torch::kCPU), nullptr);
+  EXPECT_TRUE(lazy_input.input_host_buffer_has_layout);
+  EXPECT_TRUE(lazy_input.json_object_state_snapshots.empty());
+
+  const ForwardInput materialized_input =
+      lazy_input.to(torch::Device(torch::kCPU), torch::kFloat32);
+  ASSERT_EQ(materialized_input.json_object_state_snapshots.size(), 1u);
+  EXPECT_EQ(materialized_input.json_object_state_snapshots[0].token_ids,
+            std::vector<int32_t>({0}));
+  EXPECT_FALSE(
+      materialized_input.json_object_state_snapshots[0].reasoning_enabled);
+  EXPECT_EQ(materialized_input.sample_sequence_ids,
+            std::vector<std::string>({"req-json#0"}));
+  EXPECT_EQ(materialized_input.sample_prior_output_rows,
+            std::vector<int32_t>({-1}));
 }
 
 }  // namespace xllm

--- a/tests/core/framework/batch/batch_test.cpp
+++ b/tests/core/framework/batch/batch_test.cpp
@@ -40,6 +40,7 @@ limitations under the License.
 #include "framework/kv_cache/kv_cache.h"
 #include "framework/model/model_args.h"
 #include "framework/request/stopping_checker.h"
+#include "framework/sampling/rejection_sampler.h"
 #include "framework/sampling/sampling_params.h"
 #include "framework/tokenizer/tokenizer.h"
 #include "platform/device.h"
@@ -944,6 +945,168 @@ TEST(BatchTest, JsonObjectSampleSequenceIdsFollowSamplingRows) {
   ForwardInput next_input = batch.prepare_forward_input(
       /*num_decoding_tokens=*/1, /*min_decoding_bach_size=*/0, ModelArgs());
   EXPECT_EQ(next_input.sample_prior_output_rows, std::vector<int32_t>({0, 1}));
+}
+
+TEST(BatchTest, ReorderedMtpAcceptedRowsCommitToOwningSequences) {
+  ScopedJsonObjectOutput enabled(/*enabled=*/true);
+  BlockManager::Options options;
+  options.num_blocks(8).block_size(16);
+  BlockManagerImpl manager(options);
+
+  RequestSamplingParam sampling_param;
+  StoppingChecker stopping_checker;
+  stopping_checker.set_max_generated_tokens(16);
+  std::shared_ptr<const JsonObjectGrammar> grammar =
+      std::make_shared<const JsonObjectGrammar>(
+          std::vector<std::string>{"{",
+                                   "\"a\"",
+                                   ":",
+                                   "1",
+                                   "}",
+                                   "stop",
+                                   "plain-6",
+                                   "plain-7",
+                                   "plain-8",
+                                   "]",
+                                   "plain-10",
+                                   "plain-11",
+                                   "plain-12",
+                                   "plain-13",
+                                   "plain-14",
+                                   "plain-15"},
+          std::unordered_set<int32_t>{5});
+
+  SequenceParams constrained_params;
+  constrained_params.seq_capacity = 16;
+  constrained_params.stopping_checker = &stopping_checker;
+  constrained_params.sampling_param = &sampling_param;
+  constrained_params.request_id = "req-json-chain";
+  constrained_params.json_object_grammar = grammar;
+  constrained_params.json_reasoning_enabled = false;
+  constrained_params.enable_schedule_overlap = true;
+
+  SequenceParams plain_params = constrained_params;
+  plain_params.request_id = "req-plain-chain";
+  plain_params.json_object_grammar.reset();
+
+  IncrementalDecoder constrained_decoder("", 2, false, false);
+  Sequence constrained(/*index=*/0,
+                       /*prompt_token_ids=*/{100, 101},
+                       torch::Tensor(),
+                       MMData(),
+                       std::move(constrained_decoder),
+                       constrained_params);
+  constrained.add_kv_blocks(manager.allocate(1));
+
+  IncrementalDecoder plain_decoder("", 2, false, false);
+  Sequence plain(/*index=*/1,
+                 /*prompt_token_ids=*/{200, 201},
+                 torch::Tensor(),
+                 MMData(),
+                 std::move(plain_decoder),
+                 plain_params);
+  plain.add_kv_blocks(manager.allocate(1));
+
+  Batch batch({&plain, &constrained});
+  ForwardInput first_input = batch.prepare_forward_input(
+      /*num_decoding_tokens=*/1, /*min_decoding_batch_size=*/0, ModelArgs());
+  EXPECT_EQ(
+      first_input.sample_sequence_ids,
+      std::vector<std::string>({"req-plain-chain#1", "req-json-chain#0"}));
+  EXPECT_TRUE(equal(first_input.sampling_params.selected_token_idxes,
+                    std::vector<int32_t>({1, 3})));
+  ASSERT_EQ(first_input.json_object_states.size(), 2u);
+  EXPECT_FALSE(first_input.json_object_states[0].initialized());
+  EXPECT_TRUE(first_input.json_object_states[1].initialized());
+
+  RawForwardOutput fake_output;
+  fake_output.outputs = {make_raw_sample_output(-1, std::nullopt),
+                         make_raw_sample_output(-2, std::nullopt)};
+  batch.process_sample_output(fake_output, /*replace_fake_token=*/false);
+  ForwardInput commit_input = batch.prepare_forward_input(
+      /*num_decoding_tokens=*/1, /*min_decoding_batch_size=*/0, ModelArgs());
+  EXPECT_EQ(
+      commit_input.sample_sequence_ids,
+      std::vector<std::string>({"req-plain-chain#1", "req-json-chain#0"}));
+  EXPECT_EQ(commit_input.sample_prior_output_rows,
+            std::vector<int32_t>({0, 1}));
+
+  const torch::Tensor draft_token_ids =
+      torch::tensor({{10, 11, 12, 13, 14}, {0, 1, 9, 3, 4}}, torch::kInt64);
+  const torch::Tensor target_token_ids =
+      torch::tensor({{10, 11, 12, 13, 14}, {0, 1, 2, 3, 4}}, torch::kInt64);
+  torch::Tensor target_logits = torch::zeros({2, 6, 16}, torch::kFloat32);
+  for (int64_t row = 0; row < target_token_ids.size(0); ++row) {
+    for (int64_t step = 0; step < target_token_ids.size(1); ++step) {
+      target_logits.index_put_(
+          {row, step, target_token_ids.index({row, step}).item<int64_t>()},
+          20.0F);
+    }
+  }
+  const torch::Tensor bonus_token_ids =
+      torch::tensor({{15}, {5}}, torch::kInt64);
+  const torch::Tensor do_sample = torch::tensor({false, false}, torch::kBool);
+  RejectionSampler rejection_sampler(do_sample,
+                                     /*all_random_sample=*/false,
+                                     /*all_greedy_sample=*/true,
+                                     /*logprobs=*/false,
+                                     /*max_top_logprobs=*/0);
+  const SampleOutput accepted_output =
+      rejection_sampler.forward(draft_token_ids,
+                                torch::zeros({2, 5}, torch::kFloat32),
+                                target_logits,
+                                bonus_token_ids,
+                                /*mask_out_rejected_tokens=*/true);
+  EXPECT_TRUE(torch::equal(
+      accepted_output.next_tokens,
+      torch::tensor({{10, 11, 12, 13, 14, 15}, {0, 1, 2, -1, -1, -1}},
+                    torch::kInt64)));
+
+  JsonObjectGrammarState expected_constrained_state = grammar->initial_state();
+  ASSERT_TRUE(expected_constrained_state.accept_token(0));
+  ASSERT_TRUE(expected_constrained_state.accept_token(1));
+  EXPECT_FALSE(expected_constrained_state.can_accept_token(9));
+  ASSERT_TRUE(expected_constrained_state.accept_token(2));
+
+  const torch::Tensor undefined;
+  proto::ForwardOutput proto_output;
+  forward_output_to_proto(accepted_output.next_tokens,
+                          undefined,
+                          undefined,
+                          undefined,
+                          undefined,
+                          undefined,
+                          /*prepared_layer_id=*/-1,
+                          undefined,
+                          undefined,
+                          undefined,
+                          /*dit_images=*/{},
+                          /*json_object_errors=*/{},
+                          &proto_output);
+  RawForwardOutput raw_output;
+  proto_to_forward_output(proto_output, raw_output);
+  ASSERT_EQ(raw_output.outputs.size(), 2u);
+  EXPECT_EQ(raw_output.outputs[0].tokens.size(), 6u);
+  EXPECT_EQ(raw_output.outputs[0].tokens.back().id, 15);
+  EXPECT_EQ(raw_output.outputs[1].tokens.size(), 3u);
+  EXPECT_EQ(raw_output.outputs[1].tokens.back().id, 2);
+
+  EXPECT_NO_FATAL_FAILURE(
+      batch.process_sample_output(raw_output, /*replace_fake_token=*/true));
+  ASSERT_FALSE(plain.error_status().has_value());
+  ASSERT_FALSE(constrained.error_status().has_value());
+  ASSERT_EQ(plain.num_generated_tokens(), 6u);
+  ASSERT_EQ(constrained.num_generated_tokens(), 3u);
+  for (size_t token_idx = 0; token_idx < 6; ++token_idx) {
+    EXPECT_EQ(plain.tokens()[plain.num_prompt_tokens() + token_idx],
+              10 + token_idx);
+  }
+  EXPECT_EQ(constrained.tokens()[constrained.num_prompt_tokens()], 0);
+  EXPECT_EQ(constrained.tokens()[constrained.num_prompt_tokens() + 1], 1);
+  EXPECT_EQ(constrained.tokens()[constrained.num_prompt_tokens() + 2], 2);
+  ASSERT_NE(constrained.json_object_state(), nullptr);
+  EXPECT_EQ(constrained.json_object_state()->fingerprint(),
+            expected_constrained_state.fingerprint());
 }
 
 TEST(BatchTest, JsonObjectMetadataIsSkippedWhenDisabled) {

--- a/tests/core/framework/sampling/json_object_grammar_test.cpp
+++ b/tests/core/framework/sampling/json_object_grammar_test.cpp
@@ -202,6 +202,17 @@ TEST(JsonObjectGrammarTest, ReasoningIsUnconstrainedUntilEndMarker) {
   EXPECT_FALSE(state.can_accept_token(1));
 }
 
+TEST(JsonObjectGrammarTest, ReasoningDisabledRejectsEndMarkerAtJsonStart) {
+  JsonObjectGrammar grammar({"{", "}", "reasoning", "<think>", "</think>"},
+                            /*stop_token_ids=*/{1},
+                            {3, 4});
+  JsonObjectGrammarState state = grammar.initial_state();
+
+  EXPECT_FALSE(state.in_reasoning());
+  EXPECT_FALSE(state.can_accept_token(/*reasoning_end=*/4));
+  EXPECT_TRUE(state.can_accept_token(/*open_object=*/0));
+}
+
 TEST(JsonObjectGrammarTest, RejectsNonEmptyStopTokensBeforeRootCompletion) {
   JsonObjectGrammar grammar({"{",
                              "\"",

--- a/tests/core/framework/sampling/rejection_sampler_test.cpp
+++ b/tests/core/framework/sampling/rejection_sampler_test.cpp
@@ -201,6 +201,58 @@ TEST(RejectionSamplerTest, Greedy) {
                               bonus_token_ids));
 }
 
+TEST(RejectionSamplerTest, GreedyRejectsGrammarMaskedDraftToken) {
+  const auto options = get_test_options(torch::kFloat32);
+
+  // The JSON grammar mask removes draft token 0 from the target distribution.
+  const auto draft_token_ids =
+      torch::tensor({{0}}, options.dtype(torch::kInt64));
+  const auto target_probs = torch::tensor({{{0.0F, 1.0F, 0.0F}}}, options);
+  const auto bonus_token_ids =
+      torch::tensor({{2}}, options.dtype(torch::kInt64));
+
+  auto [output, masked_output] =
+      RejectionSampler::greedy_sample(draft_token_ids,
+                                      target_probs,
+                                      bonus_token_ids,
+                                      /*mask_out_rejected_tokens=*/true);
+
+  const auto expected_output =
+      torch::tensor({{1, 2}}, options.dtype(torch::kInt64));
+  const auto expected_masked_output =
+      torch::tensor({{1, -1}}, options.dtype(torch::kInt64));
+  EXPECT_TRUE(torch::equal(output, expected_output));
+  EXPECT_TRUE(torch::equal(masked_output, expected_masked_output));
+}
+
+TEST(RejectionSamplerTest, RandomRejectsGrammarMaskedDraftToken) {
+  const auto options = get_test_options(torch::kFloat32);
+
+  // The JSON grammar mask removes draft token 0 from the target distribution.
+  const auto draft_token_ids =
+      torch::tensor({{0}}, options.dtype(torch::kInt64));
+  const auto draft_probs = torch::tensor({{{1.0F, 0.0F, 0.0F}}}, options);
+  const auto target_probs = torch::tensor({{{0.0F, 1.0F, 0.0F}}}, options);
+  const auto uniform_rand = torch::tensor({{0.5F}}, options);
+  const auto bonus_token_ids =
+      torch::tensor({{2}}, options.dtype(torch::kInt64));
+
+  auto [output, masked_output] =
+      RejectionSampler::random_sample(draft_token_ids,
+                                      draft_probs,
+                                      target_probs,
+                                      uniform_rand,
+                                      bonus_token_ids,
+                                      /*mask_out_rejected_tokens=*/true);
+
+  const auto expected_output =
+      torch::tensor({{1, 2}}, options.dtype(torch::kInt64));
+  const auto expected_masked_output =
+      torch::tensor({{1, -1}}, options.dtype(torch::kInt64));
+  EXPECT_TRUE(torch::equal(output, expected_output));
+  EXPECT_TRUE(torch::equal(masked_output, expected_masked_output));
+}
+
 TEST(RejectionSamplerTest, LogProbs) {
   const auto options = get_test_options(torch::kFloat32);
   const auto device = get_test_device();
@@ -527,6 +579,37 @@ TEST(RejectionSamplerTest, RandomFused) {
       }
     }
   }
+}
+
+TEST(RejectionSamplerTest, RandomFusedRejectsGrammarMaskedDraftToken) {
+  if (Device::type_str() != "mlu" || Device::device_count() == 0) {
+    GTEST_SKIP() << "Skipping test: MLU device required.";
+  }
+
+  const torch::Device device(Device::type_torch(), 0);
+  const auto options = torch::dtype(torch::kFloat32).device(device);
+
+  // The JSON grammar mask removes draft token 0 from the target distribution.
+  const auto draft_token_ids =
+      torch::tensor({{0}}, options.dtype(torch::kInt64));
+  const auto draft_probs = torch::tensor({{{1.0F, 0.0F, 0.0F}}}, options);
+  const auto target_probs = torch::tensor({{{0.0F, 1.0F, 0.0F}}}, options);
+  const auto uniform_rand = torch::tensor({{0.5F}}, options);
+  const auto bonus_token_ids =
+      torch::tensor({{2}}, options.dtype(torch::kInt64));
+
+  auto [output, masked_output] =
+      RejectionSampler::random_sample_fused(draft_token_ids,
+                                            draft_probs,
+                                            target_probs,
+                                            uniform_rand,
+                                            bonus_token_ids,
+                                            /*mask_out_rejected_tokens=*/true);
+
+  const auto expected_masked_output =
+      torch::tensor({{1, -1}}, options.dtype(torch::kInt64));
+  EXPECT_TRUE(torch::equal(output, expected_masked_output));
+  EXPECT_TRUE(torch::equal(masked_output, expected_masked_output));
 }
 
 TEST(RejectionSamplerTest, RandomFusedRecoveryDistribution) {

--- a/tests/core/runtime/mtp_json_object_state_test.cpp
+++ b/tests/core/runtime/mtp_json_object_state_test.cpp
@@ -119,6 +119,141 @@ TEST(MtpJsonObjectStateTest, PreservesAcceptedPrefixAfterMiddleInvalidDraft) {
             scratch.states_after[0][0].fingerprint());
 }
 
+TEST(MtpJsonObjectStateTest, FiveDraftRowsReplayFromCommittedState) {
+  JsonObjectGrammar grammar = make_mtp_grammar();
+  const std::vector<JsonObjectGrammarState> initial_states = {
+      grammar.initial_state()};
+  std::vector<JsonObjectGrammarState> current_states = initial_states;
+  std::vector<uint8_t> invalid_suffix(1, 0);
+  detail::JsonDraftValidationScratch scratch;
+  const std::vector<int32_t> draft_tokens = {0, 1, 2, 3, 4};
+
+  for (const int32_t token_id : draft_tokens) {
+    EXPECT_FALSE(detail::append_json_draft_step(
+        current_states, invalid_suffix, {token_id}, scratch));
+  }
+
+  std::vector<uint8_t> invalid_draft;
+  const std::vector<JsonObjectGrammarState> validation_states =
+      detail::build_json_validation_states(
+          initial_states, scratch, invalid_draft);
+
+  ASSERT_EQ(validation_states.size(), 6u);
+  EXPECT_EQ(invalid_draft, std::vector<uint8_t>({0, 0, 0, 0, 0}));
+  JsonObjectGrammarState committed_state = initial_states[0];
+  for (size_t token_idx = 0; token_idx < draft_tokens.size(); ++token_idx) {
+    EXPECT_EQ(validation_states[token_idx].fingerprint(),
+              committed_state.fingerprint());
+    ASSERT_TRUE(
+        validation_states[token_idx].can_accept_token(draft_tokens[token_idx]));
+    ASSERT_TRUE(committed_state.accept_token(draft_tokens[token_idx]));
+  }
+  EXPECT_EQ(validation_states.back().fingerprint(),
+            committed_state.fingerprint());
+  EXPECT_TRUE(validation_states.back().can_accept_token(/*stop=*/5));
+  EXPECT_TRUE(committed_state.accept_token(/*stop=*/5));
+}
+
+TEST(MtpJsonObjectStateTest,
+     ReasoningDisabledValidationRowsRejectReasoningEndMarker) {
+  JsonObjectGrammar grammar(
+      {"{", "\"a\"", ":", "1", "}", "stop", "<think>", "</think>"},
+      /*stop_token_ids=*/{5},
+      /*reasoning_end_token_ids=*/{7});
+  const std::vector<JsonObjectGrammarState> initial_states = {
+      grammar.initial_state(/*reasoning_phase=*/false)};
+  std::vector<JsonObjectGrammarState> current_states = initial_states;
+  std::vector<uint8_t> invalid_suffix(1, 0);
+  detail::JsonDraftValidationScratch scratch;
+  const std::vector<int32_t> draft_tokens = {0, 1, 2, 3, 4};
+
+  for (const int32_t token_id : draft_tokens) {
+    EXPECT_FALSE(detail::append_json_draft_step(
+        current_states, invalid_suffix, {token_id}, scratch));
+  }
+
+  std::vector<uint8_t> invalid_draft;
+  const std::vector<JsonObjectGrammarState> validation_states =
+      detail::build_json_validation_states(
+          initial_states, scratch, invalid_draft);
+
+  ASSERT_EQ(validation_states.size(), 6u);
+  for (const JsonObjectGrammarState& state : validation_states) {
+    EXPECT_FALSE(state.in_reasoning());
+    EXPECT_FALSE(state.can_accept_token(/*reasoning_end=*/7));
+  }
+}
+
+TEST(MtpJsonObjectStateTest, ReplaysFiveStepMixedAcceptedOutputRows) {
+  JsonObjectGrammar grammar = make_mtp_grammar();
+  const std::vector<JsonObjectGrammarState> initial_states = {
+      grammar.initial_state(), JsonObjectGrammarState()};
+  const int64_t accepted_tokens[] = {
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      5,
+      4,
+      3,
+      2,
+      1,
+      0,
+  };
+
+  const std::vector<detail::JsonAcceptedTokenMismatch> mismatches =
+      detail::find_json_accepted_token_mismatches(
+          initial_states, accepted_tokens, /*num_rows=*/2, /*row_width=*/6);
+
+  EXPECT_TRUE(mismatches.empty());
+}
+
+TEST(MtpJsonObjectStateTest, ReportsFirstAcceptedOutputMismatchPerSequence) {
+  JsonObjectGrammar grammar = make_mtp_grammar();
+  JsonObjectGrammarState committed_state = grammar.initial_state();
+  ASSERT_TRUE(committed_state.accept_token(/*open_object=*/0));
+  const std::vector<JsonObjectGrammarState> initial_states = {
+      committed_state, JsonObjectGrammarState()};
+  const int64_t accepted_tokens[] = {
+      1,
+      4,
+      3,
+      -1,
+      -1,
+      -1,
+      5,
+      4,
+      3,
+      2,
+      1,
+      0,
+  };
+
+  const std::vector<detail::JsonAcceptedTokenMismatch> mismatches =
+      detail::find_json_accepted_token_mismatches(
+          initial_states, accepted_tokens, /*num_rows=*/2, /*row_width=*/6);
+
+  ASSERT_EQ(mismatches.size(), 1u);
+  EXPECT_EQ(mismatches[0].sequence_index, 0u);
+  EXPECT_EQ(mismatches[0].token_offset, 1u);
+  EXPECT_EQ(mismatches[0].token_id, 4);
+  EXPECT_EQ(mismatches[0].committed_tokens, 2u);
+}
+
+TEST(MtpJsonObjectStateTest, AcceptedOutputOnlyUsesMinusOneAsPadding) {
+  JsonObjectGrammar grammar = make_mtp_grammar();
+  const std::vector<JsonObjectGrammarState> initial_states = {
+      grammar.initial_state()};
+  const int64_t accepted_tokens[] = {0, -2};
+
+  EXPECT_DEATH(
+      detail::find_json_accepted_token_mismatches(
+          initial_states, accepted_tokens, /*num_rows=*/1, /*row_width=*/2),
+      "padding must use -1");
+}
+
 TEST(MtpJsonObjectStateTest, CopiesContiguousHostDraftTokensInBulk) {
   const int64_t token_ids[] = {0, 4, -1, 5};
 

--- a/xllm/core/runtime/mtp_json_object_state.h
+++ b/xllm/core/runtime/mtp_json_object_state.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <utility>
 #include <vector>
 
@@ -32,6 +33,14 @@ struct JsonDraftValidationScratch final {
   std::vector<std::vector<JsonObjectGrammarState>> states_after;
   // Invalid suffix flags in [draft_step][sequence] order.
   std::vector<uint8_t> invalid_draft_step_major;
+};
+
+struct JsonAcceptedTokenMismatch final {
+  size_t sequence_index = 0;
+  size_t token_offset = 0;
+  int32_t token_id = -1;
+  size_t committed_tokens = 0;
+  uint64_t state_fingerprint = 0;
 };
 
 inline std::vector<int32_t> copy_json_draft_token_ids(const int64_t* token_ids,
@@ -111,6 +120,51 @@ inline std::vector<JsonObjectGrammarState> build_json_validation_states(
     validation_states.push_back(scratch.states_after.back()[seq_idx]);
   }
   return validation_states;
+}
+
+inline std::vector<JsonAcceptedTokenMismatch>
+find_json_accepted_token_mismatches(
+    const std::vector<JsonObjectGrammarState>& initial_states,
+    const int64_t* accepted_tokens,
+    size_t num_rows,
+    size_t row_width) {
+  CHECK_EQ(initial_states.size(), num_rows)
+      << "JSON accepted output rows must match grammar state rows";
+  CHECK(accepted_tokens != nullptr || num_rows * row_width == 0)
+      << "JSON accepted output token buffer must be defined";
+
+  std::vector<JsonAcceptedTokenMismatch> mismatches;
+  mismatches.reserve(num_rows);
+  for (size_t sequence_index = 0; sequence_index < num_rows; ++sequence_index) {
+    JsonObjectGrammarState state = initial_states[sequence_index];
+    if (!state.initialized()) {
+      continue;
+    }
+
+    const size_t row_offset = sequence_index * row_width;
+    for (size_t token_offset = 0; token_offset < row_width; ++token_offset) {
+      const int64_t raw_token_id = accepted_tokens[row_offset + token_offset];
+      if (raw_token_id == -1) {
+        break;
+      }
+      CHECK_GE(raw_token_id, 0) << "MTP accepted output padding must use -1";
+      CHECK_LE(raw_token_id,
+               static_cast<int64_t>(std::numeric_limits<int32_t>::max()))
+          << "JSON accepted output token id exceeds int32 range";
+      const int32_t token_id = static_cast<int32_t>(raw_token_id);
+      if (!state.can_accept_token(token_id)) {
+        const JsonObjectGrammarSnapshot snapshot = state.snapshot();
+        mismatches.push_back({sequence_index,
+                              token_offset,
+                              token_id,
+                              snapshot.token_ids.size(),
+                              state.fingerprint()});
+        break;
+      }
+      CHECK(state.accept_token(token_id));
+    }
+  }
+  return mismatches;
 }
 
 }  // namespace xllm::detail

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 #include <exception>
 #include <memory>
 #include <string>
+#include <unordered_set>
 
 #if defined(USE_NPU)
 #include <acl/acl.h>
@@ -727,7 +728,7 @@ class NpuJsonDraftTokenHandoff final {
   bool can_use_async_handoff(const torch::Tensor& next_tokens,
                              const int64_t token_count) const {
     return event_path_enabled_ && max_sequences_per_batch_ > 0 &&
-           token_count >= 0 && token_count <= max_sequences_per_batch_ &&
+           token_count > 0 && token_count <= max_sequences_per_batch_ &&
            !next_tokens.device().is_cpu() && next_tokens.is_contiguous() &&
            next_tokens.scalar_type() == torch::kLong;
   }
@@ -1130,7 +1131,10 @@ folly::SemiFuture<std::optional<ForwardOutput>> MTPWorkerImpl::step_async(
 
     auto output = this->step_for_schedule_overlap(input_on_device);
     if (output.has_value()) {
-      output->json_object_errors = input_on_device.json_object_errors;
+      output->json_object_errors.insert(
+          output->json_object_errors.end(),
+          input_on_device.json_object_errors.begin(),
+          input_on_device.json_object_errors.end());
       if (is_driver() || ::xllm::EPLBConfig::get_instance().enable_eplb()) {
         std::unique_lock<std::mutex> output_lock(mtx_);
         cv_.wait(output_lock, [this] { return !is_recorded_; });
@@ -1714,6 +1718,68 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
       static_cast<int64_t>(final_sync_timer.elapsed_microseconds()));
   release_retained_inputs(target_output);
   val_output.next_tokens = val_output.next_tokens.to(torch::kCPU);
+  std::vector<size_t> failed_sequence_rows;
+  if (!input.json_object_states.empty()) {
+    CHECK_EQ(val_output.next_tokens.dim(), 2)
+        << "MTP JSON accepted output must be [sequence, token]";
+    CHECK_EQ(input.sample_sequence_ids.size(), input.json_object_states.size())
+        << "MTP JSON sequence ids must match grammar state rows";
+    const torch::Tensor accepted_tokens =
+        val_output.next_tokens.to(torch::kInt64).contiguous();
+    const std::vector<detail::JsonAcceptedTokenMismatch> mismatches =
+        detail::find_json_accepted_token_mismatches(
+            input.json_object_states,
+            accepted_tokens.const_data_ptr<int64_t>(),
+            static_cast<size_t>(accepted_tokens.size(0)),
+            static_cast<size_t>(accepted_tokens.size(1)));
+    CHECK_EQ(input.input_params.embedding.embedding_ids.size(),
+             input.json_object_states.size())
+        << "MTP JSON embedding ids must match grammar state rows";
+    std::unordered_set<std::string> failed_sequence_ids;
+    failed_sequence_ids.reserve(input.json_object_errors.size() +
+                                target_output.json_object_errors.size() +
+                                mismatches.size());
+    for (const JsonObjectOutputError& error : input.json_object_errors) {
+      CHECK(!error.sample_sequence_id.empty())
+          << "MTP JSON input error requires a sampled sequence id";
+      failed_sequence_ids.emplace(error.sample_sequence_id);
+    }
+    for (const JsonObjectOutputError& error :
+         target_output.json_object_errors) {
+      CHECK(!error.sample_sequence_id.empty())
+          << "MTP JSON output error requires a sampled sequence id";
+      failed_sequence_ids.emplace(error.sample_sequence_id);
+    }
+    for (const detail::JsonAcceptedTokenMismatch& mismatch : mismatches) {
+      const std::string& sample_sequence_id =
+          input.sample_sequence_ids[mismatch.sequence_index];
+      CHECK(!sample_sequence_id.empty())
+          << "MTP JSON mismatch requires a sampled sequence id";
+      LOG(ERROR) << "MTP JSON accepted output replay mismatch: sequence_id="
+                 << sample_sequence_id
+                 << ", token_offset=" << mismatch.token_offset
+                 << ", token_id=" << mismatch.token_id
+                 << ", committed_tokens=" << mismatch.committed_tokens
+                 << ", state_fingerprint=" << mismatch.state_fingerprint;
+      if (failed_sequence_ids.emplace(sample_sequence_id).second) {
+        target_output.json_object_errors.push_back(
+            {sample_sequence_id,
+             "accepted MTP output violates json_object grammar, token_id=" +
+                 std::to_string(mismatch.token_id)});
+      }
+    }
+    failed_sequence_rows.reserve(failed_sequence_ids.size());
+    for (size_t sequence_index = 0;
+         sequence_index < input.sample_sequence_ids.size();
+         ++sequence_index) {
+      if (failed_sequence_ids.contains(
+              input.sample_sequence_ids[sequence_index])) {
+        failed_sequence_rows.emplace_back(sequence_index);
+      }
+    }
+    CHECK_EQ(failed_sequence_rows.size(), failed_sequence_ids.size())
+        << "MTP JSON errors must reference sampled rows in the current batch";
+  }
   {
     int64_t constrained_accepted = 0;
     int64_t plain_accepted = 0;
@@ -1757,7 +1823,7 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
                 constrained_draft);
     COUNTER_ADD(speculative_num_draft_tokens_plain_total, plain_draft);
   }
-  write_target_context_to_cache(input, val_output);
+  write_target_context_to_cache(input, val_output, failed_sequence_rows);
 
   if (!enable_schedule_overlap() && !driver_ && !dp_driver_) {
     return std::nullopt;
@@ -1770,17 +1836,62 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
 
 void MTPWorkerImpl::write_target_context_to_cache(
     const ForwardInput& input,
-    const SampleOutput& validate_output) {
+    const SampleOutput& validate_output,
+    const std::vector<size_t>& failed_rows) {
   CHECK(embedding_cache_ != nullptr)
       << "embedding_cache_ must be initialized before target cache write";
   CHECK(!input.input_params.embedding.embedding_ids.empty())
       << "target context cache write requires embedding ids";
-  embedding_cache_->write_target_context(
-      input.input_params.embedding.embedding_ids,
-      input.input_params.embedding.request_ids,
-      validate_output.next_tokens,
-      validate_output.embeddings,
-      options_.num_speculative_tokens());
+  if (failed_rows.empty()) {
+    embedding_cache_->write_target_context(
+        input.input_params.embedding.embedding_ids,
+        input.input_params.embedding.request_ids,
+        validate_output.next_tokens,
+        validate_output.embeddings,
+        options_.num_speculative_tokens());
+    return;
+  }
+
+  const std::vector<int32_t>& embedding_ids =
+      input.input_params.embedding.embedding_ids;
+  const std::vector<std::string>& request_ids =
+      input.input_params.embedding.request_ids;
+  CHECK(request_ids.empty() || request_ids.size() == embedding_ids.size())
+      << "target context request ids must match embedding ids";
+  std::unordered_set<size_t> failed_row_set(failed_rows.begin(),
+                                            failed_rows.end());
+  CHECK_EQ(failed_row_set.size(), failed_rows.size())
+      << "target context failed rows must be unique";
+
+  std::vector<int32_t> failed_embedding_ids;
+  failed_embedding_ids.reserve(failed_rows.size());
+  for (const size_t failed_row : failed_rows) {
+    CHECK_LT(failed_row, embedding_ids.size())
+        << "target context failed row exceeds embedding ids";
+    failed_embedding_ids.emplace_back(embedding_ids[failed_row]);
+  }
+  embedding_cache_->clear(failed_embedding_ids);
+
+  for (size_t sequence_index = 0; sequence_index < embedding_ids.size();
+       ++sequence_index) {
+    if (failed_row_set.contains(sequence_index)) {
+      continue;
+    }
+    const std::vector<int32_t> row_embedding_ids = {
+        embedding_ids[sequence_index]};
+    const std::vector<std::string> row_request_ids =
+        request_ids.empty()
+            ? std::vector<std::string>()
+            : std::vector<std::string>{request_ids[sequence_index]};
+    embedding_cache_->write_target_context(
+        row_embedding_ids,
+        row_request_ids,
+        validate_output.next_tokens.narrow(
+            /*dim=*/0, /*start=*/sequence_index, /*length=*/1),
+        validate_output.embeddings.narrow(
+            /*dim=*/0, /*start=*/sequence_index, /*length=*/1),
+        options_.num_speculative_tokens());
+  }
 }
 
 void MTPWorkerImpl::process_draft_sample_output(SampleOutput& sample_output) {

--- a/xllm/core/runtime/mtp_worker_impl.h
+++ b/xllm/core/runtime/mtp_worker_impl.h
@@ -146,7 +146,8 @@ class MTPWorkerImpl : public SpeculativeWorkerImpl {
       ForwardInput& extend_input);
 
   void write_target_context_to_cache(const ForwardInput& input,
-                                     const SampleOutput& validate_output);
+                                     const SampleOutput& validate_output,
+                                     const std::vector<size_t>& failed_rows);
 
  protected:
   // Draft model worker

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -989,6 +989,12 @@ void WorkerImpl::prepare_work_before_execute_on_stream(
 
   auto prepare_device_on_stream = [&]() {
     processed_input = prep_for_device.to(device_, dtype_);
+    // Packed RPC/SHM inputs deserialize JSON snapshots inside ForwardInput::to.
+    // Restore them before speculative dispatch so MTP sees the grammar rows.
+    if (processed_input.json_object_states.empty() &&
+        !processed_input.json_object_state_snapshots.empty()) {
+      restore_json_object_states(processed_input);
+    }
     ensure_forward_input_device_tensors(processed_input, device_);
 
 #if defined(USE_NPU)


### PR DESCRIPTION
- restore packed JSON snapshots after ForwardInput materialization

- validate accepted MTP output against committed grammar state

- isolate invalid rows from embedding-cache updates

- add packed-input, five-step MTP, and mixed-row regressions

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
