### PR TITLE
bugfix: fix tilelang g_tilingKey multiple definition across kernel families.

### DIFF
--- a/xllm/compiler/tilelang/targets/ascend/kernel_family_builder.py
+++ b/xllm/compiler/tilelang/targets/ascend/kernel_family_builder.py
@@ -107,7 +107,7 @@ def _run_variant_worker(args: _VariantWorkerArgs) -> _VariantBuildResult:
     compile_cmd = [
         args.bisheng_executable,
         *args.bisheng_compile_flags,
-        f"-Dg_tilingKey=g_tilingKey__{compile_spec.variant_key}",
+        f"-Dg_tilingKey=g_tilingKey__{compile_spec.kernel_name}_{compile_spec.variant_key}",
         *[f"-I{d}" for d in args.include_dirs],
         str(plan.generated_source),
         "-c",


### PR DESCRIPTION

## Description
修复不同 TileLang kernel family 共享相同 variant key 后缀（如 `w4`、`w5`、`w6`）时 `g_tilingKey` 多重定义的链接错误。
### 根因
`_run_variant_worker` 中将 `g_tilingKey` 定义为 `g_tilingKey__{variant_key}`，当 `spec_verify_token_update` 和 `spec_verify_attention_tiling_update` 两个 family 使用相同的 variant 后缀（`w4`/`w5`/`w6`）时，生成相同的全局符号名。两者同时链接进 `libtilelang_kernels.a` 后，链接器报 multiple definition 错误：
ld: multiple definition of g_tilingKey__w4'
ld: multiple definition of g_tilingKey__w5'
ld: multiple definition of `g_tilingKey__w6'
### 修复方案
在 `-Dg_tilingKey` 宏定义中加入 `kernel_name` 前缀：
-Dg_tilingKey=g_tilingKey_{kernel_name}{variant_key}
使每个 family 生成唯一符号（如 `g_tilingKey__spec_verify_token_update_w4` 与 `g_tilingKey__spec_verify_attention_tiling_update_w4`），消除冲突。
`kernel_family_builder.py` 本身已包含在缓存依赖文件列表中，修改后自动触发所有 variant 重新编译，无需手动清理缓存

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
