### PR TITLE
bugfix: enable speculative decode under dp4 when some DP ranks are idle.

### DIFF
--- a/xllm/core/runtime/speculative_worker_impl.cpp
+++ b/xllm/core/runtime/speculative_worker_impl.cpp
@@ -104,9 +104,24 @@ bool should_run_speculative_decode(const ModelInputParams& params) {
     return false;
   }
 
-  return std::all_of(dp_is_decode.begin(),
-                     dp_is_decode.end(),
-                     [](int32_t is_decode) { return is_decode == 1; });
+  // Idle DP ranks (no scheduled tokens this step) must not veto speculative
+  // decode for the active ranks. Under enable_graph=False these idle ranks keep
+  // dp_is_decode=0 (the backfill in llm_engine only fires when enable_graph=
+  // True), which made an all-of-ones check fail for any bs<dp_size batch and
+  // silently fell back to the non-speculative path (validate never ran). Only
+  // ranks that actually carry tokens gate the decision; require every such rank
+  // to be in decode.
+  bool any_active = false;
+  for (size_t i = 0; i < dp_is_decode.size(); ++i) {
+    if (dp_token_nums[i] == 0) {
+      continue;  // idle rank: does not participate in the vote
+    }
+    any_active = true;
+    if (dp_is_decode[i] != 1) {
+      return false;
+    }
+  }
+  return any_active;
 }
 
 void scale_speculative_parallel_token_counts(ModelInputParams& params,


### PR DESCRIPTION
## Problem
Under dp4_ep4 with MTP (speculative decode) and enable_graph=False, dp4+MTP is
*slower* than dp4 without MTP (36.1ms vs 32ms TPOT). Profiling shows the validate
stage never runs (validation latency = 0, draft_tokens = 0): speculation silently
falls back to the plain decode path while still paying the draft cost.

## Root cause
`should_run_speculative_decode()` requires **all** DP ranks to be in decode
(`dp_is_decode` all ones). With bs < dp_size, idle DP ranks carry no tokens and keep
`dp_is_decode = 0`. The backfill in `llm_engine.cpp` that marks empty ranks as decode
is gated on `enable_graph=True`, so under `enable_graph=False` those idle ranks veto
speculation for the whole step.

## Fix
Only ranks that actually carry tokens (`dp_global_token_nums != 0`) gate the decision;
idle ranks no longer veto. dp1 and the non-speculative fallback are unaffected.

## Validation (16-card Ascend, V3-server103 w8a8, dp4_ep4, enable_graph=False)
| metric | before | after |
|---|---|---|
| avg TPOT | 36.1 ms | **16.0 ms** |
| validate latency | 0 | 0.194 s |
| draft tokens | 0 | 7696 (accept 83%) |