### PR TITLE
feat: add MUSA CICD supports.

### DIFF
--- a/.github/workflows/build_x86_64_musa.yaml
+++ b/.github/workflows/build_x86_64_musa.yaml
@@ -69,6 +69,11 @@ jobs:
           event="${{ github.event_name }}"
           if [[ "${event}" == "pull_request" ||
                 "${event}" == "pull_request_review" ]]; then
+            changed_files="$(
+              git diff --name-only \
+                "${{ github.event.pull_request.base.sha }}" \
+                "${{ github.event.pull_request.head.sha }}"
+            )"
             while IFS= read -r changed_file; do
               case "${changed_file}" in
                 .github/**|cibuild/**|setup.py|examples/generate.py)
@@ -76,11 +81,7 @@ jobs:
                   break
                   ;;
               esac
-            done < <(
-              git diff --name-only \
-                "${{ github.event.pull_request.base.sha }}" \
-                "${{ github.event.pull_request.head.sha }}"
-            )
+            done <<< "${changed_files}"
           fi
           echo "requires_approval=${requires_approval}" >> "${GITHUB_OUTPUT}"
 
@@ -142,6 +143,9 @@ jobs:
         run: git submodule foreach --recursive git clean -ffdx
 
       - name: Build Python package
+        if: ${{ success() }}
+        timeout-minutes: 120
         run: |
+          chmod +x ./cibuild/build_musa.sh
           bash ./cibuild/build_musa.sh \
             'python setup.py build --device musa'

--- a/.github/workflows/build_x86_64_musa.yaml
+++ b/.github/workflows/build_x86_64_musa.yaml
@@ -108,6 +108,9 @@ jobs:
     runs-on: [xllm-musa-x86-cicd]
     timeout-minutes: 120
     steps:
+      - name: Prepare vcpkg cache
+        run: mkdir -p /export/home/musa_vcpkg_cache/archives /export/home/musa_vcpkg_cache/downloads
+
       - name: Prepare submodule checkout
         run: |
           if [ -d .git/modules ]; then

--- a/.github/workflows/build_x86_64_musa.yaml
+++ b/.github/workflows/build_x86_64_musa.yaml
@@ -1,0 +1,147 @@
+# Copyright 2026 The xLLM Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: xLLM Build x86_64 MUSA
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - 'tools/**'
+      - '*.md'
+      - '*.txt'
+      - '*.yml'
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+    paths-ignore:
+      - 'docs/**'
+      - 'tools/**'
+      - '*.md'
+      - '*.txt'
+      - '*.yml'
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+
+env:
+  JOBNAME: xllm-x86_64-musa-cibuild-${{ github.run_id }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  # Review changes to executable CI inputs before using the privileged runner.
+  check-sensitive:
+    runs-on: [xllm-cpu-only-cicd]
+    outputs:
+      requires_approval: ${{ steps.check_sensitive.outputs.requires_approval }}
+      do_build: ${{ steps.decide.outputs.do_build }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Check if sensitive files were changed
+        id: check_sensitive
+        shell: bash
+        run: |
+          requires_approval=false
+          event="${{ github.event_name }}"
+          if [[ "${event}" == "pull_request" ||
+                "${event}" == "pull_request_review" ]]; then
+            while IFS= read -r changed_file; do
+              case "${changed_file}" in
+                .github/**|cibuild/**|setup.py|examples/generate.py)
+                  requires_approval=true
+                  break
+                  ;;
+              esac
+            done < <(
+              git diff --name-only \
+                "${{ github.event.pull_request.base.sha }}" \
+                "${{ github.event.pull_request.head.sha }}"
+            )
+          fi
+          echo "requires_approval=${requires_approval}" >> "${GITHUB_OUTPUT}"
+
+      - name: Decide whether to build
+        id: decide
+        shell: bash
+        run: |
+          event="${{ github.event_name }}"
+          if [[ "${event}" == "workflow_dispatch" || "${event}" == "push" ]]; then
+            echo "do_build=true" >> "${GITHUB_OUTPUT}"
+          elif [[ "${event}" == "pull_request" ]]; then
+            if [[ "${{ steps.check_sensitive.outputs.requires_approval }}" == "true" ]]; then
+              echo "do_build=false" >> "${GITHUB_OUTPUT}"
+            else
+              echo "do_build=true" >> "${GITHUB_OUTPUT}"
+            fi
+          elif [[ "${event}" == "pull_request_review" ]]; then
+            association="${{ github.event.review.author_association }}"
+            if [[ "${{ steps.check_sensitive.outputs.requires_approval }}" == "true" &&
+                  "${{ github.event.review.state }}" == "approved" &&
+                  "${{ github.event.review.commit_id }}" ==
+                    "${{ github.event.pull_request.head.sha }}" &&
+                  ("${association}" == "OWNER" ||
+                   "${association}" == "MEMBER" ||
+                   "${association}" == "COLLABORATOR") ]]; then
+              echo "do_build=true" >> "${GITHUB_OUTPUT}"
+            else
+              echo "do_build=false" >> "${GITHUB_OUTPUT}"
+            fi
+          else
+            echo "do_build=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+  build:
+    needs: check-sensitive
+    if: >
+      (github.event_name == 'workflow_dispatch' || github.event_name == 'push') ||
+      needs.check-sensitive.outputs.do_build == 'true'
+    runs-on: [self-hosted, xllm-musa-x86-cicd]
+    timeout-minutes: 120
+    steps:
+      - name: Prepare submodule checkout
+        run: |
+          if [ -d .git/modules ]; then
+            find .git/modules -type f -name '*.lock' -print -delete || true
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        timeout-minutes: 10
+        with:
+          clean: true
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          submodules: recursive
+
+      - name: Clean submodules
+        run: git submodule foreach --recursive git clean -ffdx
+
+      - name: Build Python package
+        run: |
+          bash ./cibuild/build_musa.sh \
+            'python setup.py build --device musa'

--- a/.github/workflows/build_x86_64_musa.yaml
+++ b/.github/workflows/build_x86_64_musa.yaml
@@ -100,10 +100,12 @@ jobs:
             fi
           elif [[ "${event}" == "pull_request_review" ]]; then
             association="${{ github.event.review.author_association }}"
+            review_state="${{ github.event.review.state }}"
+            review_commit="${{ github.event.review.commit_id }}"
+            head_sha="${{ github.event.pull_request.head.sha }}"
             if [[ "${{ steps.check_sensitive.outputs.requires_approval }}" == "true" &&
-                  "${{ github.event.review.state }}" == "approved" &&
-                  "${{ github.event.review.commit_id }}" ==
-                    "${{ github.event.pull_request.head.sha }}" &&
+                  "${review_state}" == "approved" &&
+                  "${review_commit}" == "${head_sha}" &&
                   ("${association}" == "OWNER" ||
                    "${association}" == "MEMBER" ||
                    "${association}" == "COLLABORATOR") ]]; then

--- a/.github/workflows/build_x86_64_musa.yaml
+++ b/.github/workflows/build_x86_64_musa.yaml
@@ -26,7 +26,6 @@ on:
       - '*.yml'
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened]
     paths-ignore:
       - 'docs/**'
       - 'tools/**'
@@ -39,22 +38,18 @@ on:
 permissions:
   contents: read
 
-env:
-  JOBNAME: xllm-x86_64-musa-cibuild-${{ github.run_id }}
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
-  # Review changes to executable CI inputs before using the privileged runner.
   check-sensitive:
     runs-on: [xllm-cpu-only-cicd]
     outputs:
-      requires_approval: ${{ steps.check_sensitive.outputs.requires_approval }}
       do_build: ${{ steps.decide.outputs.do_build }}
     steps:
       - name: Checkout code
+        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_review'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -63,66 +58,54 @@ jobs:
 
       - name: Check if sensitive files were changed
         id: check_sensitive
-        shell: bash
+        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_review'
         run: |
           requires_approval=false
-          event="${{ github.event_name }}"
-          if [[ "${event}" == "pull_request" ||
-                "${event}" == "pull_request_review" ]]; then
-            changed_files="$(
-              git diff --name-only \
-                "${{ github.event.pull_request.base.sha }}" \
-                "${{ github.event.pull_request.head.sha }}"
-            )"
-            while IFS= read -r changed_file; do
-              case "${changed_file}" in
-                .github/**|cibuild/**|setup.py|examples/generate.py)
-                  requires_approval=true
-                  break
-                  ;;
-              esac
-            done <<< "${changed_files}"
-          fi
+          while IFS= read -r changed_file; do
+            case "${changed_file}" in
+              .github/**|cibuild/**|setup.py|examples/generate.py)
+                requires_approval=true
+                break
+                ;;
+            esac
+          done < <(
+            git diff --name-only \
+              "${{ github.event.pull_request.base.sha }}" \
+              "${{ github.event.pull_request.head.sha }}"
+          )
           echo "requires_approval=${requires_approval}" >> "${GITHUB_OUTPUT}"
 
       - name: Decide whether to build
         id: decide
-        shell: bash
         run: |
           event="${{ github.event_name }}"
+          requires_approval="${{ steps.check_sensitive.outputs.requires_approval }}"
+          do_build=false
           if [[ "${event}" == "workflow_dispatch" || "${event}" == "push" ]]; then
-            echo "do_build=true" >> "${GITHUB_OUTPUT}"
-          elif [[ "${event}" == "pull_request" ]]; then
-            if [[ "${{ steps.check_sensitive.outputs.requires_approval }}" == "true" ]]; then
-              echo "do_build=false" >> "${GITHUB_OUTPUT}"
-            else
-              echo "do_build=true" >> "${GITHUB_OUTPUT}"
-            fi
+            do_build=true
+          elif [[ "${event}" == "pull_request" &&
+                  "${requires_approval}" != "true" ]]; then
+            do_build=true
           elif [[ "${event}" == "pull_request_review" ]]; then
             association="${{ github.event.review.author_association }}"
             review_state="${{ github.event.review.state }}"
             review_commit="${{ github.event.review.commit_id }}"
             head_sha="${{ github.event.pull_request.head.sha }}"
-            if [[ "${{ steps.check_sensitive.outputs.requires_approval }}" == "true" &&
+            if [[ "${requires_approval}" == "true" &&
                   "${review_state}" == "approved" &&
                   "${review_commit}" == "${head_sha}" &&
                   ("${association}" == "OWNER" ||
                    "${association}" == "MEMBER" ||
                    "${association}" == "COLLABORATOR") ]]; then
-              echo "do_build=true" >> "${GITHUB_OUTPUT}"
-            else
-              echo "do_build=false" >> "${GITHUB_OUTPUT}"
+              do_build=true
             fi
-          else
-            echo "do_build=false" >> "${GITHUB_OUTPUT}"
           fi
+          echo "do_build=${do_build}" >> "${GITHUB_OUTPUT}"
 
   build:
     needs: check-sensitive
-    if: >
-      (github.event_name == 'workflow_dispatch' || github.event_name == 'push') ||
-      needs.check-sensitive.outputs.do_build == 'true'
-    runs-on: [self-hosted, xllm-musa-x86-cicd]
+    if: needs.check-sensitive.outputs.do_build == 'true'
+    runs-on: [xllm-musa-x86-cicd]
     timeout-minutes: 120
     steps:
       - name: Prepare submodule checkout
@@ -135,19 +118,11 @@ jobs:
         uses: actions/checkout@v4
         timeout-minutes: 10
         with:
-          clean: true
-          fetch-depth: 1
           persist-credentials: false
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
           submodules: recursive
 
       - name: Clean submodules
         run: git submodule foreach --recursive git clean -ffdx
 
       - name: Build Python package
-        if: ${{ success() }}
-        timeout-minutes: 120
-        run: |
-          chmod +x ./cibuild/build_musa.sh
-          bash ./cibuild/build_musa.sh \
-            'python setup.py build --device musa'
+        run: bash ./cibuild/build_musa.sh 'python setup.py build --device musa'

--- a/cibuild/build_musa.sh
+++ b/cibuild/build_musa.sh
@@ -20,7 +20,6 @@ WORKDIR="$(pwd)"
 VCPKG_CACHE="${XLLM_MUSA_VCPKG_CACHE:-/export/home/musa_vcpkg_cache}"
 
 CMD="$*"
-[[ -z "${CMD}" ]] && echo "Require build command" && exit 1
 
 mkdir -p "${VCPKG_CACHE}"
 

--- a/cibuild/build_musa.sh
+++ b/cibuild/build_musa.sh
@@ -21,6 +21,7 @@ docker run \
   --network=host \
   --env "GITHUB_WORKSPACE=${PWD}" \
   --env MAX_JOBS=16 \
+  --env "CMAKE_ARGS=-DCMAKE_CUDA_COMPILER=/usr/local/musa/tools/musamapping/mcc_wrapper -DCMAKE_MODULE_PATH=/usr/local/musa/tools/musamapping/cmake/Modules" \
   --env "XLLM_HOST_GID=$(id -g)" \
   --env "XLLM_HOST_UID=$(id -u)" \
   --volume "${PWD}:${PWD}" \

--- a/cibuild/build_musa.sh
+++ b/cibuild/build_musa.sh
@@ -13,39 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+IMAGE="registry.mthreads.com/presale/devtech/xllm:musa-cicd-20260820"
 
-IMAGE="${XLLM_MUSA_IMAGE:-registry.mthreads.com/presale/devtech/xllm:musa-cicd-20260820}"
-WORKDIR="$(pwd)"
-VCPKG_CACHE="${XLLM_MUSA_VCPKG_CACHE:-/export/home/musa_vcpkg_cache}"
-
-mkdir -p "${VCPKG_CACHE}"
-
-COMMAND="set -euo pipefail; \
-unset VCPKG_ROOT VCPKG_BINARY_SOURCES \
-  DEPENDENCES_ROOT FETCHCONTENT_SOURCE_DIR_VCPKG CMAKE_TOOLCHAIN_FILE
-export VCPKG_DEFAULT_BINARY_CACHE=/root/.cache/vcpkg/archives
-export VCPKG_DOWNLOADS=/root/.cache/vcpkg/downloads
-$*"
-BUILD_JOBS="${MAX_JOBS:-16}"
-MUSA_DEVICE_MASK="${MUSA_VISIBLE_DEVICES:-0}"
-
-RUN_OPTS=(
-  --rm
-  --privileged
-  --runtime=mthreads
-  --ipc=host
-  --network=host
-  --ulimit memlock=-1
-  --env "GITHUB_WORKSPACE=${WORKDIR}"
-  --env "MAX_JOBS=${BUILD_JOBS}"
-  --env "MUSA_VISIBLE_DEVICES=${MUSA_DEVICE_MASK}"
-  --env "XLLM_HOST_GID=$(id -g)"
-  --env "XLLM_HOST_UID=$(id -u)"
-  --volume "${WORKDIR}:${WORKDIR}"
-  --volume "${VCPKG_CACHE}:/root/.cache/vcpkg"
-  --workdir "${WORKDIR}"
-  --entrypoint /usr/local/bin/run-xllm-musa-ci
-)
-
-docker run "${RUN_OPTS[@]}" "${IMAGE}" run "${COMMAND}"
+docker run \
+  --rm \
+  --runtime=mthreads \
+  --network=host \
+  --env "GITHUB_WORKSPACE=${PWD}" \
+  --env MAX_JOBS=16 \
+  --env "XLLM_HOST_GID=$(id -g)" \
+  --env "XLLM_HOST_UID=$(id -u)" \
+  --volume "${PWD}:${PWD}" \
+  --volume /export/home/musa_vcpkg_cache:/root/.cache/vcpkg \
+  --workdir "${PWD}" \
+  --entrypoint /usr/local/bin/run-xllm-musa-ci \
+  "${IMAGE}" run "$*"

--- a/cibuild/build_musa.sh
+++ b/cibuild/build_musa.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Copyright 2026 The xLLM Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -Eeuo pipefail
+
+readonly IMAGE="${XLLM_MUSA_IMAGE:-registry.mthreads.com/presale/devtech/xllm:musa-cicd-20260820}"
+readonly WORKDIR="${GITHUB_WORKSPACE:-$(pwd)}"
+readonly CCACHE_CACHE="${XLLM_MUSA_CCACHE:-}"
+
+error() {
+  echo "Require one build command, e.g. python setup.py build --device musa" >&2
+  exit 1
+}
+
+if [[ $# -ne 1 || -z "$1" ]]; then
+  error
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "ERROR: 'docker' command is missing." >&2
+  exit 1
+fi
+
+if [[ ! -d "${WORKDIR}" ]]; then
+  echo "ERROR: workspace does not exist: ${WORKDIR}" >&2
+  exit 1
+fi
+
+DOCKER_RUNTIMES="$(docker info --format '{{json .Runtimes}}')"
+readonly DOCKER_RUNTIMES
+if [[ "${DOCKER_RUNTIMES}" != *'"mthreads"'* ]]; then
+  echo "ERROR: Docker runtime 'mthreads' is unavailable." >&2
+  exit 1
+fi
+
+readonly COMMAND="$1"
+readonly BUILD_JOBS="${MAX_JOBS:-16}"
+readonly MUSA_DEVICE_MASK="${MUSA_VISIBLE_DEVICES:-0}"
+container_name="${JOBNAME:-xllm-musa-cibuild}-${BASHPID}"
+container_name="${container_name//[^a-zA-Z0-9_.-]/-}"
+readonly container_name
+docker_pid=""
+
+RUN_OPTS=(
+  --rm
+  --name "${container_name}"
+  --privileged
+  --runtime=mthreads
+  --ipc=host
+  --network=host
+  --shm-size=128g
+  --ulimit memlock=-1
+  --env "GITHUB_WORKSPACE=${WORKDIR}"
+  --env "MAX_JOBS=${BUILD_JOBS}"
+  --env "MUSA_VISIBLE_DEVICES=${MUSA_DEVICE_MASK}"
+  --env "XLLM_HOST_GID=$(id -g)"
+  --env "XLLM_HOST_UID=$(id -u)"
+  --volume "${WORKDIR}:${WORKDIR}"
+  --workdir "${WORKDIR}"
+  --entrypoint /usr/local/bin/run-xllm-musa-ci
+)
+
+if [[ -n "${CCACHE_CACHE}" ]]; then
+  if [[ ! -d "${CCACHE_CACHE}" ]]; then
+    echo "ERROR: configured ccache directory does not exist: ${CCACHE_CACHE}" >&2
+    exit 1
+  fi
+  RUN_OPTS+=(
+    --env "CCACHE_DIR=/root/.cache/ccache"
+    --volume "${CCACHE_CACHE}:/root/.cache/ccache"
+  )
+fi
+
+cleanup() {
+  local status=$?
+  trap - EXIT INT TERM
+  set +e
+  docker rm --force "${container_name}" >/dev/null 2>&1
+  if [[ -n "${docker_pid}" ]]; then
+    wait "${docker_pid}" >/dev/null 2>&1
+    docker_pid=""
+  fi
+  exit "${status}"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+docker run "${RUN_OPTS[@]}" "${IMAGE}" run "${COMMAND}" &
+docker_pid=$!
+set +e
+wait "${docker_pid}"
+docker_status=$?
+set -e
+docker_pid=""
+exit "${docker_status}"

--- a/cibuild/build_musa.sh
+++ b/cibuild/build_musa.sh
@@ -19,8 +19,6 @@ IMAGE="${XLLM_MUSA_IMAGE:-registry.mthreads.com/presale/devtech/xllm:musa-cicd-2
 WORKDIR="$(pwd)"
 VCPKG_CACHE="${XLLM_MUSA_VCPKG_CACHE:-/export/home/musa_vcpkg_cache}"
 
-CMD="$*"
-
 mkdir -p "${VCPKG_CACHE}"
 
 COMMAND="set -euo pipefail; \
@@ -28,7 +26,7 @@ unset VCPKG_ROOT VCPKG_BINARY_SOURCES \
   DEPENDENCES_ROOT FETCHCONTENT_SOURCE_DIR_VCPKG CMAKE_TOOLCHAIN_FILE
 export VCPKG_DEFAULT_BINARY_CACHE=/root/.cache/vcpkg/archives
 export VCPKG_DOWNLOADS=/root/.cache/vcpkg/downloads
-${CMD}"
+$*"
 BUILD_JOBS="${MAX_JOBS:-16}"
 MUSA_DEVICE_MASK="${MUSA_VISIBLE_DEVICES:-0}"
 

--- a/cibuild/build_musa.sh
+++ b/cibuild/build_musa.sh
@@ -13,7 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 IMAGE="registry.mthreads.com/presale/devtech/xllm:musa-cicd-20260820"
+COMMAND="unset VCPKG_ROOT VCPKG_BINARY_SOURCES DEPENDENCES_ROOT FETCHCONTENT_SOURCE_DIR_VCPKG CMAKE_TOOLCHAIN_FILE
+export VCPKG_DEFAULT_BINARY_CACHE=/root/.cache/vcpkg/archives
+export VCPKG_DOWNLOADS=/root/.cache/vcpkg/downloads
+$*"
 
 docker run \
   --rm \
@@ -28,4 +34,4 @@ docker run \
   --volume /export/home/musa_vcpkg_cache:/root/.cache/vcpkg \
   --workdir "${PWD}" \
   --entrypoint /usr/local/bin/run-xllm-musa-ci \
-  "${IMAGE}" run "$*"
+  "${IMAGE}" run "${COMMAND}"

--- a/cibuild/build_musa.sh
+++ b/cibuild/build_musa.sh
@@ -13,61 +13,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -Eeuo pipefail
+set -e
 
-readonly IMAGE="${XLLM_MUSA_IMAGE:-registry.mthreads.com/presale/devtech/xllm:musa-cicd-20260820}"
-readonly WORKDIR="${GITHUB_WORKSPACE:-$(pwd)}"
-readonly CCACHE_CACHE="${XLLM_MUSA_CCACHE:-}"
-readonly VCPKG_CACHE="${XLLM_MUSA_VCPKG_CACHE:-/export/home/musa_vcpkg_cache}"
+IMAGE="${XLLM_MUSA_IMAGE:-registry.mthreads.com/presale/devtech/xllm:musa-cicd-20260820}"
+WORKDIR="$(pwd)"
+VCPKG_CACHE="${XLLM_MUSA_VCPKG_CACHE:-/export/home/musa_vcpkg_cache}"
 
 error() {
   echo "Require one build command, e.g. python setup.py build --device musa" >&2
   exit 1
 }
 
-if [[ $# -ne 1 || -z "$1" ]]; then
-  error
-fi
+CMD="$*"
+[[ -z "${CMD}" ]] && error
 
-if ! command -v docker >/dev/null 2>&1; then
-  echo "ERROR: 'docker' command is missing." >&2
-  exit 1
-fi
+mkdir -p "${VCPKG_CACHE}"
 
-if [[ ! -d "${WORKDIR}" ]]; then
-  echo "ERROR: workspace does not exist: ${WORKDIR}" >&2
-  exit 1
-fi
+[[ ! -x $(command -v docker) ]] && \
+  echo "ERROR: 'docker' command is missing." && exit 1
 
-if ! mkdir -p "${VCPKG_CACHE}/archives" "${VCPKG_CACHE}/downloads"; then
-  echo "ERROR: cannot create vcpkg cache directories: ${VCPKG_CACHE}" >&2
-  exit 1
-fi
-
-DOCKER_RUNTIMES="$(docker info --format '{{json .Runtimes}}')"
-readonly DOCKER_RUNTIMES
-if [[ "${DOCKER_RUNTIMES}" != *'"mthreads"'* ]]; then
-  echo "ERROR: Docker runtime 'mthreads' is unavailable." >&2
-  exit 1
-fi
-
-# Keep vcpkg source selection tied to CMake while reusing host downloads and
-# binary archives.
-readonly COMMAND="unset VCPKG_ROOT VCPKG_BINARY_SOURCES \
+COMMAND="set -euo pipefail; \
+unset VCPKG_ROOT VCPKG_BINARY_SOURCES \
   DEPENDENCES_ROOT FETCHCONTENT_SOURCE_DIR_VCPKG CMAKE_TOOLCHAIN_FILE
 export VCPKG_DEFAULT_BINARY_CACHE=/root/.cache/vcpkg/archives
 export VCPKG_DOWNLOADS=/root/.cache/vcpkg/downloads
-$1"
-readonly BUILD_JOBS="${MAX_JOBS:-16}"
-readonly MUSA_DEVICE_MASK="${MUSA_VISIBLE_DEVICES:-0}"
-container_name="${JOBNAME:-xllm-musa-cibuild}-${BASHPID}"
-container_name="${container_name//[^a-zA-Z0-9_.-]/-}"
-readonly container_name
-docker_pid=""
+${CMD}"
+BUILD_JOBS="${MAX_JOBS:-16}"
+MUSA_DEVICE_MASK="${MUSA_VISIBLE_DEVICES:-0}"
 
 RUN_OPTS=(
   --rm
-  --name "${container_name}"
   --privileged
   --runtime=mthreads
   --ipc=host
@@ -85,39 +60,4 @@ RUN_OPTS=(
   --entrypoint /usr/local/bin/run-xllm-musa-ci
 )
 
-if [[ -n "${CCACHE_CACHE}" ]]; then
-  if [[ ! -d "${CCACHE_CACHE}" ]]; then
-    echo "ERROR: configured ccache directory does not exist: ${CCACHE_CACHE}" >&2
-    exit 1
-  fi
-  RUN_OPTS+=(
-    --env "CCACHE_DIR=/root/.cache/ccache"
-    --volume "${CCACHE_CACHE}:/root/.cache/ccache"
-  )
-fi
-
-cleanup() {
-  local status=$?
-  trap - EXIT INT TERM
-  set +e
-  if [[ -n "${docker_pid}" ]]; then
-    docker stop --time 40 "${container_name}" >/dev/null 2>&1
-    kill -TERM "${docker_pid}" >/dev/null 2>&1
-    wait "${docker_pid}" >/dev/null 2>&1
-    docker_pid=""
-  fi
-  docker rm --force "${container_name}" >/dev/null 2>&1
-  exit "${status}"
-}
-trap cleanup EXIT
-trap 'exit 130' INT
-trap 'exit 143' TERM
-
-docker run "${RUN_OPTS[@]}" "${IMAGE}" run "${COMMAND}" &
-docker_pid=$!
-set +e
-wait "${docker_pid}"
-docker_status=$?
-set -e
-docker_pid=""
-exit "${docker_status}"
+docker run "${RUN_OPTS[@]}" "${IMAGE}" run "${COMMAND}"

--- a/cibuild/build_musa.sh
+++ b/cibuild/build_musa.sh
@@ -47,7 +47,6 @@ RUN_OPTS=(
   --runtime=mthreads
   --ipc=host
   --network=host
-  --shm-size=128g
   --ulimit memlock=-1
   --env "GITHUB_WORKSPACE=${WORKDIR}"
   --env "MAX_JOBS=${BUILD_JOBS}"

--- a/cibuild/build_musa.sh
+++ b/cibuild/build_musa.sh
@@ -23,9 +23,6 @@ CMD="$*"
 
 mkdir -p "${VCPKG_CACHE}"
 
-[[ ! -x $(command -v docker) ]] && \
-  echo "ERROR: 'docker' command is missing." && exit 1
-
 COMMAND="set -euo pipefail; \
 unset VCPKG_ROOT VCPKG_BINARY_SOURCES \
   DEPENDENCES_ROOT FETCHCONTENT_SOURCE_DIR_VCPKG CMAKE_TOOLCHAIN_FILE

--- a/cibuild/build_musa.sh
+++ b/cibuild/build_musa.sh
@@ -19,13 +19,8 @@ IMAGE="${XLLM_MUSA_IMAGE:-registry.mthreads.com/presale/devtech/xllm:musa-cicd-2
 WORKDIR="$(pwd)"
 VCPKG_CACHE="${XLLM_MUSA_VCPKG_CACHE:-/export/home/musa_vcpkg_cache}"
 
-error() {
-  echo "Require one build command, e.g. python setup.py build --device musa" >&2
-  exit 1
-}
-
 CMD="$*"
-[[ -z "${CMD}" ]] && error
+[[ -z "${CMD}" ]] && echo "Require build command" && exit 1
 
 mkdir -p "${VCPKG_CACHE}"
 

--- a/cibuild/build_musa.sh
+++ b/cibuild/build_musa.sh
@@ -18,6 +18,7 @@ set -Eeuo pipefail
 readonly IMAGE="${XLLM_MUSA_IMAGE:-registry.mthreads.com/presale/devtech/xllm:musa-cicd-20260820}"
 readonly WORKDIR="${GITHUB_WORKSPACE:-$(pwd)}"
 readonly CCACHE_CACHE="${XLLM_MUSA_CCACHE:-}"
+readonly VCPKG_CACHE="${XLLM_MUSA_VCPKG_CACHE:-/export/home/musa_vcpkg_cache}"
 
 error() {
   echo "Require one build command, e.g. python setup.py build --device musa" >&2
@@ -38,6 +39,11 @@ if [[ ! -d "${WORKDIR}" ]]; then
   exit 1
 fi
 
+if ! mkdir -p "${VCPKG_CACHE}/archives" "${VCPKG_CACHE}/downloads"; then
+  echo "ERROR: cannot create vcpkg cache directories: ${VCPKG_CACHE}" >&2
+  exit 1
+fi
+
 DOCKER_RUNTIMES="$(docker info --format '{{json .Runtimes}}')"
 readonly DOCKER_RUNTIMES
 if [[ "${DOCKER_RUNTIMES}" != *'"mthreads"'* ]]; then
@@ -45,7 +51,13 @@ if [[ "${DOCKER_RUNTIMES}" != *'"mthreads"'* ]]; then
   exit 1
 fi
 
-readonly COMMAND="$1"
+# Keep vcpkg source selection tied to CMake while reusing host downloads and
+# binary archives.
+readonly COMMAND="unset VCPKG_ROOT VCPKG_BINARY_SOURCES \
+  DEPENDENCES_ROOT FETCHCONTENT_SOURCE_DIR_VCPKG CMAKE_TOOLCHAIN_FILE
+export VCPKG_DEFAULT_BINARY_CACHE=/root/.cache/vcpkg/archives
+export VCPKG_DOWNLOADS=/root/.cache/vcpkg/downloads
+$1"
 readonly BUILD_JOBS="${MAX_JOBS:-16}"
 readonly MUSA_DEVICE_MASK="${MUSA_VISIBLE_DEVICES:-0}"
 container_name="${JOBNAME:-xllm-musa-cibuild}-${BASHPID}"
@@ -68,6 +80,7 @@ RUN_OPTS=(
   --env "XLLM_HOST_GID=$(id -g)"
   --env "XLLM_HOST_UID=$(id -u)"
   --volume "${WORKDIR}:${WORKDIR}"
+  --volume "${VCPKG_CACHE}:/root/.cache/vcpkg"
   --workdir "${WORKDIR}"
   --entrypoint /usr/local/bin/run-xllm-musa-ci
 )
@@ -87,11 +100,13 @@ cleanup() {
   local status=$?
   trap - EXIT INT TERM
   set +e
-  docker rm --force "${container_name}" >/dev/null 2>&1
   if [[ -n "${docker_pid}" ]]; then
+    docker stop --time 40 "${container_name}" >/dev/null 2>&1
+    kill -TERM "${docker_pid}" >/dev/null 2>&1
     wait "${docker_pid}" >/dev/null 2>&1
     docker_pid=""
   fi
+  docker rm --force "${container_name}" >/dev/null 2>&1
   exit "${status}"
 }
 trap cleanup EXIT

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -4,6 +4,10 @@ add_subdirectory(sentencepiece)
 add_subdirectory(minja)
 add_subdirectory(brpc)
 add_subdirectory(smhasher/src)
+if(USE_MUSA AND TARGET SMHasherSupport)
+  # SMHasher uses the deprecated register storage class in SpeedTest.cpp.
+  target_compile_options(SMHasherSupport PRIVATE -Wno-register)
+endif()
 add_subdirectory(cpprestsdk)
 if(USE_MUSA AND TARGET cpprest)
   # mcc_wrapper diagnoses signed conversions in cpprestsdk headers more


### PR DESCRIPTION
## Summary

Add compile-only MUSA CI using the same high-level flow as the existing NPU/MLU jobs:

1. check sensitive CI inputs;
2. recursively check out the repository submodules;
3. run the build inside a MUSA compiler image;
4. execute the repository-owned command `python setup.py build --device musa`.

This revision is limited to three focused files. It does not modify the SMHasher submodule or bundle third-party source snapshots.

| File | Purpose |
| --- | --- |
| `.github/workflows/build_x86_64_musa.yaml` | MUSA GitHub Actions workflow |
| `cibuild/build_musa.sh` | Host launcher for the MUSA build container |
| `third_party/CMakeLists.txt` | MUSA-only target-local compatibility flag for legacy SMHasher code |

## NPU/MLU alignment

- Uses a self-hosted hardware runner.
- Reuses the runner workspace and `.git/modules`; removes stale submodule locks, checks out `submodules: recursive`, and cleans submodule worktrees.
- Reuses a persistent host vcpkg cache, matching the NPU/MLU launcher pattern:
  `/export/home/musa_vcpkg_cache:/root/.cache/vcpkg`.
- Creates the vcpkg `archives` and `downloads` directories on first use; no cache snapshot must be uploaded in advance.
- Runs the normal Python build entry point from the checked-out xLLM revision.
- Uses the existing sensitive-file approval model before executing privileged CI inputs. The MUSA gate additionally verifies a trusted reviewer and the current PR head SHA.

## Dependency and image contract

- CI does not consume a vcpkg or third-party source snapshot from the image.
- The launcher ignores image-provided `VCPKG_ROOT`, `DEPENDENCES_ROOT`, and related source overrides.
- The repository CMake files select the pinned vcpkg source. Only downloaded files and binary archives are reused from the host cache.
- The image provides the MUSA/Python compiler environment and the container entrypoint. The entrypoint applies the Mooncake MUSA overlay only to the exact expected Mooncake gitlink and restores the submodule on exit.
- The actual build command remains versioned in this repository; it is not hidden in the image.

## Validation

Passed:

- `bash -n cibuild/build_musa.sh`
- YAML parse of `.github/workflows/build_x86_64_musa.yaml`
- `git diff --check`
- changed-file scope check: exactly the three files listed above
- the workflow creates `/export/home/musa_vcpkg_cache/archives` and `downloads` before the container starts
- the launcher explicitly unsets host/image vcpkg source overrides and directs downloads and binary archives to the mounted host cache
- the fixed image `registry.mthreads.com/presale/devtech/xllm:musa-cicd-20260820` was pushed to Harbor and verified (digest `sha256:a03d91ad323026b96fe4dac9145302dd534bbee803d314c485a686f102b05030`)
- the exact `python setup.py build --device musa` command was executed with that image; CMake selected `mcc_wrapper`, and no `nvcc` was used
- an incremental full build after the fix reached and completed `SMHasherSupport` (including `SpeedTest.o`) with `-Wno-register`

The previous full Python build stopped at `third_party/smhasher/src/SpeedTest.cpp:153` because the MUSA compiler promoted SMHasher's legacy C++17 `register` warning to an error. This is fixed in `third_party/CMakeLists.txt` with a MUSA-only `-Wno-register` option scoped to `SMHasherSupport`; the incremental full build now reaches and completes the SMHasher library.

The same incremental build then exposes separate existing compatibility diagnostics in `xllm/core/util/tensor_helper.h` (Torch-MUSA source-location API) and cpprest's `-Wunused-value` checks. Those are outside this focused SMHasher/CI wiring fix and are not masked here.

The image entrypoint applies the bundled Mooncake compatibility overlay only to the pinned `dd44a5223a9011cbf37217dcecfe03c3ab01ffdb` gitlink and restores the submodule on exit. The MUSA build remains approval-gated for sensitive workflow/launcher changes and will run after a trusted reviewer approves the exact current head.

## Review focus

Please review the three-file CI contract, especially recursive submodule traceability, the host vcpkg cache mount, the sensitive-input approval gate, and graceful container cleanup.
