### PR TITLE
feat: support Qwen3.8-27B chat templates.

### DIFF
--- a/tests/core/framework/chat_template/jinja_chat_template_test.cpp
+++ b/tests/core/framework/chat_template/jinja_chat_template_test.cpp
@@ -124,4 +124,37 @@ TEST(ChatTemplate, ClassifiesTerminalGenerationMarkers) {
             ChatTemplateGenerationMode::UNKNOWN);
 }
 
+TEST(JinjaChatTemplate, SupportsUndefinedTests) {
+  // Qwen3.8 uses both forms for optional chat-template arguments. Quoted text
+  // must remain unchanged while executable Jinja expressions are normalized.
+  const std::string template_str =
+      "plain text: value is undefined|"
+      "{{ 'quoted value is undefined' }}|"
+      "{% if enable_thinking is undefined %}default"
+      "{% else %}configured{% endif %}|"
+      "{% if enable_thinking is not undefined %}present"
+      "{% else %}missing{% endif %}";
+
+  nlohmann::ordered_json messages = {{{"role", "user"}, {"content", "hello"}}};
+  TokenizerArgs args;
+  args.chat_template(template_str);
+  args.bos_token("");
+  args.eos_token("");
+  TestableJinjaChatTemplate template_(args);
+
+  auto default_result = template_.apply(messages);
+  ASSERT_TRUE(default_result.has_value());
+  EXPECT_EQ(default_result.value(),
+            "plain text: value is undefined|quoted value is undefined|default|"
+            "missing");
+
+  const nlohmann::ordered_json tools = nlohmann::json::array();
+  const nlohmann::ordered_json kwargs = {{"enable_thinking", false}};
+  auto configured_result = template_.apply(messages, tools, kwargs);
+  ASSERT_TRUE(configured_result.has_value());
+  EXPECT_EQ(configured_result.value(),
+            "plain text: value is undefined|quoted value is undefined|"
+            "configured|present");
+}
+
 }  // namespace xllm

--- a/xllm/core/framework/chat_template/jinja_chat_template.cpp
+++ b/xllm/core/framework/chat_template/jinja_chat_template.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 #include <glog/logging.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <optional>
 #include <string>
 
@@ -31,12 +32,73 @@ const std::unordered_map<std::string, std::string> type_to_modality = {
     {"image_embedding", "image"},
     {"video_embedding", "video"},
     {"audio_embedding", "audio"}};
+
+void replace_undefined_tests(std::string& block) {
+  char quote = '\0';
+  for (size_t pos = 0; pos < block.size(); ++pos) {
+    const char current = block[pos];
+    if (quote != '\0') {
+      if (current == '\\') {
+        ++pos;
+      } else if (current == quote) {
+        quote = '\0';
+      }
+      continue;
+    }
+    if (current == '\'' || current == '"') {
+      quote = current;
+      continue;
+    }
+
+    static constexpr char kIsNotUndefined[] = " is not undefined";
+    static constexpr char kIsNotNone[] = " is not none";
+    static constexpr char kIsUndefined[] = " is undefined";
+    static constexpr char kIsNone[] = " is none";
+    if (block.compare(pos, sizeof(kIsNotUndefined) - 1, kIsNotUndefined) == 0) {
+      block.replace(pos, sizeof(kIsNotUndefined) - 1, kIsNotNone);
+    } else if (block.compare(pos, sizeof(kIsUndefined) - 1, kIsUndefined) ==
+               0) {
+      block.replace(pos, sizeof(kIsUndefined) - 1, kIsNone);
+    }
+  }
 }
