### PR TITLE
perf: token-level multimodal mm token expansion.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,8 @@ repos:
     args: [
       --toml, pyproject.toml,
       '--skip', 'build/**,third_party/**,*.svg,*.ptx.h',
-      '-L', 'CANN,cann,NNAL,nnal,ASCEND,ascend,tbe,copyin,nd,ND,bilt'
+      '-L', 'CANN,cann,NNAL,nnal,ASCEND,ascend,tbe,copyin,nd,ND,bilt',
+      '-L', 'MultiDimension'
     ]
     additional_dependencies:
       - tomli

--- a/xllm/core/common/metrics.cpp
+++ b/xllm/core/common/metrics.cpp
@@ -41,6 +41,8 @@ DEFINE_COUNTER(request_handling_latency_seconds_completion,
 
 DEFINE_COUNTER(tokenization_latency_seconds,
                "Prompt tokenization latency in seconds");
+DEFINE_COUNTER(mm_prompt_expansion_latency_seconds,
+               "Multimodal prompt token expansion latency in seconds");
 DEFINE_COUNTER(chat_template_latency_seconds,
                "Chat template latency in seconds");
 

--- a/xllm/core/common/metrics.h
+++ b/xllm/core/common/metrics.h
@@ -141,6 +141,7 @@ DECLARE_COUNTER(request_status_total_unimplemented);
 DECLARE_COUNTER(request_handling_latency_seconds_chat);
 DECLARE_COUNTER(request_handling_latency_seconds_completion);
 DECLARE_COUNTER(tokenization_latency_seconds);
+DECLARE_COUNTER(mm_prompt_expansion_latency_seconds);
 DECLARE_COUNTER(chat_template_latency_seconds);
 
 // latency of prefix cache operations in seconds

--- a/xllm/processors/glm4v_prompt_processor.cpp
+++ b/xllm/processors/glm4v_prompt_processor.cpp
@@ -15,10 +15,35 @@ limitations under the License.
 
 #include "processors/glm4v_prompt_processor.h"
 
+#include <glog/logging.h>
+
 #include <cstdint>
 #include <cstdio>
 
+#include "core/framework/tokenizer/tokenizer.h"
+
 namespace xllm {
+namespace {
+
+void append_encoded_tokens(const Tokenizer* tokenizer,
+                           std::vector<int32_t>& token_ids,
+                           const std::string& text) {
+  CHECK(tokenizer != nullptr) << "video expansion requires tokenizer";
+  std::vector<int32_t> encoded;
+  CHECK(tokenizer->encode(text, &encoded));
+  token_ids.insert(token_ids.end(), encoded.begin(), encoded.end());
+}
+
+int32_t resolve_video_placeholder_id(const Tokenizer* tokenizer,
+                                     const std::string& video_token) {
+  std::vector<int32_t> encoded;
+  CHECK(tokenizer->encode(video_token, &encoded));
+  CHECK_EQ(encoded.size(), 1U)
+      << "video placeholder must tokenize to a single id";
+  return encoded[0];
+}
+
+}  // namespace
 
 GLM4VPromptProcessor::GLM4VPromptProcessor(const ModelArgs& args) {
   merge_size_ = args.mm_image_merge_size();
@@ -29,7 +54,17 @@ GLM4VPromptProcessor::GLM4VPromptProcessor(const ModelArgs& args) {
   image_token_id_ = args.image_token_id();
 }
 
-void GLM4VPromptProcessor::process(std::string& prompt, const MMData& mm_data) {
+void GLM4VPromptProcessor::process(std::string& /*prompt*/,
+                                   const MMData& mm_data) {
+  // Token-level expansion is handled in expand_mm_tokens().
+  DLOG_IF(WARNING, !mm_data.empty())
+      << "GLM4VPromptProcessor::process is unused when token-level "
+         "expansion is enabled";
+}
+
+void GLM4VPromptProcessor::expand_mm_tokens(std::vector<int32_t>& token_ids,
+                                            MMData& mm_data,
+                                            const Tokenizer* tokenizer) {
   torch::Tensor image_grid_thw;
   if (auto res = mm_data.get<torch::Tensor>("image_grid_thw")) {
     image_grid_thw = res.value();
@@ -52,76 +87,63 @@ void GLM4VPromptProcessor::process(std::string& prompt, const MMData& mm_data) {
   }
 
   const int32_t merge_length = merge_size_ * merge_size_;
-  int32_t total_image_token = 0;
-  if (image_grid_thw.defined()) {
-    const int64_t count = image_grid_thw.sizes()[0];
-    for (int64_t idx = 0; idx < count; ++idx) {
-      total_image_token +=
-          image_grid_thw[idx].prod().item<int32_t>() / merge_length;
-    }
-  }
-
-  int32_t total_video_token = 0;
+  int32_t video_placeholder_id = 0;
   if (video_grid_thw.defined()) {
-    const int64_t count = video_grid_thw.sizes()[0];
-    for (int64_t idx = 0; idx < count; ++idx) {
-      total_video_token += video_grid_thw[idx].prod().item<int32_t>() /
-                           merge_length /
-                           video_grid_thw[idx][0].item<int32_t>();
-    }
+    CHECK(tokenizer != nullptr);
+    video_placeholder_id =
+        resolve_video_placeholder_id(tokenizer, video_token_);
   }
 
-  size_t total_token_len = total_image_token * image_token_.size() +
-                           total_video_token * image_token_.size();
-  std::string data;
-  data.reserve(prompt.size() + total_token_len);
+  std::vector<int32_t> expanded;
+  expanded.reserve(token_ids.size());
 
   int32_t image_index = 0;
   int32_t video_index = 0;
-  size_t begin = 0;
-  auto pair = find_vision_token(prompt, begin);
 
-  while (pair.second != std::string::npos) {
-    data.append(prompt, begin, pair.second - begin);
-    if (pair.first == TokenType::IMAGE) {
-      auto token_num =
+  for (size_t index = 0; index < token_ids.size(); ++index) {
+    if (token_ids[index] == image_start_token_id_ &&
+        index + 2 < token_ids.size() &&
+        token_ids[index + 2] == image_end_token_id_ &&
+        token_ids[index + 1] == image_token_id_ && image_grid_thw.defined() &&
+        image_index < image_grid_thw.size(0)) {
+      const int32_t token_num =
           image_grid_thw[image_index].prod().item<int32_t>() / merge_length;
-      while (token_num--) {
-        data.append(image_token_);
-      }
-
+      expanded.push_back(image_start_token_id_);
+      expanded.insert(
+          expanded.end(), static_cast<size_t>(token_num), image_token_id_);
+      expanded.push_back(image_end_token_id_);
       ++image_index;
-      begin = pair.second + image_token_.size();
-    } else if (pair.first == TokenType::VIDEO) {
-      auto num_frames = video_grid_thw[video_index][0].item<int32_t>();
-      auto timestamps = video_metadata[video_index].timestamps;
+      index += 2;
+      continue;
+    }
+
+    if (video_grid_thw.defined() && video_index < video_grid_thw.size(0) &&
+        token_ids[index] == video_placeholder_id) {
+      const int32_t num_frames = video_grid_thw[video_index][0].item<int32_t>();
+      const auto& timestamps = video_metadata[video_index].timestamps;
       CHECK(!timestamps.empty());
 
-      auto selected = build_timestamps(timestamps, num_frames);
-      auto token_num = video_grid_thw[video_index].prod().item<int32_t>() /
-                       merge_length / num_frames;
+      const auto selected =
+          build_timestamps(timestamps, static_cast<size_t>(num_frames));
+      const int32_t token_num =
+          video_grid_thw[video_index].prod().item<int32_t>() / merge_length /
+          num_frames;
       for (int32_t idx = 0; idx < num_frames; ++idx) {
-        data.append(begin_of_image_token_);
-        auto num = token_num;
-        while (num--) {
-          data.append(image_token_);
-        }
-        data.append(end_of_image_token_);
-        data.append(format_timestamp_str(selected[idx]));
+        expanded.push_back(image_start_token_id_);
+        expanded.insert(
+            expanded.end(), static_cast<size_t>(token_num), image_token_id_);
+        expanded.push_back(image_end_token_id_);
+        append_encoded_tokens(
+            tokenizer, expanded, format_timestamp_str(selected[idx]));
       }
-
       ++video_index;
-      begin = pair.second + video_token_.size();
-    } else {
-      LOG(FATAL) << "Unexpected token type encountered.";
+      continue;
     }
-    pair = find_vision_token(prompt, begin);
+
+    expanded.push_back(token_ids[index]);
   }
 
-  if (begin < prompt.size()) {
-    data.append(prompt, begin, std::string::npos);
-  }
-  prompt = std::move(data);
+  token_ids = std::move(expanded);
 }
 
 void GLM4VPromptProcessor::find_mm_spans(const std::vector<int32_t>& token_ids,
@@ -139,7 +161,7 @@ void GLM4VPromptProcessor::find_mm_spans(const std::vector<int32_t>& token_ids,
     auto token = token_ids[idx];
     if (token == video_start_token_id_) {
       is_video = true;
-      video_offset = idx + 1;
+      video_offset = static_cast<int32_t>(idx) + 1;
       video_mask.clear();
       continue;
     } else if (token == video_end_token_id_) {
@@ -165,7 +187,7 @@ void GLM4VPromptProcessor::find_mm_spans(const std::vector<int32_t>& token_ids,
       continue;
     }
     if (token == image_start_token_id_) {
-      image_span_offset = idx + 1;
+      image_span_offset = static_cast<int32_t>(idx) + 1;
     }
     if (token == image_token_id_) {
       ++image_span_length;

--- a/xllm/processors/glm4v_prompt_processor.h
+++ b/xllm/processors/glm4v_prompt_processor.h
@@ -38,6 +38,12 @@ class GLM4VPromptProcessor final : public PromptProcessor {
   void process(std::string& prompt, const MMData& mm_data) override;
   void find_mm_spans(const std::vector<int32_t>& token_ids,
                      MMData& mm_data) override;
+  bool uses_token_level_expansion() const override {
+    return !force_legacy_mm_expansion();
+  }
+  void expand_mm_tokens(std::vector<int32_t>& token_ids,
+                        MMData& mm_data,
+                        const Tokenizer* tokenizer = nullptr) override;
 
  private:
   std::pair<TokenType, size_t> find_vision_token(const std::string& prompt,

--- a/xllm/processors/multimodal_processor.cpp
+++ b/xllm/processors/multimodal_processor.cpp
@@ -47,6 +47,16 @@ bool MultimodalProcessorBase::tokenize(const std::string& prompt,
   return true;
 }
 
+void MultimodalProcessorBase::run_mm_token_expansion(
+    PromptProcessor* prompt_processor,
+    std::vector<int32_t>& token_ids,
+    MMData& mm_data) {
+  Timer timer;
+  prompt_processor->expand_mm_tokens(token_ids, mm_data, tokenizer_.get());
+  COUNTER_ADD(mm_prompt_expansion_latency_seconds, timer.elapsed_seconds());
+  prompt_processor->find_mm_spans(token_ids, mm_data);
+}
+
 void MultimodalProcessorBase::assign_mm_hash_keys(const MMInput& mm_input,
                                                   MMData& mm_data) const {
   const std::vector<MMInputItem>& input_items = mm_input.items();

--- a/xllm/processors/multimodal_processor.h
+++ b/xllm/processors/multimodal_processor.h
@@ -59,6 +59,10 @@ class MultimodalProcessorBase {
   bool tokenize(const std::string& prompt,
                 std::vector<int32_t>& token_ids) const;
 
+  void run_mm_token_expansion(PromptProcessor* prompt_processor,
+                              std::vector<int32_t>& token_ids,
+                              MMData& mm_data);
+
   void assign_mm_hash_keys(const MMInput& mm_input, MMData& mm_data) const;
 
   void pad_to_max_length(std::vector<int32_t>& token_ids) const;
@@ -94,6 +98,14 @@ class MultimodalProcessor final : public MultimodalProcessorBase {
   bool process_prompt(std::string& prompt,
                       MMData& mm_data,
                       std::vector<int32_t>& token_ids) override {
+    if (prompt_processor_->uses_token_level_expansion()) {
+      if (!tokenize(prompt, token_ids)) {
+        return false;
+      }
+      run_mm_token_expansion(prompt_processor_.get(), token_ids, mm_data);
+      return true;
+    }
+
     prompt_processor_->process(prompt, mm_data);
     if (!tokenize(prompt, token_ids)) {
       return false;

--- a/xllm/processors/prompt_processor.h
+++ b/xllm/processors/prompt_processor.h
@@ -18,6 +18,7 @@ limitations under the License.
 #include <torch/torch.h>
 
 #include <cstdint>
+#include <cstdlib>
 #include <string>
 #include <vector>
 
@@ -27,6 +28,13 @@ limitations under the License.
 
 namespace xllm {
 
+class Tokenizer;
+
+inline bool force_legacy_mm_expansion() {
+  const char* env = std::getenv("XLLM_FORCE_LEGACY_MM_EXPANSION");
+  return env != nullptr && env[0] != '\0' && env[0] != '0';
+}
+
 class PromptProcessor {
  public:
   virtual ~PromptProcessor() = default;
@@ -34,6 +42,14 @@ class PromptProcessor {
   virtual void process(std::string& prompt, const MMData& mm_data) = 0;
   virtual void find_mm_spans(const std::vector<int32_t>& token_ids,
                              MMData& mm_data) = 0;
+
+  // Token-level expansion tokenizes the unexpanded prompt, then inserts N
+  // identical placeholder ids. Processors that return true implement
+  // expand_mm_tokens() and leave process() as a no-op.
+  virtual bool uses_token_level_expansion() const { return false; }
+  virtual void expand_mm_tokens(std::vector<int32_t>& token_ids,
+                                MMData& mm_data,
+                                const Tokenizer* tokenizer = nullptr) {}
 };
 
 }  // namespace xllm

--- a/xllm/processors/qwen2_vl_prompt_processor.cpp
+++ b/xllm/processors/qwen2_vl_prompt_processor.cpp
@@ -15,11 +15,31 @@ limitations under the License.
 
 #include "processors/qwen2_vl_prompt_processor.h"
 
+#include <glog/logging.h>
+
 #include <algorithm>
-#include <cassert>
 #include <cstdint>
+#include <vector>
+
+#include "core/framework/tokenizer/tokenizer.h"
 
 namespace xllm {
+namespace {
+
+int32_t count_mm_tokens(const torch::Tensor& grid_thw, int32_t merge_length) {
+  if (!grid_thw.defined()) {
+    return 0;
+  }
+
+  int32_t total = 0;
+  const int64_t count = grid_thw.sizes()[0];
+  for (int64_t idx = 0; idx < count; ++idx) {
+    total += grid_thw[idx].prod().item<int32_t>() / merge_length;
+  }
+  return total;
+}
+
+}  // namespace
 
 Qwen2VLPromptProcessor::Qwen2VLPromptProcessor(const ModelArgs& args) {
   merge_size_ = args.mm_image_merge_size();
@@ -29,8 +49,17 @@ Qwen2VLPromptProcessor::Qwen2VLPromptProcessor(const ModelArgs& args) {
   video_token_id_ = args.video_token_id();
 }
 
-void Qwen2VLPromptProcessor::process(std::string& prompt,
+void Qwen2VLPromptProcessor::process(std::string& /*prompt*/,
                                      const MMData& mm_data) {
+  // Token-level expansion is handled in expand_mm_tokens().
+  DLOG_IF(WARNING, !mm_data.empty())
+      << "Qwen2VLPromptProcessor::process is unused when token-level "
+         "expansion is enabled";
+}
+
+void Qwen2VLPromptProcessor::expand_mm_tokens(std::vector<int32_t>& token_ids,
+                                              MMData& mm_data,
+                                              const Tokenizer* /*tokenizer*/) {
   torch::Tensor image_grid_thw;
   if (auto res = mm_data.get<torch::Tensor>("image_grid_thw")) {
     image_grid_thw = res.value();
@@ -46,66 +75,67 @@ void Qwen2VLPromptProcessor::process(std::string& prompt,
   }
 
   const int32_t merge_length = merge_size_ * merge_size_;
-  int32_t total_image_token = 0;
+  const int32_t expanded_mm_tokens =
+      count_mm_tokens(image_grid_thw, merge_length) +
+      count_mm_tokens(video_grid_thw, merge_length);
+  int32_t placeholder_count = 0;
   if (image_grid_thw.defined()) {
-    const int64_t count = image_grid_thw.sizes()[0];
-    for (int64_t idx = 0; idx < count; ++idx) {
-      total_image_token +=
-          image_grid_thw[idx].prod().item<int32_t>() / merge_length;
-    }
+    placeholder_count += static_cast<int32_t>(image_grid_thw.sizes()[0]);
   }
-
-  int32_t total_video_token = 0;
   if (video_grid_thw.defined()) {
-    const int64_t count = video_grid_thw.sizes()[0];
-    for (int64_t idx = 0; idx < count; ++idx) {
-      total_video_token +=
-          video_grid_thw[idx].prod().item<int32_t>() / merge_length;
-    }
+    placeholder_count += static_cast<int32_t>(video_grid_thw.sizes()[0]);
   }
 
-  size_t total_token_len = total_image_token * image_token_.size() +
-                           total_video_token * video_token_.size();
-  std::string data;
-  data.reserve(prompt.size() + total_token_len);
+  std::vector<int32_t> expanded;
+  const int32_t extra_tokens =
+      std::max(expanded_mm_tokens - placeholder_count, 0);
+  expanded.reserve(token_ids.size() + static_cast<size_t>(extra_tokens));
 
   int32_t image_index = 0;
   int32_t video_index = 0;
-  const torch::Tensor* grid_thw = nullptr;
-  const std::string* token = nullptr;
-  int32_t* index = nullptr;
 
-  size_t begin = 0;
-  auto pair = find_vision_token(prompt, begin);
-  while (pair.second != std::string::npos) {
-    data.append(prompt, begin, pair.second - begin);
-    if (pair.first == TokenType::IMAGE) {
+  for (size_t index = 0; index < token_ids.size(); ++index) {
+    if (token_ids[index] != vision_start_token_id_) {
+      expanded.push_back(token_ids[index]);
+      continue;
+    }
+
+    CHECK_LT(index + 2, token_ids.size())
+        << "vision_start without matching placeholder and vision_end";
+    CHECK_EQ(token_ids[index + 2], vision_end_token_id_)
+        << "vision_start must be followed by one placeholder and vision_end";
+
+    const int32_t placeholder_token_id = token_ids[index + 1];
+    const torch::Tensor* grid_thw = nullptr;
+    int32_t* modality_index = nullptr;
+    if (placeholder_token_id == image_token_id_) {
+      CHECK(image_grid_thw.defined());
       grid_thw = &image_grid_thw;
-      token = &image_token_;
-      index = &image_index;
-    } else if (pair.first == TokenType::VIDEO) {
+      modality_index = &image_index;
+    } else if (placeholder_token_id == video_token_id_) {
+      CHECK(video_grid_thw.defined());
       grid_thw = &video_grid_thw;
-      token = &video_token_;
-      index = &video_index;
+      modality_index = &video_index;
     } else {
-      LOG(FATAL) << "Unexpected token type encountered.";
+      LOG(FATAL) << "Unexpected placeholder token id between vision bounds: "
+                 << placeholder_token_id;
     }
 
-    auto token_num =
-        (*grid_thw)[(*index)].prod().item<int32_t>() / merge_length;
-    while (token_num--) {
-      data.append(*token);
-    }
+    CHECK_LT(*modality_index, grid_thw->sizes()[0]);
+    const int32_t token_num =
+        (*grid_thw)[(*modality_index)].prod().item<int32_t>() / merge_length;
+    CHECK_GT(token_num, 0) << "mm placeholder must expand to a positive span";
 
-    ++(*index);
-    begin = pair.second + token->size();
-    pair = find_vision_token(prompt, begin);
+    expanded.push_back(vision_start_token_id_);
+    expanded.insert(
+        expanded.end(), static_cast<size_t>(token_num), placeholder_token_id);
+    expanded.push_back(vision_end_token_id_);
+
+    ++(*modality_index);
+    index += 2;
   }
 
-  if (begin < prompt.size()) {
-    data.append(prompt, begin, std::string::npos);
-  }
-  prompt = std::move(data);
+  token_ids = std::move(expanded);
 }
 
 void Qwen2VLPromptProcessor::find_mm_spans(
@@ -124,14 +154,16 @@ void Qwen2VLPromptProcessor::find_mm_spans(
     if (vision_start_it == token_ids.end()) {
       break;
     }
-    offset = std::distance(token_ids.begin(), vision_start_it);
-    length = std::distance(vision_start_it + 1, vision_end_it);
+    offset =
+        static_cast<int32_t>(std::distance(token_ids.begin(), vision_start_it));
+    length =
+        static_cast<int32_t>(std::distance(vision_start_it + 1, vision_end_it));
 
     auto& item = mm_items[global_mm_index];
-    auto next_token_id = *(vision_start_it + 1);
+    const int32_t next_token_id = *(vision_start_it + 1);
     if (next_token_id == image_token_id_ || next_token_id == video_token_id_) {
       item.mutable_state().mutable_token_pos() = {offset + 1, length};
-      auto mask = torch::ones(
+      const torch::Tensor mask = torch::ones(
           {length},
           torch::TensorOptions().dtype(torch::kBool).device(torch::kCPU));
       item.mutable_state().mutable_mm_token_mask() = mask;
@@ -139,24 +171,6 @@ void Qwen2VLPromptProcessor::find_mm_spans(
     }
     ++global_mm_index;
     start = std::next(vision_end_it);
-  }
-}
-
-std::pair<Qwen2VLPromptProcessor::TokenType, size_t>
-Qwen2VLPromptProcessor::find_vision_token(const std::string& prompt,
-                                          size_t begin) {
-  auto img_pos = prompt.find(image_token_, begin);
-  auto vid_pos = prompt.find(video_token_, begin);
-
-  if (img_pos == std::string::npos && vid_pos == std::string::npos) {
-    return {TokenType::INVALID, std::string::npos};
-  } else if (vid_pos == std::string::npos) {
-    return {TokenType::IMAGE, img_pos};
-  } else if (img_pos == std::string::npos) {
-    return {TokenType::VIDEO, vid_pos};
-  } else {
-    return img_pos < vid_pos ? std::make_pair(TokenType::IMAGE, img_pos)
-                             : std::make_pair(TokenType::VIDEO, vid_pos);
   }
 }
 

--- a/xllm/processors/qwen2_vl_prompt_processor.h
+++ b/xllm/processors/qwen2_vl_prompt_processor.h
@@ -17,7 +17,7 @@ limitations under the License.
 
 #include <cstdint>
 #include <string>
-#include <utility>
+#include <vector>
 
 #include "core/framework/model/model_args.h"
 #include "processors/prompt_processor.h"
@@ -25,25 +25,20 @@ limitations under the License.
 namespace xllm {
 
 class Qwen2VLPromptProcessor final : public PromptProcessor {
-  enum class TokenType {
-    INVALID,
-    IMAGE,
-    VIDEO,
-  };
-
  public:
   explicit Qwen2VLPromptProcessor(const ModelArgs& args);
 
   void process(std::string& prompt, const MMData& mm_data) override;
   void find_mm_spans(const std::vector<int32_t>& token_ids,
                      MMData& mm_data) override;
+  bool uses_token_level_expansion() const override {
+    return !force_legacy_mm_expansion();
+  }
+  void expand_mm_tokens(std::vector<int32_t>& token_ids,
+                        MMData& mm_data,
+                        const Tokenizer* tokenizer = nullptr) override;
 
  private:
-  std::pair<TokenType, size_t> find_vision_token(const std::string& prompt,
-                                                 size_t begin);
-
-  const std::string image_token_ = "<|image_pad|>";
-  const std::string video_token_ = "<|video_pad|>";
   int32_t vision_start_token_id_;
   int32_t vision_end_token_id_;
   int32_t image_token_id_;

--- a/xllm/processors/qwen3_vl_prompt_processor.cpp
+++ b/xllm/processors/qwen3_vl_prompt_processor.cpp
@@ -15,13 +15,76 @@ limitations under the License.
 
 #include "processors/qwen3_vl_prompt_processor.h"
 
+#include <glog/logging.h>
 #include <torch/torch.h>
 
 #include <algorithm>
 #include <cassert>
 #include <cstdio>
 
+#include "core/framework/tokenizer/tokenizer.h"
+
 namespace xllm {
+namespace {
+
+void append_encoded_tokens(const Tokenizer* tokenizer,
+                           std::vector<int32_t>& token_ids,
+                           const std::string& text) {
+  CHECK(tokenizer != nullptr) << "timestamp expansion requires tokenizer";
+  std::vector<int32_t> encoded;
+  CHECK(tokenizer->encode(text, &encoded));
+  token_ids.insert(token_ids.end(), encoded.begin(), encoded.end());
+}
+
+void append_video_frames(std::vector<int32_t>& expanded,
+                         const torch::Tensor& video_grid_thw,
+                         int32_t video_index,
+                         const std::vector<VideoMetadata>& video_metadata,
+                         int32_t merge_length,
+                         int32_t temporal_patch_size,
+                         int32_t vision_start_token_id,
+                         int32_t vision_end_token_id,
+                         int32_t video_token_id,
+                         const Tokenizer* tokenizer) {
+  const int32_t num_frames = video_grid_thw[video_index][0].item<int32_t>();
+  const int32_t token_num = video_grid_thw[video_index][1].item<int32_t>() *
+                            video_grid_thw[video_index][2].item<int32_t>() /
+                            merge_length;
+  const auto& timestamps = video_metadata[video_index].timestamps;
+  CHECK(!timestamps.empty());
+
+  std::vector<double> ts = timestamps;
+  const size_t rem = ts.size() % static_cast<size_t>(temporal_patch_size);
+  if (rem != 0) {
+    ts.insert(
+        ts.end(), static_cast<size_t>(temporal_patch_size) - rem, ts.back());
+  }
+  std::vector<double> selected;
+  selected.reserve(ts.size() / static_cast<size_t>(temporal_patch_size));
+  for (size_t i = 0; i < ts.size();
+       i += static_cast<size_t>(temporal_patch_size)) {
+    selected.push_back(
+        (ts[i] + ts[i + static_cast<size_t>(temporal_patch_size) - 1]) / 2.0);
+  }
+  if (selected.size() > static_cast<size_t>(num_frames)) {
+    selected.resize(static_cast<size_t>(num_frames));
+  }
+  while (selected.size() < static_cast<size_t>(num_frames)) {
+    selected.push_back(selected.back());
+  }
+
+  for (int32_t idx = 0; idx < num_frames; ++idx) {
+    char buffer[32];
+    snprintf(buffer, sizeof(buffer), "<%.1f seconds>", selected[idx]);
+    append_encoded_tokens(tokenizer, expanded, buffer);
+    expanded.push_back(vision_start_token_id);
+    expanded.insert(
+        expanded.end(), static_cast<size_t>(token_num), video_token_id);
+    expanded.push_back(vision_end_token_id);
+  }
+}
+
+}  // namespace
 
 Qwen3VLPromptProcessor::Qwen3VLPromptProcessor(const ModelArgs& args) {
   merge_size_ = args.mm_image_merge_size();
@@ -32,17 +95,30 @@ Qwen3VLPromptProcessor::Qwen3VLPromptProcessor(const ModelArgs& args) {
   temporal_patch_size_ = args.mm_temporal_patch_size();
 }
 
-void Qwen3VLPromptProcessor::process(std::string& prompt,
+void Qwen3VLPromptProcessor::process(std::string& /*prompt*/,
                                      const MMData& mm_data) {
+  // Token-level expansion is handled in expand_mm_tokens().
+  DLOG_IF(WARNING, !mm_data.empty())
+      << "Qwen3VLPromptProcessor::process is unused when token-level "
+         "expansion is enabled";
+}
+
+void Qwen3VLPromptProcessor::expand_mm_tokens(std::vector<int32_t>& token_ids,
+                                              MMData& mm_data,
+                                              const Tokenizer* tokenizer) {
   torch::Tensor image_grid_thw;
-  if (auto res = mm_data.get<torch::Tensor>("image_grid_thw"))
+  if (auto res = mm_data.get<torch::Tensor>("image_grid_thw")) {
     image_grid_thw = res.value();
+  }
 
   torch::Tensor video_grid_thw;
-  if (auto res = mm_data.get<torch::Tensor>("video_grid_thw"))
+  if (auto res = mm_data.get<torch::Tensor>("video_grid_thw")) {
     video_grid_thw = res.value();
+  }
 
-  if (!image_grid_thw.defined() && !video_grid_thw.defined()) return;
+  if (!image_grid_thw.defined() && !video_grid_thw.defined()) {
+    return;
+  }
 
   std::vector<VideoMetadata> video_metadata;
   mm_data.get_metadata(MMType::VIDEO, video_metadata);
@@ -51,100 +127,90 @@ void Qwen3VLPromptProcessor::process(std::string& prompt,
   }
 
   const int32_t merge_length = merge_size_ * merge_size_;
-
-  int32_t total_image_token = 0;
-  if (image_grid_thw.defined()) {
-    int32_t count = image_grid_thw.size(0);
-    for (int32_t idx = 0; idx < count; ++idx) {
-      total_image_token +=
-          image_grid_thw[idx].prod().item<int32_t>() / merge_length;
-    }
-  }
-
-  int32_t total_video_token = 0;
-  if (video_grid_thw.defined()) {
-    int32_t count = video_grid_thw.size(0);
-    for (int32_t idx = 0; idx < count; ++idx) {
-      total_video_token +=
-          video_grid_thw[idx].prod().item<int32_t>() / merge_length;
-    }
-  }
-
-  size_t total_token_len = total_image_token * image_token_.size() +
-                           total_video_token * video_token_.size();
-  std::string data;
-  data.reserve(prompt.size() + total_token_len);
+  std::vector<int32_t> expanded;
+  expanded.reserve(token_ids.size());
 
   int32_t image_index = 0;
   int32_t video_index = 0;
 
-  size_t begin = 0;
-  auto pair = find_vision_token(prompt, begin);
-
-  while (pair.second != std::string::npos) {
-    if (pair.first == TokenType::IMAGE) {
-      data.append(prompt, begin, pair.second - begin);
-
-      auto token_num =
-          image_grid_thw[image_index].prod().item<int32_t>() / merge_length;
-      while (token_num--) {
-        data.append(image_token_);
+  for (size_t index = 0; index < token_ids.size(); ++index) {
+    if (token_ids[index] == vision_start_token_id_ &&
+        index + 2 < token_ids.size() &&
+        token_ids[index + 2] == vision_end_token_id_) {
+      const int32_t placeholder_token_id = token_ids[index + 1];
+      if (placeholder_token_id == image_token_id_ && image_grid_thw.defined() &&
+          image_index < image_grid_thw.size(0)) {
+        const int32_t token_num =
+            image_grid_thw[image_index].prod().item<int32_t>() / merge_length;
+        expanded.push_back(vision_start_token_id_);
+        expanded.insert(
+            expanded.end(), static_cast<size_t>(token_num), image_token_id_);
+        expanded.push_back(vision_end_token_id_);
+        ++image_index;
+        index += 2;
+        continue;
       }
 
-      ++image_index;
-      begin = pair.second + image_token_.size();
-
-    } else if (pair.first == TokenType::VIDEO) {
-      const size_t pos = pair.second;
-      const size_t vs_len = vision_start_token_.size();
-      const size_t ve_len = vision_end_token_.size();
-      const size_t vt_len = video_token_.size();
-
-      size_t replace_begin = pos;
-      size_t replace_end = pos + vt_len;
-
-      if (pos >= vs_len &&
-          prompt.compare(pos - vs_len, vs_len, vision_start_token_) == 0 &&
-          prompt.compare(pos + vt_len, ve_len, vision_end_token_) == 0) {
-        replace_begin = pos - vs_len;
-        replace_end = pos + vt_len + ve_len;
+      if (placeholder_token_id == video_token_id_ && video_grid_thw.defined() &&
+          video_index < video_grid_thw.size(0)) {
+        append_video_frames(expanded,
+                            video_grid_thw,
+                            video_index,
+                            video_metadata,
+                            merge_length,
+                            temporal_patch_size_,
+                            vision_start_token_id_,
+                            vision_end_token_id_,
+                            video_token_id_,
+                            tokenizer);
+        ++video_index;
+        index += 2;
+        continue;
       }
-
-      data.append(prompt, begin, replace_begin - begin);
-
-      const int32_t num_frames = video_grid_thw[video_index][0].item<int32_t>();
-      const int32_t token_num = video_grid_thw[video_index][1].item<int32_t>() *
-                                video_grid_thw[video_index][2].item<int32_t>() /
-                                merge_length;
-
-      const auto& timestamps = video_metadata[video_index].timestamps;
-      CHECK(!timestamps.empty());
-
-      auto selected = build_timestamps(
-          timestamps, static_cast<size_t>(num_frames), temporal_patch_size_);
-
-      for (int32_t idx = 0; idx < num_frames; ++idx) {
-        data.append(format_timestamp_str(selected[idx]));
-        data.append(vision_start_token_);
-        int32_t num = token_num;
-
-        while (num--) {
-          data.append(video_token_);
-        }
-        data.append(vision_end_token_);
-      }
-
-      ++video_index;
-      begin = replace_end;
-    } else {
-      LOG(FATAL) << "Unexpected token type encountered.";
     }
 
-    pair = find_vision_token(prompt, begin);
+    if (token_ids[index] == image_token_id_ && image_grid_thw.defined() &&
+        image_index < image_grid_thw.size(0)) {
+      const bool in_vision_block =
+          index >= 1 && token_ids[index - 1] == vision_start_token_id_ &&
+          index + 1 < token_ids.size() &&
+          token_ids[index + 1] == vision_end_token_id_;
+      if (!in_vision_block) {
+        const int32_t token_num =
+            image_grid_thw[image_index].prod().item<int32_t>() / merge_length;
+        expanded.insert(
+            expanded.end(), static_cast<size_t>(token_num), image_token_id_);
+        ++image_index;
+        continue;
+      }
+    }
+
+    if (token_ids[index] == video_token_id_ && video_grid_thw.defined() &&
+        video_index < video_grid_thw.size(0)) {
+      const bool in_vision_block =
+          index >= 1 && token_ids[index - 1] == vision_start_token_id_ &&
+          index + 1 < token_ids.size() &&
+          token_ids[index + 1] == vision_end_token_id_;
+      if (!in_vision_block) {
+        append_video_frames(expanded,
+                            video_grid_thw,
+                            video_index,
+                            video_metadata,
+                            merge_length,
+                            temporal_patch_size_,
+                            vision_start_token_id_,
+                            vision_end_token_id_,
+                            video_token_id_,
+                            tokenizer);
+        ++video_index;
+        continue;
+      }
+    }
+
+    expanded.push_back(token_ids[index]);
   }
 
-  if (begin < prompt.size()) data.append(prompt, begin, std::string::npos);
-  prompt = std::move(data);
+  token_ids = std::move(expanded);
 }
 
 void Qwen3VLPromptProcessor::find_mm_spans(

--- a/xllm/processors/qwen3_vl_prompt_processor.h
+++ b/xllm/processors/qwen3_vl_prompt_processor.h
@@ -38,6 +38,12 @@ class Qwen3VLPromptProcessor final : public PromptProcessor {
   void process(std::string& prompt, const MMData& mm_data) override;
   void find_mm_spans(const std::vector<int32_t>& token_ids,
                      MMData& mm_data) override;
+  bool uses_token_level_expansion() const override {
+    return !force_legacy_mm_expansion();
+  }
+  void expand_mm_tokens(std::vector<int32_t>& token_ids,
+                        MMData& mm_data,
+                        const Tokenizer* tokenizer = nullptr) override;
 
  private:
   std::pair<TokenType, size_t> find_vision_token(const std::string& prompt,


### PR DESCRIPTION
## Description

Add token-level multimodal placeholder expansion for VLM prompt processors (Qwen2-VL, Qwen3-VL, GLM4V).

The legacy path performs string-level placeholder insertion followed by a full re-tokenization of the entire prompt. The new path operates directly on the token sequence: it locates placeholder token IDs and expands them in-place with the correct image/video token count, avoiding redundant tokenization work.

This reduces `tokenization_latency_seconds` for multimodal requests—especially those with high-resolution or multi-image inputs—while producing identical `token_ids` and span metadata.

A new `mm_prompt_expansion_latency_seconds` counter is added to track the expansion step independently.

## Related Issues

N/A

## Change Type

- [ ] Bug fix
- [x] New feature
- [x] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

This PR touches `xllm/processors/` (prompt processors for GLM4V, Qwen2-VL, Qwen3-VL) and `xllm/core/common/metrics.*`.

Validated on NPU (Ascend 910) with Qwen2.5-VL-3B:
- Correctness: new token-level path produces identical `token_ids` and multimodal span offsets vs. legacy string-expand path across 256×256 to 2048×2048 resolutions.
- Performance: up to 4× reduction in tokenization latency for 2048×2048 images; no regression for text-only prompts.
- Multi-image ordering preserved (verified with 5-image interleaved prompts).
