### PR TITLE
bugfix: keep true num_accepted_tokens for Qwen3.5 GDN spec-verify checkpoint.

### DIFF
--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -1365,7 +1365,6 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_decode(
   const bool reuse_mtp_topk_state = layer::is_mtp_dsa_topk_reuse_enabled(
       draft_impl_->context_.get_model_args());
   MtpTopkStatePtr mtp_topk_state;
-  timer.reset();
   for (int32_t draft_idx = 0; draft_idx < num_speculative_tokens; ++draft_idx) {
     const bool is_final_draft = draft_idx == num_speculative_tokens - 1;
     const bool static_graph_tasks_prepared =

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -60,20 +60,6 @@ constexpr uint64_t MBUF_SIZE = 128 * 1024 * 1024;
 
 namespace {
 
-// Qwen3.5 GDN conv_state history capacity (kernel_conv_size - 1). Values of
-// num_accepted_tokens beyond this describe history that has already rolled
-// out of conv_state; passing them to aclnnCausalConv1d makes tiling fail when
-// the current step's per_seq_val_tokens is small (e.g. adaptive prunes down
-// to 2 while nat=5). Callers clamp accepted-prefix lengths to this cap before
-// invoking the GDN spec-verify path.
-constexpr int32_t kGdnConvHistoryCap = 3;
-
-void clamp_gdn_conv_history(std::vector<int32_t>& accepted_prefix_lengths) {
-  for (int32_t& v : accepted_prefix_lengths) {
-    v = std::min(v, kGdnConvHistoryCap);
-  }
-}
-
 bool has_active_dp_tokens(const ForwardInput& input) {
   const ParallelInput& parallel = input.input_params.parallel;
   const std::vector<int32_t>& token_nums =
@@ -1698,21 +1684,21 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_adaptive_validate(
     effective_speculative_tokens = 1;
   }
 
-  // The Qwen3.5 GDN CausalConv1d kernel produces aivec errors when the
-  // per-seq validate segment length is smaller than num_accepted_tokens
-  // (the previous step's accepted count). The tiling validation would
-  // reject nat > lenI, but the underlying kernel itself is fragile at
-  // those boundaries. Floor effective_speculative_tokens by the batch's
-  // max num_accepted so uniform_val_tokens >= max(nat) + 1. Read from
-  // embedding_cache directly since input.num_accepted_tokens_host is
-  // populated by prepare_validate_inputs which hasn't run yet here.
+  // Qwen3.5 GDN spec-verify commits the recurrent/conv checkpoint selected by
+  // the previous step's num_accepted_tokens (nat): the GDN kernel indexes
+  // ssm_state as nat - 1 and requires nat <= this step's validate width. Floor
+  // effective_speculative_tokens by the batch's max nat so uniform_val_tokens
+  // >= max(nat) + 1. nat itself must stay the true accepted count (never
+  // clamped) so the committed checkpoint matches the last accepted token;
+  // clamping it would commit a stale checkpoint (see issue #2247). Read from
+  // embedding_cache directly since input.num_accepted_tokens_host is populated
+  // by prepare_validate_inputs which hasn't run yet here.
   if (supports_explicit_spec_verify_replay_update() &&
       embedding_cache_ != nullptr &&
       !input.input_params.embedding.embedding_ids.empty()) {
     std::vector<int32_t> nat = embedding_cache_->read_accepted_prefix_lengths(
         input.input_params.embedding.embedding_ids,
         input.input_params.embedding.request_ids);
-    clamp_gdn_conv_history(nat);
     int32_t max_nat = 0;
     for (int32_t v : nat) {
       max_nat = std::max(max_nat, v);
@@ -2628,14 +2614,11 @@ void MTPWorkerImpl::prepare_validate_inputs(const ForwardInput& input,
           input.input_params.embedding.embedding_ids,
           input.input_params.embedding.request_ids);
     }
-    // Clamp num_accepted_tokens to Qwen3.5 GDN conv_state history capacity
-    // (kernel_conv_size - 1 = 3). Larger values describe history that has
-    // already rolled out of conv_state; passing them to aclnnCausalConv1d
-    // makes tiling fail when the current step's per_seq_val_tokens is small
-    // (e.g. adaptive prunes down to 2 while nat=5).
-    if (supports_explicit_spec_verify_replay_update()) {
-      clamp_gdn_conv_history(accepted_prefix_lengths);
-    }
+    // num_accepted_tokens must stay the true accepted count. The Qwen3.5 GDN
+    // spec-verify kernel uses it to select which recurrent/conv checkpoint to
+    // commit (checkpoint index = nat - 1); it is a logical checkpoint index,
+    // not the conv_state physical history capacity. Clamping it commits a
+    // stale checkpoint whenever 4+ tokens were accepted (see issue #2247).
     input_params.num_accepted_tokens_host.assign(
         accepted_prefix_lengths.begin(), accepted_prefix_lengths.end());
     if (!use_explicit_spec_verify_replay_update) {
@@ -2969,14 +2952,12 @@ void MTPWorkerImpl::prepare_validate_inputs(
           input.input_params.embedding.embedding_ids,
           input.input_params.embedding.request_ids);
     }
-    // Clamp num_accepted_tokens to Qwen3.5 GDN conv_state history capacity
-    // (kernel_conv_size - 1 = 3). Larger values describe history that has
-    // already rolled out of conv_state; passing them to aclnnCausalConv1d
-    // makes tiling fail when the current step's per_seq_val_tokens is small
-    // (e.g. adaptive prunes down to 2 while nat=5).
-    if (supports_explicit_spec_verify_replay_update()) {
-      clamp_gdn_conv_history(accepted_prefix_lengths);
-    }
+    // num_accepted_tokens must stay the true accepted count: the Qwen3.5 GDN
+    // spec-verify kernel commits the recurrent/conv checkpoint at index
+    // nat - 1, so clamping it would commit a stale state whenever 4+ tokens
+    // were accepted (see issue #2247). The conv1d kernel already clamps its
+    // own physical conv_state read offset internally, and the tiling check
+    // no longer rejects nat > segment length, so no host-side clamp is needed.
     input_params.num_accepted_tokens =
         torch::tensor(accepted_prefix_lengths, token_options);
     input_params.num_accepted_tokens_host.assign(


### PR DESCRIPTION
## Summary

Fixes #2247. PR #1876 introduced `clamp_gdn_conv_history`, which clamped `num_accepted_tokens` (nat) to the conv_state physical history capacity (`kernel_conv_size - 1 = 3`) before the Qwen3.5 GDN speculative-verify path.

The problem is that nat serves two distinct roles:
1. the conv_state physical rolling-history capacity — cappable;
2. the **logical checkpoint index** selecting which recurrent/conv state to commit (`checkpoint index = nat - 1`) — must **not** be capped.

Clamping nat commits a stale GDN checkpoint whenever 4+ tokens are accepted (MTP speculative length ≥ 3): the token/KV state advances 4 steps but the recurrent state is committed from checkpoint 2 instead of 3, leaving the GDN state one or more steps behind on the next decode round. Accuracy degrades as accept counts grow.

Because the clamp also lived in the common/static validate-input path, enabling graph mode or disabling adaptive speculative decoding did not avoid it.

## Changes

**Commit 1 (correctness fix):**
- Remove `clamp_gdn_conv_history` / `kGdnConvHistoryCap`.
- Pass the true accepted count through all three call sites: adaptive width, common validate input, and per-seq validate input.
- The adaptive width path still floors `effective_speculative_tokens` by `max(nat)` so `uniform_val_tokens >= max(nat) + 1` — this keeps `nat <= the current step's validate width` without altering nat itself.

**Commit 2 (telemetry cleanup, metrics-only):**
- Remove a `timer.reset()` that #1876 added before the draft loop in `step_decode`, which had narrowed `speculative_execution_latency_seconds_draft` to exclude pre-loop preparation. Restores the pre-#1876 counter scope. No effect on decode outputs (the counter feeds no tensor/kernel/control-flow; the adaptive controller uses `full_draft_time_ms=0.0`).

## Static-path contamination review

Since #2247 was caused by an adaptive-feature change leaking into the static path, I audited every other change #1876 made to confirm there is no second contamination. Verified two ways (manual diff of all 22 hunks against `0fbdb417e~1`, plus an independent pass): **the clamp was the only correctness-affecting change to the static path.** Every other shared-function change is a pure refactor, adaptive-gated, or telemetry-only.

Key structural guarantee: `AdaptiveSpeculativeController::enabled_` requires `!options.enable_graph()`, so under `enable_graph=true` (or adaptive off, or EAGLE-3, or DP/EP>1) `adaptive_enabled()==false`, `pruned_prefix_lengths==nullptr`, `per_seq_val_tokens` is uniform, and `needs_padding==false` — driving the static path exclusively through the fast paths that reduce to pre-#1876 behavior. The adaptive-only branches (`run_adaptive_validate`, per-seq `prepare_validate_inputs`, `record_validate_metrics`, `write_target_context_to_cache`) are gated behind `pruned_prefix_lengths != nullptr` / `adaptive_enabled()` and are never reached on the static path.

Runtime corroboration: across 3 diverse greedy prompts, MTP3 output from this branch is byte-identical to MTP3 built from #1876's parent commit (029425e8d), confirming static-path behavior is unchanged from before #1876 through this fix.

## Note on verification

The `check_mtp3.py` script in the issue asserts MTP3 greedy output is byte-identical to MTP0 (non-speculative). That assertion does not hold as a fix criterion: on this hardware, Qwen3.5 MTP greedy already diverges from MTP0 greedy **independently of this bug** (different kernel paths → different FP rounding → a different argmax at some token). Verified three ways: (a) MTP2 (`num_speculative_tokens=2`, where nat ≤ 3 makes the bug structurally impossible) still diverges identically; (b) eager mode (`enable_graph=false`), where the spec-verify checkpoint kernel is never called, still diverges; (c) building #1876's direct parent commit (029425e8d) and running its MTP3 vs MTP0 reproduces the exact same divergence. So the divergence predates #1876 and is not the #2247 bug.

The fix here follows the issue's root-cause analysis (do not clamp the checkpoint index). A state-level regression test (comparing the committed GDN/conv checkpoint at nat = 1..num_speculative_tokens+1 against a non-speculative reference, per the issue's suggestion #5) is the correct verification and can be added as a follow-up.

## Test plan

- [x] Builds on NPU (`hwz_xllm_cann9`, USE_NPU).
- [x] Static-path behavior unchanged vs #1876-parent (byte-identical MTP3 output across 3 prompts).
- [ ] State-level GDN/conv checkpoint regression test (follow-up).