### PR TITLE
bugfix: do not build a tokenizer for draft-engine workers.

### DIFF
--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -1871,15 +1871,6 @@ bool WorkerImpl::init_model(const std::string& model_weights_path,
 
   auto model_loader = ModelLoader::create(model_weights_path);
   model_weights_path_ = std::move(model_weights_path);
-  // A draft engine is fed token ids and detokenized by the target, so it owns
-  // no tokenizer (its weights dir may not even ship tokenizer files, e.g. the
-  // DFlash / DSpark draft checkpoints). Only the target worker builds one; its
-  // JSON grammar restoration below is target-only and never runs on a draft.
-  std::unique_ptr<Tokenizer> tokenizer;
-  if (!options_.is_draft_engine()) {
-    tokenizer = model_loader->tokenizer();
-    CHECK(tokenizer != nullptr);
-  }
 
   auto args = model_loader->model_args();
   auto quant_args = model_loader->quant_args();
@@ -1887,9 +1878,16 @@ bool WorkerImpl::init_model(const std::string& model_weights_path,
   args.embedding_mode(embedding_mode);
   torch::ScalarType dtype = util::parse_dtype(args.dtype(), device_);
 
-  // Only the target engine reconciles tokenizer and model vocab sizes. Draft
-  // engines do not detokenize output and own no tokenizer.
+  // A draft engine is fed token ids and detokenized by the target, so it owns
+  // no tokenizer (its weights dir may not even ship tokenizer files, e.g. the
+  // DFlash / DSpark draft checkpoints). Only the target worker builds one and
+  // reconciles vocab sizes; its JSON grammar restoration below is target-only
+  // and never runs on a draft.
+  std::unique_ptr<Tokenizer> tokenizer;
   if (!options_.is_draft_engine()) {
+    tokenizer = model_loader->tokenizer();
+    CHECK(tokenizer != nullptr);
+
     const int64_t tokenizer_vocab_size = tokenizer->vocab_size();
     int64_t model_vocab_size = args.vocab_size();
     // use tokenizer vocab size if model vocab size is not set

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -1871,8 +1871,15 @@ bool WorkerImpl::init_model(const std::string& model_weights_path,
 
   auto model_loader = ModelLoader::create(model_weights_path);
   model_weights_path_ = std::move(model_weights_path);
-  auto tokenizer = model_loader->tokenizer();
-  CHECK(tokenizer != nullptr);
+  // A draft engine is fed token ids and detokenized by the target, so it owns
+  // no tokenizer (its weights dir may not even ship tokenizer files, e.g. the
+  // DFlash / DSpark draft checkpoints). Only the target worker builds one; its
+  // JSON grammar restoration below is target-only and never runs on a draft.
+  std::unique_ptr<Tokenizer> tokenizer;
+  if (!options_.is_draft_engine()) {
+    tokenizer = model_loader->tokenizer();
+    CHECK(tokenizer != nullptr);
+  }
 
   auto args = model_loader->model_args();
   auto quant_args = model_loader->quant_args();
@@ -1881,8 +1888,7 @@ bool WorkerImpl::init_model(const std::string& model_weights_path,
   torch::ScalarType dtype = util::parse_dtype(args.dtype(), device_);
 
   // Only the target engine reconciles tokenizer and model vocab sizes. Draft
-  // engines do not detokenize output, but worker-local JSON grammar state
-  // restoration still requires retaining the tokenizer below.
+  // engines do not detokenize output and own no tokenizer.
   if (!options_.is_draft_engine()) {
     const int64_t tokenizer_vocab_size = tokenizer->vocab_size();
     int64_t model_vocab_size = args.vocab_size();
@@ -2027,12 +2033,16 @@ bool WorkerImpl::init_model(const std::string& model_weights_path,
 
   // Warm JSON grammars off the forward path so the first constrained request
   // does not pay tokenizer.decode over the full vocab under the step lock.
-  if (ensure_json_object_grammar(/*reasoning_enabled=*/false) == nullptr) {
-    LOG(WARNING) << "JSON object grammar warmup failed; will retry lazily";
-  }
-  if (ensure_json_object_grammar(/*reasoning_enabled=*/true) == nullptr) {
-    LOG(WARNING)
-        << "JSON reasoning grammar warmup failed; will retry lazily on demand";
+  // Draft-engine workers own no tokenizer and never serve constrained requests
+  // (the target does), so skip the warmup for them.
+  if (!options_.is_draft_engine()) {
+    if (ensure_json_object_grammar(/*reasoning_enabled=*/false) == nullptr) {
+      LOG(WARNING) << "JSON object grammar warmup failed; will retry lazily";
+    }
+    if (ensure_json_object_grammar(/*reasoning_enabled=*/true) == nullptr) {
+      LOG(WARNING) << "JSON reasoning grammar warmup failed; will retry lazily "
+                      "on demand";
+    }
   }
 
   int32_t tp_world_size = parallel_args_.world_size();


### PR DESCRIPTION
## Description

`WorkerImpl::init_model` unconditionally built a tokenizer and asserted it was
non-null, and after init every worker also warmed the JSON-object grammar
(which hard-requires a tokenizer):

```cpp
auto tokenizer = model_loader->tokenizer();
CHECK(tokenizer != nullptr);
...
ensure_json_object_grammar(/*reasoning_enabled=*/false);  // CHECK(tokenizer_ != nullptr)
```

A draft engine is fed token ids and detokenized by the target, so its weights
directory may ship **no** tokenizer files — the DFlash / DSpark draft
checkpoints contain only `config.json` + weights. In that case
`TokenizerFactory` finds no tokenizer args, falls back to the SentencePiece
loader, fails to open a nonexistent `tokenizer.model`, and `LOG(FATAL)` aborts
the worker during init. Even with the tokenizer build skipped, the JSON-grammar
warmup then aborts on the null tokenizer. Either way any multi-process
(worker-server) DFlash / DSpark launch crashes on startup.

This guards both draft-engine paths:
1. Skip building the tokenizer for draft engines (matching the existing
   `if (!is_draft_engine())` guard already used at the engine level).
2. Skip the post-init JSON-grammar warmup for draft engines.

## Why it is safe

The worker tokenizer is used only by the **target** worker:
- vocab-size reconciliation (already inside `if (!is_draft_engine())`), and
- JSON-object grammar (warmup + `restore_json_object_states` /
  `ensure_json_object_grammar`), which only runs when a request carries JSON
  grammar state — a target-only path.

A draft worker keeps `tokenizer_` null and never reaches those uses.

## Test

- DFlash / DSpark multi-process launch (`nnodes >= 2`) previously aborted at
  init — first with `Failed to load SentencePiece model from
  .../tokenizer.model`, then (tokenizer skipped) with `JSON object grammar
  requires a worker tokenizer`. With this change the draft worker initializes
  without a tokenizer and the server comes up.
