### PR TITLE
refactor: remove ACL Graph capture failure fallback.

### DIFF
--- a/.agents/skills/code-review/references/custom-code-style.md
+++ b/.agents/skills/code-review/references/custom-code-style.md
@@ -243,6 +243,29 @@ LOG(FATAL) << "Unsupported model type: " << model_type;
 throw std::runtime_error("Unsupported model type: " + model_type);
 ```
 
+### Online Serving Failures and Fallbacks
+
+- **Prefer the let-it-crash principle for unexpected failures in online execution paths.** Model execution, graph capture/replay, device operations, and runtime state updates should normally let unexpected exceptions propagate instead of catching them and continuing the request.
+- **Do not introduce `try/catch` or `try/except` casually in online execution paths.** In particular, do not swallow an exception, retry the operation, fall back to another execution path, or keep serving from state that may already be partially modified.
+- **Do not introduce fallback code casually.** A fallback is appropriate only when it is an explicitly supported path selected before execution through observable conditions, and both paths have defined and tested semantics. It must not be used to mask a correctness issue, unsupported state, or failed operation.
+- Express expected unsupported conditions through explicit validation, `Status`, or return values before mutating execution state. Do not use exceptions as normal capability detection.
+- Exception handling remains valid at required process, RPC, C ABI, untrusted-input, or third-party API boundaries. Such handlers must catch the narrowest practical exception, preserve the failure signal, and must not pretend that a partially failed online operation succeeded.
+
+```cpp
+// Good: choose a supported path before execution starts.
+if (!graph_supported(params)) {
+  return forward_eager(model, params);
+}
+return forward_graph(model, params);
+
+// Bad: graph execution may have modified runtime state before failing.
+try {
+  return forward_graph(model, params);
+} catch (...) {
+  return forward_eager(model, params);
+}
+```
+
 ---
 
 ## 8. Code Style & Control Flow

--- a/xllm/core/runtime/acl_graph_executor_impl.cpp
+++ b/xllm/core/runtime/acl_graph_executor_impl.cpp
@@ -394,45 +394,22 @@ bool AclGraph::capture(CausalLM* model,
 
     // no mempool id, will create a new one; capture mode is thread local, allow
     // other threads to execute synchronous operations
-    bool capture_started = false;
-    try {
-      graph_.capture_begin(
-          {0, 0}, aclmdlRICaptureMode::ACL_MODEL_RI_CAPTURE_MODE_THREAD_LOCAL);
-      capture_started = true;
-      // Execute forward pass - NPUGraph mempool manages temporary tensors
-      auto forward_result =
-          model->forward({persistent_param_.persistent_tokens(num_tokens_)},
-                         {persistent_param_.persistent_positions(num_tokens_)},
-                         kv_cache,
-                         {graph_params.value()});
+    graph_.capture_begin(
+        {0, 0}, aclmdlRICaptureMode::ACL_MODEL_RI_CAPTURE_MODE_THREAD_LOCAL);
+    // Execute forward pass - NPUGraph mempool manages temporary tensors
+    auto forward_result =
+        model->forward({persistent_param_.persistent_tokens(num_tokens_)},
+                       {persistent_param_.persistent_positions(num_tokens_)},
+                       kv_cache,
+                       {graph_params.value()});
 
-      // Store result in persistent buffer owned by NPUGraph mempool
-      persistent_param_.set_hidden_states(forward_result.hidden_states);
-      if (options.enable_graph_aux_hidden_states() &&
-          forward_result.aux_hidden_states.defined()) {
-        persistent_param_.set_aux_hidden_states(
-            forward_result.aux_hidden_states);
-      }
-      graph_.capture_end();
-      capture_started = false;
-    } catch (...) {
-      if (capture_started) {
-        try {
-          graph_.capture_end();
-        } catch (const std::exception& cleanup_error) {
-          LOG(ERROR) << "ACL graph capture_end during cleanup failed: "
-                     << cleanup_error.what();
-        } catch (...) {
-          LOG(ERROR) << "ACL graph capture_end during cleanup failed.";
-        }
-        graph_.reset();
-      }
-      if (need_restore_stream) {
-        c10_npu::setCurrentNPUStream(
-            c10_npu::getDefaultNPUStream(tensor_options.device().index()));
-      }
-      throw;
+    // Store result in persistent buffer owned by NPUGraph mempool
+    persistent_param_.set_hidden_states(forward_result.hidden_states);
+    if (options.enable_graph_aux_hidden_states() &&
+        forward_result.aux_hidden_states.defined()) {
+      persistent_param_.set_aux_hidden_states(forward_result.aux_hidden_states);
     }
+    graph_.capture_end();
     if (graph_task_context_ != nullptr) {
       graph_task_context_->end_capture();
     }
@@ -1046,68 +1023,50 @@ ModelOutput AclGraphExecutorImpl::run(const torch::Tensor& tokens,
       std::make_shared<AclGraph>(active_persistent_param, device_.index());
   VLOG(kGraphExecutorLogVerboseLevel)
       << "AclGraphExecutorImpl::run() in capture mode";
-  bool capture_success = false;
-  try {
-    capture_success = graph->capture(model_,
-                                     options_,
-                                     tokens_tensor,
-                                     positions_tensor,
-                                     params_single,
-                                     kv_caches,
-                                     bucket_num_tokens);
-  } catch (const std::exception& e) {
-    LOG(ERROR) << "ACL graph capture threw exception for bucket num_tokens="
-               << bucket_num_tokens << ": " << e.what();
-    if (model_->supports_mla_graph_kv_bucketing()) {
-      throw;
+  const bool capture_success = graph->capture(model_,
+                                              options_,
+                                              tokens_tensor,
+                                              positions_tensor,
+                                              params_single,
+                                              kv_caches,
+                                              bucket_num_tokens);
+
+  CHECK(capture_success)
+      << "Failed to capture ACL graph for bucket num_tokens: "
+      << bucket_num_tokens;
+  LOG(INFO) << "Lazy capturing ACL graph for bucket num_tokens: "
+            << bucket_num_tokens << " (actual num_tokens: " << n_tokens
+            << ") done";
+
+  const bool static_mtp_variant = uses_static_mtp_graph_task_variant(
+      params_single, bucket_num_tokens, options_.block_size());
+  {
+    std::lock_guard<std::mutex> lock(graph_slots_mutex_);
+    if (static_mtp_variant) {
+      while (active_slot.static_mtp_graph_keys.size() >=
+             kMaxStaticMtpGraphVariantsPerSlot) {
+        const uint64_t evicted_key = active_slot.static_mtp_graph_keys.front();
+        active_slot.static_mtp_graph_keys.pop_front();
+        active_slot.graphs.erase(evicted_key);
+      }
+      active_slot.static_mtp_graph_keys.push_back(graph_key);
     }
-    LOG(ERROR) << "Falling back to eager mode.";
-    COUNTER_INC(num_model_execution_total_eager);
-    return forward_eager(model_, tokens, positions, kv_caches, params);
+    // shared_ptr keeps a replay/prepare that already left the map alive if a
+    // later capture evicts this static variant.
+    active_slot.graphs[graph_key] = graph;
   }
 
-  if (capture_success) {
-    LOG(INFO) << "Lazy capturing ACL graph for bucket num_tokens: "
-              << bucket_num_tokens << " (actual num_tokens: " << n_tokens
-              << ") done";
-
-    const bool static_mtp_variant = uses_static_mtp_graph_task_variant(
-        params_single, bucket_num_tokens, options_.block_size());
-    {
-      std::lock_guard<std::mutex> lock(graph_slots_mutex_);
-      if (static_mtp_variant) {
-        while (active_slot.static_mtp_graph_keys.size() >=
-               kMaxStaticMtpGraphVariantsPerSlot) {
-          const uint64_t evicted_key =
-              active_slot.static_mtp_graph_keys.front();
-          active_slot.static_mtp_graph_keys.pop_front();
-          active_slot.graphs.erase(evicted_key);
-        }
-        active_slot.static_mtp_graph_keys.push_back(graph_key);
-      }
-      // shared_ptr keeps a replay/prepare that already left the map alive if a
-      // later capture evicts this static variant.
-      active_slot.graphs[graph_key] = graph;
+  // Return the output from capture (no need to replay since capture
+  // already executed)
+  torch::Tensor hidden_states = graph->get_hidden_states(n_tokens);
+  if (options_.enable_graph_aux_hidden_states()) {
+    torch::Tensor aux_hidden_states =
+        active_persistent_param.aux_hidden_states(n_tokens);
+    if (aux_hidden_states.defined() && aux_hidden_states.numel() > 0) {
+      return ModelOutput(hidden_states, torch::Tensor(), aux_hidden_states);
     }
-
-    // Return the output from capture (no need to replay since capture
-    // already executed)
-    torch::Tensor hidden_states = graph->get_hidden_states(n_tokens);
-    if (options_.enable_graph_aux_hidden_states()) {
-      torch::Tensor aux_hidden_states =
-          active_persistent_param.aux_hidden_states(n_tokens);
-      if (aux_hidden_states.defined() && aux_hidden_states.numel() > 0) {
-        return ModelOutput(hidden_states, torch::Tensor(), aux_hidden_states);
-      }
-    }
-    return ModelOutput(hidden_states);
   }
-
-  // Fallback to eager mode if capture fails
-  LOG(ERROR) << "Failed to capture ACL graph for bucket num_tokens: "
-             << bucket_num_tokens;
-  COUNTER_INC(num_model_execution_total_eager);
-  return forward_eager(model_, tokens, positions, kv_caches, params);
+  return ModelOutput(hidden_states);
 }
 
 void AclGraphExecutorImpl::prepare_graph_input(const torch::Tensor& tokens,

--- a/xllm/python/model_executor/runners/decode_acl_graph.py
+++ b/xllm/python/model_executor/runners/decode_acl_graph.py
@@ -244,23 +244,20 @@ class DecodeAclGraphRunner(BaseRunner):
         metadata: AttentionMetadata,
     ) -> bool:
         """Check the one-token-per-sequence contract of ACL decode graphs."""
-        try:
-            (
-                block_table,
-                _,
-                _,
-                _,
-                _,
-                _,
-            ) = self._decode_metadata(metadata)
-            self._validate_decode_token_layout(
-                input_ids,
-                None,
-                metadata.slot_mapping,
-                block_table.shape[0],
-            )
-        except (RuntimeError, ValueError):
-            return False
+        (
+            block_table,
+            _,
+            _,
+            _,
+            _,
+            _,
+        ) = self._decode_metadata(metadata)
+        self._validate_decode_token_layout(
+            input_ids,
+            None,
+            metadata.slot_mapping,
+            block_table.shape[0],
+        )
         batch_size = input_ids.numel()
         is_expanded = resolve_expanded_decode_metadata(metadata) is not None
         if not is_expanded and metadata.kv_cu_seq_lens is not None:
@@ -697,10 +694,6 @@ class DecodeAclGraphRunner(BaseRunner):
     ) -> None:
         for task in graph_tasks:
             torch.npu.graph_task_update_begin(stream, task.handle)
-            try:
-                task.update()
-            except Exception:
-                torch.npu.graph_task_update_end(stream)
-                raise
+            task.update()
             torch.npu.graph_task_update_end(stream)
             task.event.record(stream)


### PR DESCRIPTION
- 移除 ACL Graph 捕获失败后的清理重试，让捕获异常直接向上传播。
- 不再将捕获失败和元数据错误转换为 eager 执行。
- 在代码规范中补充在线服务执行路径的 let-it-crash 和 fallback 使用原则。

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

本 PR 重构 ACL Graph 捕获失败时的处理方式：删除 C++ executor 中捕获异常后的二次 `capture_end()` 和 eager fallback，并删除 Python decode ACL Graph 路径中吞掉元数据及 graph task 更新异常的逻辑。

在线服务出现未预期异常后，runtime 或 graph 状态可能已经被污染，继续复用该状态执行 eager 请求无法保证正确性。因此，本 PR 让这类错误直接失败，并在 xLLM 代码规范中明确：在线执行路径不要随意引入 `try/catch` 或 fallback；预期的不支持状态应在执行和状态变更前通过显式能力检查完成路由。

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactor
- [x] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->

在 NPU 3、5 上使用 DeepSeek-V3.2 W8A8 5-layer target 模型和 DeepSeek-V3.2 W8A8 MTP draft 模型，按 TP=2、schedule overlap 开启和 ACL Graph 开启的配置完成了端到端验证。测试脚本为 `xllm_scripts/deepseek-v3.2-w8a8-5layer-tp2.sh`，核心配置如下：

```bash
MODEL_PATH="/path/to/DeepSeek-V3.2-w8a8-5layer"
DRAFT_MODEL_PATH="/path/to/DeepSeek-V3.2-w8a8-MTP"

