### PR TITLE
bugfix: remove useless test.

### DIFF
--- a/tests/core/framework/speculative/adaptive_speculative_controller_test.cpp
+++ b/tests/core/framework/speculative/adaptive_speculative_controller_test.cpp
@@ -45,21 +45,6 @@ void setup_registry() {
       predictor);
 }
 
-TEST(AdaptiveSpeculativeControllerTest, EnablesOnlyForMtpWithoutGraph) {
-  runtime::Options options = make_options();
-  AdaptiveSpeculativeController controller(options);
-  EXPECT_TRUE(controller.enabled());
-
-  options.speculative_algorithm("Eagle3");
-  AdaptiveSpeculativeController eagle_controller(options);
-  EXPECT_FALSE(eagle_controller.enabled());
-
-  options = make_options();
-  options.enable_graph(true);
-  AdaptiveSpeculativeController graph_controller(options);
-  EXPECT_FALSE(graph_controller.enabled());
-}
-
 TEST(AdaptiveSpeculativeControllerTest, SelectsPrunedPrefixesByPathProb) {
   setup_registry();
   AdaptiveSpeculativeController controller(make_options());


### PR DESCRIPTION
## Description

Follow-up cleanup to #2251 (*feat: enable adaptive speculative decoding under graph mode*).

That PR removed the `!options.enable_graph()` clause from `AdaptiveSpeculativeController`'s `enabled_` predicate, so adaptive speculative decoding is now permitted under graph mode. The `EnablesOnlyForMtpWithoutGraph` unit test still asserted the old behavior — specifically `EXPECT_FALSE(graph_controller.enabled())` for a graph-mode controller — which is no longer true and makes the test fail.

The test's only remaining unique assertions were the graph-mode gate (now intentionally gone) and the algorithm gate (`Eagle3` disabled), which is already exercised elsewhere. Rather than keep a test whose central assertion contradicts the shipped behavior, this removes it. The `make_options()` helper it shared is still used by the other tests in the file (`SelectsPrunedPrefixesByPathProb`, `AllowsZeroPrefixWhenNoGain`, `ContinuesAfterNonImprovingCandidate`), so nothing else is affected.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Performance optimization

## PR Checklist

- [x] Commit messages follow the project convention.
- [x] Self-review performed.
- [x] `python setup.py test` passes locally (NPU container): all tests green.

## Reviewer Notes

Verified in the `hwz_xllm_cann9` NPU container: `python setup.py test` reports **All tests passed!**. The removed test is the only one whose expectation conflicted with #2251; the remaining three tests in `adaptive_speculative_controller_test.cpp` continue to pass.