+
+std::string normalize_minja_tests(std::string chat_template) {
+  size_t search_pos = 0;
+  while (search_pos < chat_template.size()) {
+    const size_t expression_pos = chat_template.find("{{", search_pos);
+    const size_t statement_pos = chat_template.find("{%", search_pos);
+    const size_t block_pos = std::min(expression_pos, statement_pos);
+    if (block_pos == std::string::npos) {
+      break;
+    }
+
+    const std::string close = block_pos == expression_pos ? "}}" : "%}";
+    const size_t close_pos = chat_template.find(close, block_pos + 2);
+    if (close_pos == std::string::npos) {
+      break;
+    }
+
+    std::string block =
+        chat_template.substr(block_pos, close_pos + close.size() - block_pos);
+    // Qwen3.8's official template uses Jinja's `is undefined` test for optional
+    // arguments. Minja represents missing arguments as null and only supports
+    // `is none`, so normalize the test before Minja parses the template.
+    replace_undefined_tests(block);
+    chat_template.replace(
+        block_pos, close_pos + close.size() - block_pos, block);
+    search_pos = block_pos + block.size();
+  }
+  return chat_template;
+}
+}  // namespace
 
 JinjaChatTemplate::JinjaChatTemplate(const TokenizerArgs& args) : args_(args) {
   try {
     template_ = std::make_unique<minja::chat_template>(
-        args_.chat_template(), args_.bos_token(), args_.eos_token());
+        normalize_minja_tests(args_.chat_template()),
+        args_.bos_token(),
+        args_.eos_token());
     LOG(INFO) << "Jinja chat template init succeed.";
 
   } catch (const std::exception& e) {


### PR DESCRIPTION
## Description

本 PR 为 xLLM 增加对最新发布的 Qwen3.8-27B 模型官方 Chat Template 的支持。

Qwen3.8-27B 的官方模板使用 Jinja `is undefined` 和 `is not undefined` 判断 `enable_thinking`、`preserve_thinking` 等可选参数。xLLM 当前使用的 Minja 将缺失参数表示为 null，仅支持 `is none`，无法直接解析上述测试语法，导致官方 Chat Template 初始化失败。

### 为什么 Hugging Face 官方 Chat Template 发生变化

Qwen3.8 不仅更新了模型权重，也扩展了官方对话协议中的 Thinking 控制能力：

- Thinking 模式默认开启；调用方不传 `enable_thinking` 时应按 `true` 处理，显式传入 `false` 时才关闭。
- 新增 `reasoning_effort`，支持 `xhigh`、`medium`、`low` 三档推理深度，并由模板注入对应的 reasoning instructions。
- `preserve_thinking` 默认开启，用于保留历史消息中的 reasoning content，维持多轮推理上下文并提升 KV Cache 利用率。

为了区分“参数未传入”和“参数被显式设置为 `false`”，Qwen3.8 官方模板在核心控制分支中使用了标准 Jinja 的 `is undefined` 语义，例如：

```jinja2
{% if enable_thinking is undefined or enable_thinking is true %}
{% if preserve_thinking is undefined or preserve_thinking is true %}
```

这使参数缺省行为与模型卡声明的默认行为保持一致，不能简单删除或统一按 `false` 处理。

### 为什么 xLLM 需要代码适配

xLLM 会直接读取 Hugging Face `tokenizer_config.json` 中发布的官方 Chat Template，但当前模板引擎使用的是 Minja，而不是 Hugging Face Transformers 使用的完整 Jinja 环境。两者对缺失变量的表示和测试语法存在差异：Minja 将缺失参数表示为 null，并使用 `is none` 判断，不能直接按官方模板的 `is undefined` / `is not undefined` 语义完成解析。

如果不适配，Qwen3.8 官方模板可能初始化失败，或者无法正确执行 Thinking 和 preserved-thinking 的缺省逻辑，最终造成请求失败、输入 prompt 与官方定义不一致，进而影响模型输出和评测精度。

因此，本 PR 在进入 Minja 解析前进行语义等价的兼容转换：将可执行 Jinja 块中的 `is undefined` / `is not undefined` 转换为 Minja 支持的 `is none` / `is not none`。转换不修改 Hugging Face 模板定义的默认行为，也不会修改普通文本或引号内字符串。

本 PR 进行以下最小范围修改：

- 在 Minja 解析前，将可执行 Jinja 块中的 `is undefined`、`is not undefined` 分别转换为 `is none`、`is not none`。
- 仅处理 `{{ ... }}` 和 `{% ... %}` 块，不修改普通模板文本。
- 跳过单引号和双引号内的内容，避免改变用户可见字符串。
- 新增单元测试，覆盖参数缺失、参数显式传入以及普通文本和引号内容保持不变的场景。

本次提交仅包含 Qwen3.8 Chat Template 兼容性修改及对应测试。

### IFBench 验证

使用 xLLM 的 OpenAI-compatible API，在完整的 `allenai/IFBench_test` 300 条样本上对 Qwen3.8-27B 进行了 0-shot 验证。

配置参数与 Hugging Face 官方 model card 保持一致：
- 硬件与并行配置：NPU，TP4
- 推理配置：MTP2、Graph 模式、Decode no-padding
- 评测工具：EvalScope 1.8.0
- 数据集：IFBench，0-shot，300/300 样本
- Thinking：开启，`reasoning_effort=xhigh`
- 采样参数：temperature 1.0、top-p 0.95、top-k 20、min-p 0.0
- 最大输出长度：32,768 tokens
- 评分前处理：移除 `</think>` 及其之前的 reasoning 内容
- 模型请求错误：0
- 评分错误：0

| 结果 | Qwen3.8-27B 官方分数 | xLLM 实测 | 差值 |
|---|---:|---:|---:|
| IFBench aggregate / prompt-level loose | 79.50 | 79.33 | -0.17 pp |

xLLM 完整指标：

| 指标 | xLLM 实测 |
|---|---:|
| Prompt-level strict | 71.33 |
| Instruction-level strict | 74.00 |
| Prompt-level loose | 79.33 |
| Instruction-level loose | 81.33 |

xLLM 的 IFBench 实测分数与 [Qwen3.8-27B 官方模型卡](https://huggingface.co/Qwen/Qwen3.8-27B)公布的 79.5 仅相差 0.17 个百分点。完整数据集上的结果对齐证明 xLLM 能够正确处理 Qwen3.8-27B 的官方 Chat Template 与 Thinking 配置。

官方模型卡只公布了单一 IFBench 汇总分数，未注明具体指标变体和完整评测 harness。本次对比采用与官方汇总分数对应的 EvalScope prompt-level loose 指标。

## Related Issues

N/A

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [x] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

NPU 验证结果：

- Commit：`13af18fab3a2ea51be0c2d0322cb69c674dedbb7`
- Base：`67459aba105d7fe9a38d1970c1a4c0c68966f6c2`
- 命令：`python setup.py build test`
- 结果：PASS
- CTest：1,229 个非 Disabled 测试，0 失败
- Passed：1,222
- Skipped：7
- Disabled：29
- Qwen3.8 直接相关测试：`JinjaChatTemplate.SupportsUndefinedTests` 通过

## Reviewer Notes

建议重点审查以下边界：

- 只转换可执行 Jinja 表达式和语句块。
- 普通文本和引号内字符串保持不变。
- 同时覆盖 `is undefined` 与 `is not undefined`。
- 实现为通用 Minja 兼容处理，但修改原因是适配 Qwen3.8-27B 官方 Chat Template。
