### PR TITLE
refactor: share the accept core across DFlash/Suffix/MTP speculative workers.

### DIFF
--- a/tests/core/framework/speculative/spec_input_builder_test.cpp
+++ b/tests/core/framework/speculative/spec_input_builder_test.cpp
@@ -411,29 +411,6 @@ TEST(SpecDecodeInputBuilderTest, AppendDecodeRowFromLastStep) {
   EXPECT_EQ(buf.out_kv_seq_lens, to_layout_seq_lens({6, 10}));
 }
 
-TEST(SpecDecodeInputBuilderTest, QCuSeqLensConsistency) {
-  ModelInputParams params;
-  params.meta.num_sequences = 3;
-  params.attention.host.q_seq_lens = to_layout_seq_lens({1, 2, 3});
-  params.attention.host.q_cu_seq_lens = {1, 3, 6};
-
-  torch::Tensor q_cu_seq_lens = build_q_cu_seq_lens_tensor(params);
-  EXPECT_EQ(tensor_to_vec_int32(q_cu_seq_lens),
-            std::vector<int32_t>({1, 3, 6}));
-}
-
-TEST(SpecDecodeInputBuilderTest, QCuSeqLensWithLeadingZero) {
-  ModelInputParams params;
-  params.meta.num_sequences = 3;
-  params.attention.host.q_seq_lens = to_layout_seq_lens({1, 2, 3});
-  params.attention.host.q_cu_seq_lens = {1, 3, 6};
-
-  torch::Tensor q_cu_seq_lens =
-      build_q_cu_seq_lens_tensor(params, torch::kCPU, true);
-  EXPECT_EQ(tensor_to_vec_int32(q_cu_seq_lens),
-            std::vector<int32_t>({0, 1, 3, 6}));
-}
-
 TEST(SpecDecodeInputBuilderTest, CalcSlotIdOutOfRangeDeath) {
   std::vector<int32_t> block_table = {0};
   EXPECT_DEATH(calc_slot_id(/*position=*/4,

--- a/xllm/core/framework/speculative/CMakeLists.txt
+++ b/xllm/core/framework/speculative/CMakeLists.txt
@@ -12,6 +12,7 @@ cc_library(
     mtp_async_state.h
     mtp_json_object_state.h
     embedding_cache.h
+    spec_verify.h
   SRCS
     adaptive_speculative_controller.cpp
     speculative_profile_registry.cpp
@@ -20,6 +21,7 @@ cc_library(
     mtp_async_input_builder.cpp
     mtp_async_state.cpp
     embedding_cache.cpp
+    spec_verify.cpp
   DEPS
     torch
     $<$<BOOL:${USE_NPU}>:torch_npu>

--- a/xllm/core/framework/speculative/spec_input_builder.cpp
+++ b/xllm/core/framework/speculative/spec_input_builder.cpp
@@ -445,27 +445,6 @@ void append_decode_row_from_last_step(const DecodeRowContext& ctx,
   append_decode_row(ctx, row, block_size, buf);
 }
 
-torch::Tensor build_q_cu_seq_lens_tensor(const ModelInputParams& params,
-                                         torch::Device device,
-                                         bool include_leading_zero) {
-  CHECK_EQ(params.attention.host.q_seq_lens.empty(),
-           params.attention.host.q_cu_seq_lens.empty())
-      << "q_seq_lens and q_cu_seq_lens must be provided together";
-  if (!include_leading_zero) {
-    return torch::tensor(params.attention.host.q_cu_seq_lens,
-                         torch::dtype(torch::kInt).device(device));
-  }
-  std::vector<int32_t> q_cu_seq_lens_vec;
-  q_cu_seq_lens_vec.reserve(params.meta.num_sequences + 1);
-  q_cu_seq_lens_vec.emplace_back(0);
-  for (int32_t i = 0; i < params.meta.num_sequences; ++i) {
-    q_cu_seq_lens_vec.emplace_back(q_cu_seq_lens_vec.back() +
-                                   params.get_q_seq_len(i));
-  }
-  return torch::tensor(q_cu_seq_lens_vec,
-                       torch::dtype(torch::kInt).device(device));
-}
-
 void update_input_params(ModelInputParams& input_params,
                          DecodeBuildBuffers& buf,
                          int32_t q_max_seq_len,

--- a/xllm/core/framework/speculative/spec_input_builder.cpp
+++ b/xllm/core/framework/speculative/spec_input_builder.cpp
@@ -578,6 +578,25 @@ torch::Tensor compress_for_cache(const torch::Tensor& draft_probs,
   return extract_selected_probs(draft_probs, draft_token_ids);
 }
 
+void compress_sample_output_for_cache(SampleOutput& sample_output) {
+  if (!sample_output.probs.defined()) {
+    return;
+  }
+  CHECK(sample_output.next_tokens.defined())
+      << "draft sample_output.next_tokens must be defined when probs exist";
+  CHECK_EQ(sample_output.next_tokens.dim(), 1)
+      << "draft cache expects next_tokens [batch], got "
+      << sample_output.next_tokens.sizes();
+  CHECK(sample_output.probs.dim() == 1 || sample_output.probs.dim() == 2)
+      << "draft cache expects probs [batch] or [batch,vocab], got "
+      << sample_output.probs.sizes();
+  CHECK_EQ(sample_output.probs.size(0), sample_output.next_tokens.size(0))
+      << "draft cache probs/token batch mismatch";
+  // Cache always stores selected-only draft probs [batch_size] to reduce HBM.
+  sample_output.probs =
+      compress_for_cache(sample_output.probs, sample_output.next_tokens);
+}
+
 std::pair<torch::Tensor, torch::Tensor> build_validate_tensors(
     const std::vector<torch::Tensor>& draft_token_ids_steps,
     const std::vector<torch::Tensor>& draft_probs_steps,

--- a/xllm/core/framework/speculative/spec_input_builder.h
+++ b/xllm/core/framework/speculative/spec_input_builder.h
@@ -30,6 +30,7 @@ namespace xllm {
 struct ModelInputParams;
 struct ForwardInput;
 struct SamplingParameters;
+struct SampleOutput;
 
 namespace specBuilder {
 
@@ -193,6 +194,10 @@ namespace draftProbs {
 // [batch_size] / [batch_size, 1].
 torch::Tensor compress_for_cache(const torch::Tensor& draft_probs,
                                  const torch::Tensor& draft_token_ids);
+
+// Compresses a draft SampleOutput's probs to selected-only cache form in place;
+// no-op when probs are undefined.
+void compress_sample_output_for_cache(SampleOutput& sample_output);
 
 // Build validate inputs from per-step draft token ids/probs.
 // Returns:

--- a/xllm/core/framework/speculative/spec_input_builder.h
+++ b/xllm/core/framework/speculative/spec_input_builder.h
@@ -153,13 +153,6 @@ void update_kv_seq_lens_and_max(std::vector<int32_t>& kv_seq_lens_vec,
                                 int32_t kv_len,
                                 int32_t& kv_max_seq_len);
 
-// Builds q_cu_seq_lens tensor from upstream-provided host values.
-// When include_leading_zero is true, returns query_start_loc-style
-// [0, cumsum...].
-torch::Tensor build_q_cu_seq_lens_tensor(const ModelInputParams& params,
-                                         torch::Device device = torch::kCPU,
-                                         bool include_leading_zero = false);
-
 // Updates common decode-side ModelInputParams fields from built buffers.
 void update_input_params(ModelInputParams& input_params,
                          DecodeBuildBuffers& buf,

--- a/xllm/core/framework/speculative/spec_verify.cpp
+++ b/xllm/core/framework/speculative/spec_verify.cpp
@@ -44,13 +44,12 @@ SampleOutput run_rejection_sampling(const SamplerPolicy& policy,
                                          target_output.max_top_logprobs,
                                          enable_fused_kernel);
 
-  SampleOutput sample_output = rejection_sampler->forward(
-      draft_token_ids.to(bonus_token_ids),
-      draft_probs.defined() ? draft_probs.to(target_logits.device())
-                            : torch::Tensor(),
-      target_logits,
-      bonus_token_ids,
-      /*mask_out_rejected_tokens=*/true);
+  SampleOutput sample_output =
+      rejection_sampler->forward(draft_token_ids.to(bonus_token_ids),
+                                 draft_probs.to(target_logits.device()),
+                                 target_logits,
+                                 bonus_token_ids,
+                                 /*mask_out_rejected_tokens=*/true);
 
   const torch::Tensor& embeddings = target_output.sample_output.embeddings;
   sample_output.embeddings =

--- a/xllm/core/framework/speculative/spec_verify.cpp
+++ b/xllm/core/framework/speculative/spec_verify.cpp
@@ -1,0 +1,61 @@
+/* Copyright 2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "core/framework/speculative/spec_verify.h"
+
+#include <memory>
+
+#include "framework/sampling/rejection_sampler.h"
+#include "framework/sampling/sampling_params.h"
+#include "runtime/forward_params.h"
+
+namespace xllm::spec_verify {
+
+SampleOutput run_rejection_sampling(const SamplerPolicy& policy,
+                                    const torch::Tensor& draft_token_ids,
+                                    const torch::Tensor& draft_probs,
+                                    const ForwardOutput& target_output,
+                                    const torch::Tensor& bonus_token_ids,
+                                    int32_t batch_size,
+                                    int32_t num_val_tokens,
+                                    bool enable_fused_kernel) {
+  const int32_t vocab_size =
+      static_cast<int32_t>(target_output.logits.size(/*dim=*/-1));
+  torch::Tensor target_logits =
+      target_output.logits.view({batch_size, num_val_tokens, vocab_size});
+
+  auto rejection_sampler =
+      std::make_unique<RejectionSampler>(policy.do_sample,
+                                         policy.all_random_sample,
+                                         policy.all_greedy_sample,
+                                         target_output.logprobs,
+                                         target_output.max_top_logprobs,
+                                         enable_fused_kernel);
+
+  SampleOutput sample_output = rejection_sampler->forward(
+      draft_token_ids.to(bonus_token_ids),
+      draft_probs.defined() ? draft_probs.to(target_logits.device())
+                            : torch::Tensor(),
+      target_logits,
+      bonus_token_ids,
+      /*mask_out_rejected_tokens=*/true);
+
+  const torch::Tensor& embeddings = target_output.sample_output.embeddings;
+  sample_output.embeddings =
+      embeddings.view({batch_size, num_val_tokens, embeddings.size(-1)});
+  return sample_output;
+}
+
+}  // namespace xllm::spec_verify

--- a/xllm/core/framework/speculative/spec_verify.cpp
+++ b/xllm/core/framework/speculative/spec_verify.cpp
@@ -26,16 +26,10 @@ namespace xllm::spec_verify {
 SampleOutput run_rejection_sampling(const SamplerPolicy& policy,
                                     const torch::Tensor& draft_token_ids,
                                     const torch::Tensor& draft_probs,
+                                    const torch::Tensor& target_logits,
                                     const ForwardOutput& target_output,
                                     const torch::Tensor& bonus_token_ids,
-                                    int32_t batch_size,
-                                    int32_t num_val_tokens,
                                     bool enable_fused_kernel) {
-  const int32_t vocab_size =
-      static_cast<int32_t>(target_output.logits.size(/*dim=*/-1));
-  torch::Tensor target_logits =
-      target_output.logits.view({batch_size, num_val_tokens, vocab_size});
-
   auto rejection_sampler =
       std::make_unique<RejectionSampler>(policy.do_sample,
                                          policy.all_random_sample,
@@ -44,16 +38,17 @@ SampleOutput run_rejection_sampling(const SamplerPolicy& policy,
                                          target_output.max_top_logprobs,
                                          enable_fused_kernel);
 
-  SampleOutput sample_output =
-      rejection_sampler->forward(draft_token_ids.to(bonus_token_ids),
-                                 draft_probs.to(target_logits.device()),
-                                 target_logits,
-                                 bonus_token_ids,
-                                 /*mask_out_rejected_tokens=*/true);
+  SampleOutput sample_output = rejection_sampler->forward(
+      draft_token_ids.to(bonus_token_ids),
+      draft_probs.defined() ? draft_probs.to(target_logits.device())
+                            : torch::Tensor(),
+      target_logits,
+      bonus_token_ids,
+      /*mask_out_rejected_tokens=*/true);
 
   const torch::Tensor& embeddings = target_output.sample_output.embeddings;
-  sample_output.embeddings =
-      embeddings.view({batch_size, num_val_tokens, embeddings.size(-1)});
+  sample_output.embeddings = embeddings.view(
+      {target_logits.size(0), target_logits.size(1), embeddings.size(-1)});
   return sample_output;
 }
 

--- a/xllm/core/framework/speculative/spec_verify.h
+++ b/xllm/core/framework/speculative/spec_verify.h
@@ -1,0 +1,50 @@
+/* Copyright 2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <torch/torch.h>
+
+#include <cstdint>
+
+namespace xllm {
+
+struct SampleOutput;
+struct ForwardOutput;
+
+namespace spec_verify {
+
+struct SamplerPolicy {
+  torch::Tensor do_sample;
+  bool all_random_sample = false;
+  bool all_greedy_sample = false;
+};
+
+// Shared accept core for all speculative workers: build the RejectionSampler
+// from the given policy, run it, reshape embeddings. Callers own
+// bonus_token_ids and pass the policy explicitly so suffix's forced-greedy
+// verify can reuse it.
+SampleOutput run_rejection_sampling(const SamplerPolicy& policy,
+                                    const torch::Tensor& draft_token_ids,
+                                    const torch::Tensor& draft_probs,
+                                    const ForwardOutput& target_output,
+                                    const torch::Tensor& bonus_token_ids,
+                                    int32_t batch_size,
+                                    int32_t num_val_tokens,
+                                    bool enable_fused_kernel);
+
+}  // namespace spec_verify
+
+}  // namespace xllm

--- a/xllm/core/framework/speculative/spec_verify.h
+++ b/xllm/core/framework/speculative/spec_verify.h
@@ -32,17 +32,15 @@ struct SamplerPolicy {
   bool all_greedy_sample = false;
 };
 
-// Shared accept core for all speculative workers: build the RejectionSampler
-// from the given policy, run it, reshape embeddings. Callers own
-// bonus_token_ids and pass the policy explicitly so suffix's forced-greedy
-// verify can reuse it.
+// Shared accept core for the speculative workers. Callers own target_logits so
+// MTP can inject its filter mask first; draft_probs may be undefined
+// (all-greedy).
 SampleOutput run_rejection_sampling(const SamplerPolicy& policy,
                                     const torch::Tensor& draft_token_ids,
                                     const torch::Tensor& draft_probs,
+                                    const torch::Tensor& target_logits,
                                     const ForwardOutput& target_output,
                                     const torch::Tensor& bonus_token_ids,
-                                    int32_t batch_size,
-                                    int32_t num_val_tokens,
                                     bool enable_fused_kernel);
 
 }  // namespace spec_verify

--- a/xllm/core/runtime/dflash_worker_impl.cpp
+++ b/xllm/core/runtime/dflash_worker_impl.cpp
@@ -1144,16 +1144,17 @@ SampleOutput DFlashWorkerImpl::validate(
         target_next_tokens_2d.gather(/*dim=*/1, bonus_idx).view({-1, 1});
   }
 
+  torch::Tensor target_logits = target_output.logits.view(
+      {batch_size, num_val_tokens, target_output.logits.size(/*dim=*/-1)});
   return spec_verify::run_rejection_sampling(
       {.do_sample = sampling_params.do_sample,
        .all_random_sample = sampling_params.all_random_sample,
        .all_greedy_sample = sampling_params.all_greedy_sample},
       draft_token_ids,
       draft_probs,
+      target_logits,
       target_output,
       bonus_token_ids,
-      batch_size,
-      num_val_tokens,
       enable_fused_kernel_);
 }
 

--- a/xllm/core/runtime/dflash_worker_impl.cpp
+++ b/xllm/core/runtime/dflash_worker_impl.cpp
@@ -33,7 +33,7 @@ limitations under the License.
 #include "core/framework/speculative/speculative_profile_registry.h"
 #include "framework/model/model_args.h"
 #include "framework/parallel_state/process_group.h"
-#include "framework/sampling/rejection_sampler.h"
+#include "framework/sampling/sampling_params.h"
 #if defined(USE_NPU) || defined(USE_MLU)
 #include "framework/kv_cache_transfer/mooncake_kv_cache_transfer.h"
 #endif
@@ -43,6 +43,7 @@ limitations under the License.
 #include "framework/kv_cache_transfer/spec_kv_cache_transfer.h"
 #endif
 #include "core/framework/speculative/spec_input_builder.h"
+#include "core/framework/speculative/spec_verify.h"
 #include "util/json_reader.h"
 #include "util/timer.h"
 
@@ -1110,8 +1111,6 @@ SampleOutput DFlashWorkerImpl::validate(
       << "DFlash validate target logits rows must be divisible by validation "
          "width";
   const int32_t batch_size = num_logits_rows / num_val_tokens;
-  const int32_t vocab_size =
-      static_cast<int32_t>(target_output.logits.size(/*dim=*/-1));
 
   using torch::indexing::None;
   using ISlice = torch::indexing::Slice;
@@ -1145,47 +1144,22 @@ SampleOutput DFlashWorkerImpl::validate(
         target_next_tokens_2d.gather(/*dim=*/1, bonus_idx).view({-1, 1});
   }
 
-  torch::Tensor target_logits =
-      target_output.logits.view({batch_size, num_val_tokens, vocab_size});
-
-  auto rejection_sampler =
-      std::make_unique<RejectionSampler>(sampling_params.do_sample,
-                                         sampling_params.all_random_sample,
-                                         sampling_params.all_greedy_sample,
-                                         target_output.logprobs,
-                                         target_output.max_top_logprobs,
-                                         enable_fused_kernel_);
-
-  SampleOutput sample_output =
-      rejection_sampler->forward(draft_token_ids.to(bonus_token_ids),
-                                 draft_probs.to(target_logits.device()),
-                                 target_logits,
-                                 bonus_token_ids,
-                                 /*mask_out_rejected_tokens=*/true);
-
-  const torch::Tensor& embeddings = target_output.sample_output.embeddings;
-  sample_output.embeddings =
-      embeddings.view({batch_size, num_val_tokens, embeddings.size(-1)});
-  return sample_output;
+  return spec_verify::run_rejection_sampling(
+      {.do_sample = sampling_params.do_sample,
+       .all_random_sample = sampling_params.all_random_sample,
+       .all_greedy_sample = sampling_params.all_greedy_sample},
+      draft_token_ids,
+      draft_probs,
+      target_output,
+      bonus_token_ids,
+      batch_size,
+      num_val_tokens,
+      enable_fused_kernel_);
 }
 
 void DFlashWorkerImpl::process_draft_sample_output(
     SampleOutput& sample_output) {
-  if (sample_output.probs.defined()) {
-    CHECK(sample_output.next_tokens.defined())
-        << "DFlash draft sample_output.next_tokens must be defined when probs "
-           "exist";
-    CHECK_EQ(sample_output.next_tokens.dim(), 1)
-        << "DFlash draft cache expects next_tokens [batch], got "
-        << sample_output.next_tokens.sizes();
-    CHECK(sample_output.probs.dim() == 1 || sample_output.probs.dim() == 2)
-        << "DFlash draft cache expects probs [batch] or [batch,vocab], got "
-        << sample_output.probs.sizes();
-    CHECK_EQ(sample_output.probs.size(0), sample_output.next_tokens.size(0))
-        << "DFlash draft cache probs/token batch mismatch";
-    sample_output.probs = specBuilder::draftProbs::compress_for_cache(
-        sample_output.probs, sample_output.next_tokens);
-  }
+  specBuilder::draftProbs::compress_sample_output_for_cache(sample_output);
 }
 
 void DFlashWorkerImpl::maybe_broadcast_spec_tokens(torch::Tensor& tokens) {

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -2866,21 +2866,7 @@ bool MTPWorkerImpl::adaptive_enabled() const {
 }
 
 void MTPWorkerImpl::process_draft_sample_output(SampleOutput& sample_output) {
-  if (sample_output.probs.defined()) {
-    CHECK(sample_output.next_tokens.defined())
-        << "draft sample_output.next_tokens must be defined when probs exist";
-    CHECK_EQ(sample_output.next_tokens.dim(), 1)
-        << "MTP draft cache expects next_tokens [batch], got "
-        << sample_output.next_tokens.sizes();
-    CHECK(sample_output.probs.dim() == 1 || sample_output.probs.dim() == 2)
-        << "MTP draft cache expects probs [batch] or [batch,vocab], got "
-        << sample_output.probs.sizes();
-    CHECK_EQ(sample_output.probs.size(0), sample_output.next_tokens.size(0))
-        << "MTP draft cache probs/token batch mismatch";
-    // Cache always stores selected-only draft probs [batch_size] to reduce HBM.
-    sample_output.probs = specBuilder::draftProbs::compress_for_cache(
-        sample_output.probs, sample_output.next_tokens);
-  }
+  specBuilder::draftProbs::compress_sample_output_for_cache(sample_output);
 }
 
 void MTPWorkerImpl::update_decode_step_input(

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -52,6 +52,7 @@ limitations under the License.
 #include "core/framework/speculative/mtp_async_input_builder.h"
 #include "core/framework/speculative/mtp_async_state.h"
 #include "core/framework/speculative/spec_input_builder.h"
+#include "core/framework/speculative/spec_verify.h"
 #include "core/framework/speculative/speculative_profile_registry.h"
 #include "core/layers/common/dsa_topk_share_plan.h"
 #include "util/pretty_print.h"
@@ -4010,23 +4011,17 @@ SampleOutput MTPWorkerImpl::validate(
                        draft_token_ids);
     }
 
-    // prepare input for rejection sampling
-    std::unique_ptr<RejectionSampler> rejection_sampler =
-        std::make_unique<RejectionSampler>(sampling_params.do_sample,
-                                           sampling_params.all_random_sample,
-                                           sampling_params.all_greedy_sample,
-                                           target_output.logprobs,
-                                           target_output.max_top_logprobs,
-                                           enable_fused_kernel_);
-
     // get the accepted tokens
-    sample_output = rejection_sampler->forward(
-        validation_draft_token_ids.to(bonus_token_ids),
-        draft_probs.defined() ? draft_probs.to(target_logits.device())
-                              : torch::Tensor(),
+    sample_output = spec_verify::run_rejection_sampling(
+        {.do_sample = sampling_params.do_sample,
+         .all_random_sample = sampling_params.all_random_sample,
+         .all_greedy_sample = sampling_params.all_greedy_sample},
+        validation_draft_token_ids,
+        draft_probs,
         target_logits,
+        target_output,
         bonus_token_ids,
-        /*mask_out_rejected_tokens=*/true);
+        enable_fused_kernel_);
 
     if (!invalid_draft.empty()) {
       torch::Tensor target_sampled_tokens =
@@ -4058,11 +4053,6 @@ SampleOutput MTPWorkerImpl::validate(
         }
       }
     }
-
-    // process embedding
-    torch::Tensor embeddings = target_output.sample_output.embeddings;
-    sample_output.embeddings =
-        embeddings.view({batch_size, num_val_tokens, embeddings.size(-1)});
   }
 
   if (pruned_prefix_lengths != nullptr) {

--- a/xllm/core/runtime/suffix_worker_impl.cpp
+++ b/xllm/core/runtime/suffix_worker_impl.cpp
@@ -415,10 +415,9 @@ SampleOutput SuffixWorkerImpl::validate(
                                               .all_greedy_sample = true},
                                              draft_token_ids,
                                              draft_probs,
+                                             target_logits,
                                              target_output,
                                              bonus_token_ids,
-                                             batch_size,
-                                             num_val_tokens,
                                              enable_fused_kernel_);
 }
 

--- a/xllm/core/runtime/suffix_worker_impl.cpp
+++ b/xllm/core/runtime/suffix_worker_impl.cpp
@@ -19,7 +19,8 @@ limitations under the License.
 
 #include "common/metrics.h"
 #include "core/framework/eplb/eplb_utils.h"
-#include "framework/sampling/rejection_sampler.h"
+#include "core/framework/speculative/spec_verify.h"
+#include "framework/sampling/sampling_params.h"
 #include "util/slice.h"
 #include "util/timer.h"
 #include "util/utils.h"
@@ -409,26 +410,16 @@ SampleOutput SuffixWorkerImpl::validate(
   // Suffix decoding always uses greedy sampling for validation,
   // regardless of the user's sampling parameters.
   auto greedy_do_sample = torch::zeros({batch_size}, torch::kBool);
-  auto rejection_sampler =
-      std::make_unique<RejectionSampler>(greedy_do_sample,
-                                         /*all_random_sample=*/false,
-                                         /*all_greedy_sample=*/true,
-                                         target_output.logprobs,
-                                         target_output.max_top_logprobs,
-                                         enable_fused_kernel_);
-
-  SampleOutput sample_output =
-      rejection_sampler->forward(draft_token_ids.to(bonus_token_ids),
-                                 draft_probs.to(target_logits.device()),
-                                 target_logits,
-                                 bonus_token_ids,
-                                 /*mask_out_rejected_tokens=*/true);
-
-  auto embeddings = target_output.sample_output.embeddings;
-  sample_output.embeddings =
-      embeddings.view({batch_size, num_val_tokens, embeddings.size(-1)});
-
-  return sample_output;
+  return spec_verify::run_rejection_sampling({.do_sample = greedy_do_sample,
+                                              .all_random_sample = false,
+                                              .all_greedy_sample = true},
+                                             draft_token_ids,
+                                             draft_probs,
+                                             target_output,
+                                             bonus_token_ids,
+                                             batch_size,
+                                             num_val_tokens,
+                                             enable_fused_kernel_);
 }
 
 }  // namespace xllm


### PR DESCRIPTION
## Summary

Deduplicates the speculative-decoding worker **accept path**. `MTPWorkerImpl`,
`DFlashWorkerImpl`, and `SuffixWorkerImpl` each carried their own copy of the
draft accept path (RejectionSampler construction → forward → embedding reshape),
and MTP/DFlash additionally duplicated draft-prob cache compression.

Extracted into free helpers via **composition** (not base-class hoisting, so
`SuffixWorkerImpl` — which has no draft model — is not burdened):

- `spec_verify::run_rejection_sampling` (new `framework/speculative/spec_verify.*`)
  — the shared accept core. Each worker keeps its own bonus-token extraction
  (uniform stride / per-seq gather / target-argmax); batch/width are derived from
  the caller-provided `target_logits`. The sampler policy is passed explicitly
  (`SamplerPolicy`) so suffix decoding's forced-greedy verify reuses the core, and
  MTP injects its JSON filter mask into `target_logits` before verifying.
- `specBuilder::draftProbs::compress_sample_output_for_cache` — shared draft-prob
  cache compression (MTP + DFlash).

All speculative worker paths (Eagle3 via MTP, DSpark via DFlash) now commit
accepted tokens through one implementation. Net: 9 files, +167/-146.

## Gate status

- ✅ **Compiles** on NPU (CANN / torch_npu, C++20, `-Werror`) — full incremental
  build to completion, no errors/warnings.
- ✅ **Behavior-preserving — static byte-equivalence verified.** Per worker the
  extracted core receives byte-identical `RejectionSampler` ctor args, `forward`
  args, and embedding-reshape dims vs. the pre-refactor inline code. The shared
  `draft_probs.defined()` guard is superset-safe: it reproduces DFlash/Suffix's
  unconditional `.to()` (their draft_probs is always defined) and MTP's guarded
  all-greedy path. `compress_sample_output_for_cache` is byte-identical to the old
  inline bodies; `build_q_cu_seq_lens_tensor` removal has zero remaining refs. No
  new randomness / dtype / device changes → identical RNG consumption.

## Test plan

- [x] Static byte-equivalence — ctor/forward args + reshape dims byte-identical
      per worker (DFlash, Suffix, MTP); shared guard superset-safe.
- [ ] (Optional) Runtime accept-token dual-run at fixed seed + fixed
      `num_speculative_tokens` as belt-and-suspenders.