### PR TITLE
feat: enable adaptive speculative under graph mode.

### DIFF
--- a/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
+++ b/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
@@ -43,12 +43,18 @@ struct PruneCandidate {
 
 }  // namespace
 
+// Adaptive pruning is compatible with enable_graph: the pruned per-seq validate
+// step is flattened to total_num_val_tokens q=1 rows tagged BatchForwardType
+// DECODE (see SpeculativeWorkerImpl::prepare_validate_inputs), so the executor
+// routes it through the ordinary decode graph path and pads the (variable)
+// pruned token count up to the next decode bucket, exactly like an unpruned
+// decode batch of a different size. No static-shape assumption is violated, so
+// graph mode does not force the controller off.
 AdaptiveSpeculativeController::AdaptiveSpeculativeController(
     const runtime::Options& options)
     : enabled_(options.enable_adaptive_speculative_decode() &&
                options.num_speculative_tokens() > 1 &&
-               is_supported_algorithm(options.speculative_algorithm()) &&
-               !options.enable_graph()),
+               is_supported_algorithm(options.speculative_algorithm())),
       min_gain_(options.adaptive_speculative_min_gain()) {}
 
 bool AdaptiveSpeculativeController::enabled() const { return enabled_; }


### PR DESCRIPTION
## Description

Enable adaptive speculative decoding (MTP / DFlash / DSpark) to run with
`--enable_graph=true`. Previously the adaptive controller was hard-disabled
whenever graph mode was on:

```cpp
enabled_(... && is_supported_algorithm(...) && !options.enable_graph())
```

This gate was overly conservative. The pruned per-sequence validate step is
flattened to `total_num_val_tokens` q=1 rows tagged `BatchForwardType::DECODE`
(see `SpeculativeWorkerImpl::prepare_validate_inputs`), so the ACL graph
executor routes it through the ordinary **decode** graph path and pads the
(variable) pruned token count up to the next decode bucket — exactly like an
unpruned decode batch of a different size. No static-shape assumption is
violated, so there is no reason to force the controller off under graph mode.

This PR drops the `!enable_graph()` term and adds a comment documenting why the
DECODE-flattened validate is graph-capturable.

## Test

Single-NPU, ShareGPT, `--enable_graph=true` for every case. Qwen3-8B for
DFlash/DSpark; a 5-layer DeepSeek-V3.2 stub for MTP (small enough to fit one
die). Verified that graph capture actually engages under adaptive pruning
(not an eager fallback):

- MTP server log: `profile_manager: Starting speculative validate profile for
  MTP, adaptive_enabled=1` — before this change the gate forced
  `adaptive_enabled=0` under graph.
- All three algorithms log e.g.
  `Lazy capturing ACL graph for bucket num_tokens: 80 (actual num_tokens: 69)` —
  `actual num_tokens` is the adaptively-pruned variable width
  `Σ per_seq_val_tokens`, padded into the standard decode bucket.
- No `FATAL` / `CHECK` failures in any server log; all cases completed; output
  verified coherent at the most aggressive DSpark SL16 adaptive setting.