export ASCEND_RT_VISIBLE_DEVICES="3,5"
export HCCL_OP_EXPANSION_MODE="AIV"

# 每个 TP rank 的启动参数包含：
--model "$MODEL_PATH" \
--draft_model "$DRAFT_MODEL_PATH" \
--speculative_algorithm=MTP \
--num_speculative_tokens=1 \
--nnodes=2 \
--enable_schedule_overlap=true \
--enable_graph=true \
--enable_graph_mode_decode_no_padding=true
```

`--speculative_algorithm=MTP` 显式选择 MTP 投机解码算法，`--draft_model` 指定 MTP draft 模型，`--num_speculative_tokens=1` 指定每步生成 1 个 draft token。日志中的 `Speculative decode is enabled, algorithm: MTP` 用于确认服务没有忽略这些启动参数。

启动完整测试脚本：

```bash
NPU_DEVICES=3,5 \
  ./xllm_scripts/deepseek-v3.2-w8a8-5layer-tp2.sh
```

服务启动后使用以下请求验证健康状态、模型列表和文本生成：

```bash
curl --fail --max-time 10 \
  http://127.0.0.1:17983/health

curl --fail --max-time 10 \
  http://127.0.0.1:17983/v1/models

curl --fail --max-time 120 \
  http://127.0.0.1:17983/v1/completions \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "DeepSeek-V3.2-w8a8-5layer",
    "prompt": "The capital of France is",
    "max_tokens": 64,
    "temperature": 0,
    "top_p": 1
  }'
```

日志核验命令：

```bash
rg 'Speculative decode is enabled|deepseek_v32_mtp|mtp_layer_parameters|Graph warmup progress|Lazy capturing ACL graph|107025|107029' \
  ./xllm/log/node_{0,1}.log
```

验证结果：

- 两个 rank 均记录 `Speculative decode is enabled, algorithm: MTP`，并实际加载 `deepseek_v32_mtp` 和 `mtp_layer_parameters.safetensors`；
- MTP 每个序列携带 2 个验证 token，因此逻辑 batch bucket 16、8、4、2、1 分别捕获为 token bucket 32、16、8、4、2，全部捕获成功；
- `/health`、`/v1/models` 和 `/v1/completions` 均返回 HTTP 200，completion 实际生成 64 tokens，请求完成后服务保持健康；
- 两个 rank 的日志中均未出现 `ACL_ERROR_RT_STREAM_UNJOINED (107025)` 或二次 `capture_end()` 导致的 `107029`。
