### PR TITLE
perf: keep raw dit image tensors on cpu until vae preprocess.

### DIFF
--- a/xllm/core/runtime/dit_forward_params.h
+++ b/xllm/core/runtime/dit_forward_params.h
@@ -205,28 +205,30 @@ struct DiTForwardInput {
     }
 
     if (images.defined()) {
-      input.images = images.to(device, /*dtype=*/torch::kUInt8);
+      input.images = images.to(torch::kCPU, /*dtype=*/torch::kUInt8);
     }
 
     if (mask_images.defined()) {
-      input.mask_images = mask_images.to(device, /*dtype=*/torch::kUInt8);
+      input.mask_images = mask_images.to(torch::kCPU, /*dtype=*/torch::kUInt8);
     }
 
     for (auto& img : input.images_list) {
-      img = img.to(device, /*dtype=*/torch::kUInt8);
+      img = img.to(torch::kCPU, /*dtype=*/torch::kUInt8);
     }
 
     if (control_image.defined()) {
-      input.control_image = control_image.to(device, /*dtype=*/torch::kUInt8);
+      input.control_image =
+          control_image.to(torch::kCPU, /*dtype=*/torch::kUInt8);
     }
 
     if (last_images.defined()) {
-      input.last_images = last_images.to(device, /*dtype=*/torch::kUInt8);
+      input.last_images = last_images.to(torch::kCPU, /*dtype=*/torch::kUInt8);
     }
 
     if (prompt_audio.defined()) {
       input.prompt_audio = prompt_audio.to(device, torch::kFloat32);
     }
+
     return input;
   }
 


### PR DESCRIPTION
## Description

Keep raw DiT uint8 image tensors on CPU in `DiTForwardInput::to()`, and only move compute tensors to NPU.

`VAEImageProcessor::resize()` still uses a CPU Lanczos kernel, so moving `images` / `images_list` / `mask_images` / `control_image` / `last_images` to NPU early caused an extra NPU->CPU->NPU round-trip. This change avoids that copy for large and multi-image inputs such as Qwen Image Edit Plus.

Prompt embeddings, latents, `masked_image_latents`, and `prompt_audio` still follow the original `.to(device)` behavior.

## Related Issues

N/A

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

This PR only changes `xllm/core/runtime/dit_forward_params.h`.

Validated on NPU with Qwen Image Edit Plus:
- single-image and multi-image requests succeed
- raw `images_list` stays on CPU before VAE preprocess
- `condition_img` / `vae_img` still land on NPU after preprocess
- preprocess latency does not regress

NPU Lanczos resize is out of scope. Flux Fill / Flux Control / Wan I2V share the same raw-image fields, but dedicated end-to-end smoke was not run because those model services were not available in this environment.