### PR TITLE
bugfix: fix A5 mRoPE precision error in split_qkv_rmsnorm_mrope kernel.

### DIFF
--- a/xllm/compiler/tilelang/targets/ascend/kernels/split_qkv_rmsnorm_mrope.py
+++ b/xllm/compiler/tilelang/targets/ascend/kernels/split_qkv_rmsnorm_mrope.py
@@ -145,12 +145,12 @@ class SyncEvent(enum.IntEnum):
     # MTE3 -> MTE2 (per-buffer free signals)
     Q_FREE = 0
     G_FREE = 1
-    K_FREE = 9
-    V_FREE = 10
+    K_FREE = 2
+    V_FREE = 3
 
     # MTE2 -> MTE3
     GATE_READY = 3
-    V_READY = 8
+    V_READY = 4
 
 
 KERNEL_PASS_CONFIGS = {
@@ -380,7 +380,6 @@ def build_split_qkv_rmsnorm_mrope_kernel(
 
                 # Init: load gather pattern, weights.
                 T.copy(gather_pattern, gather_offset_ub)
-                T.tile.fill(axes_ub, 0.0)
                 T.copy(q_weight[0, 0], q_weight_half_ub[0, :])
                 T.copy(k_weight[0, 0], k_weight_half_ub[0, :])
                 mte2_notify_v(E.INIT_WEIGHTS)


### PR DESCRIPTION
## Description

修复 split_qkv_rmsnorm_mrope 算子在 A5 上的精度错误。

- 移除不必要的 T.tile.fill(0.0) 以消除 axes_ub 上的 WAW 竞争 — V-pipe Duplicate 与 MTE2 copy 之间无显式同步，导致 A5 上 gather 读到全零。
- 修复 SyncEvent flag ID 超出 QUE_MAX_EVENT=8 的问题（K_FREE 9→2、V_FREE 10→3、V_READY 8→4）— A5 截断为 3-bit，超范围 ID 静默回绕并导致跨管道 flag 冲突。

### 验证
```bash
python setup.py test --test-name split_qkv_rmsnorm_mrope_wrapper_test --device npu
```

A3
<img width="1380" height="508" alt="image" src="https://github.com/user-attachments/assets/d13ba3e1-5bd0-4ec3-82e1-7900fe495bb8" />

A5
<img width="2582" height="532" alt="image" src="https://github.com/user-attachments/assets/ad5216c7-acfd-4335-9c4c-2b91bb8033f5" />

Qwen3-Next-80B-A3B-Instruct
<img width="1374" height="1048" alt="image" src="https://github.com/user-attachments/assets/5bc613ab-5dcf-4000-a90d-126a385a0f91" />


## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
