### PR TITLE
feat: support DP and EP parallelism for adaptive speculative decoding.

### DIFF
--- a/xllm/core/runtime/dflash_worker_impl.cpp
+++ b/xllm/core/runtime/dflash_worker_impl.cpp
@@ -313,19 +313,14 @@ DFlashWorkerImpl::DFlashWorkerImpl(const ParallelArgs& parallel_args,
   draft_impl_ = std::make_unique<LLMWorkerImpl>(
       parallel_args, device, draft_options(options));
 
-  // Adaptive per-seq validate pruning. Same DP/EP-parallel guard as MTP.
+  // Adaptive per-seq validate pruning. DP is supported: the worker gathers
+  // each rank's true validate token count over the DP group before the target
+  // forward (see sync_dp_global_token_nums_after_prune).
   const bool enable_adaptive = options.enable_adaptive_speculative_decode() &&
                                options.num_speculative_tokens() > 1;
-  const bool enable_parallel_adaptive_sl =
-      parallel_args.dp_size() <= 1 && parallel_args.ep_size() <= 1;
-  if (enable_adaptive && enable_parallel_adaptive_sl) {
+  if (enable_adaptive) {
     adaptive_spec_controller_ =
         std::make_unique<AdaptiveSpeculativeController>(options);
-  } else if (enable_adaptive) {
-    LOG(WARNING) << "DFlash/DSpark adaptive speculative decode disabled under "
-                 << "DP/EP parallelism (v1). dp_size="
-                 << parallel_args.dp_size()
-                 << ", ep_size=" << parallel_args.ep_size();
   }
 }
 
@@ -582,6 +577,12 @@ std::optional<ForwardOutput> DFlashWorkerImpl::step_empty(
   // anchor + drafts forward.
   scale_speculative_parallel_token_counts(
       validate_input.input_params, options_.num_speculative_tokens() + 1);
+  // Deadlock-safety under DP: when all ranks decode but this rank's shard is
+  // empty (fake input), busy peers reach run_validate and allgather their
+  // pruned validate counts before the target forward. This idle rank runs the
+  // same target forward and must join that allgather in lockstep, contributing
+  // its own uniform (unpruned) count. No-op unless adaptive + dp_size>1.
+  sync_dp_global_token_nums_for_idle_rank(validate_input.input_params);
   ForwardOutput output =
       run_llm_no_sync_impl(
           *impl_, validate_input, *prepare_stream_, *compute_stream_)
@@ -965,6 +966,20 @@ std::optional<ForwardOutput> DFlashWorkerImpl::run_validate(
     fill_validate_input_from_draft_outputs(
         draft_block, validate_input, *compute_stream_, max_val_tokens);
   }
+  // Under DP, publish this rank's true validate token count to all DP peers so
+  // DpEpPadding computes matching MoE all-to-all pads. Runs on both branches
+  // (pruned and dense) and on every DP rank so the collective stays in
+  // lockstep. No-op when the DP group spans a single rank.
+  int32_t local_total_val_tokens = 0;
+  if (did_prune) {
+    for (int32_t v : per_seq_val_tokens) {
+      local_total_val_tokens += v;
+    }
+  } else {
+    local_total_val_tokens = batch_size * max_val_tokens;
+  }
+  sync_dp_global_token_nums_after_prune(validate_input.input_params,
+                                        local_total_val_tokens);
   ForwardOutput target_output =
       run_llm_no_sync_impl(
           *impl_, validate_input, *prepare_stream_, *compute_stream_)

--- a/xllm/core/runtime/mtp_worker_impl.cpp
+++ b/xllm/core/runtime/mtp_worker_impl.cpp
@@ -798,17 +798,9 @@ MTPWorkerImpl::MTPWorkerImpl(const ParallelArgs& parallel_args,
       MTPDraftParallelArgs(parallel_args, options),
       device,
       mtp_draft_options(draft_options));
-  const bool enable_parallel_adaptive_sl =
-      parallel_args.dp_size() <= 1 && parallel_args.ep_size() <= 1;
-  if (enable_adaptive_speculative_decode && enable_parallel_adaptive_sl) {
+  if (enable_adaptive_speculative_decode) {
     adaptive_spec_controller_ =
         std::make_unique<AdaptiveSpeculativeController>(options);
-  } else if (enable_adaptive_speculative_decode &&
-             options.enable_adaptive_speculative_decode()) {
-    LOG(WARNING)
-        << "Adaptive speculative decode is disabled for DP/EP parallelism "
-        << "in v1. dp_size=" << parallel_args.dp_size()
-        << ", ep_size=" << parallel_args.ep_size();
   }
 }
 
@@ -1240,6 +1232,11 @@ std::optional<ForwardOutput> MTPWorkerImpl::step_empty(
         eplb::expand_decode_token_mask(
             new_input.input_params.expert.eplb_decode_token_mask,
             options_.num_speculative_tokens() + 1);
+    // Deadlock-safety under DP: this rank's shard is empty but all peers
+    // decode, so busy peers allgather their pruned validate counts before the
+    // target forward. Join that allgather in lockstep with this rank's uniform
+    // count.
+    sync_dp_global_token_nums_for_idle_rank(new_input.input_params);
     ForwardOutput output = run_llm_no_sync_impl(*impl_,
                                                 new_input,
                                                 *prepare_stream_,
@@ -2180,6 +2177,17 @@ std::optional<ForwardOutput> MTPWorkerImpl::run_validate(
                                          per_seq_val_tokens,
                                          json_scratch,
                                          *compute_stream_);
+  // Under DP, publish this rank's true validate token count to all DP peers so
+  // DpEpPadding computes matching MoE all-to-all pads. per_seq_val_tokens is
+  // uniform (N+1) on the static path and varlen on the adaptive path; both
+  // funnel through here, so every DP rank runs the collective in lockstep.
+  // No-op when the DP group spans a single rank.
+  int32_t local_total_val_tokens = 0;
+  for (int32_t v : per_seq_val_tokens) {
+    local_total_val_tokens += v;
+  }
+  sync_dp_global_token_nums_after_prune(validate_input.input_params,
+                                        local_total_val_tokens);
   ForwardOutput target_output = run_llm_no_sync_impl(*impl_,
                                                      validate_input,
                                                      *compute_stream_,

--- a/xllm/core/runtime/speculative_worker_impl.cpp
+++ b/xllm/core/runtime/speculative_worker_impl.cpp
@@ -24,8 +24,10 @@ limitations under the License.
 #include "core/framework/eplb/eplb_utils.h"
 #include "core/framework/kv_cache/kv_cache_estimation.h"
 #include "core/framework/model/mtp_utils.h"
+#include "core/framework/parallel_state/process_group.h"
 #include "core/framework/speculative/spec_input_builder.h"
 #include "util/slice.h"
+#include "util/tensor_helper.h"
 #include "util/timer.h"
 #include "util/utils.h"
 
@@ -627,22 +629,82 @@ void SpeculativeWorkerImpl::prepare_validate_inputs(
   update_sampling_params(
       validate_input.sampling_params, per_seq_val_tokens, total_num_val_tokens);
 
-  // dp/ep parallel token counts: dense variant multiplies by num_val_tokens
-  // because each seq expands into that many validate rows. Here per-seq width
-  // varies, so scale by the average width = total_num_val_tokens /
-  // num_sequences so raw_dp_global_token_nums reflects the actual number of
-  // rows a rank owns.
-  const double avg_width =
-      num_sequences > 0
-          ? static_cast<double>(total_num_val_tokens) / num_sequences
-          : 1.0;
-  for (auto& it : input_params.parallel.dp_global_token_nums) {
-    it = static_cast<int32_t>(std::round(it * avg_width));
-  }
-  for (auto& it : input_params.parallel.raw_dp_global_token_nums) {
-    it = static_cast<int32_t>(std::round(it * avg_width));
-  }
+  // Note: dp_global_token_nums is NOT scaled here. Under adaptive pruning each
+  // DP rank's validate token count is data-dependent, so a rank-local estimate
+  // (e.g. average width) would diverge across ranks and desync the MoE
+  // all-to-all pads. The authoritative per-rank counts are gathered over the DP
+  // group by sync_dp_global_token_nums_after_prune(), which the worker calls on
+  // every DP rank right before the target validate forward.
   validate_input.device_tensors_ready = true;
+}
+
+void SpeculativeWorkerImpl::sync_dp_global_token_nums_after_prune(
+    ModelInputParams& input_params,
+    int32_t local_total_val_tokens) {
+  // Only the adaptive controller makes the per-rank validate token count
+  // data-dependent. When it is inactive the dense path already keeps
+  // dp_global_token_nums identical across ranks (constant width multiplier), so
+  // skip the collective entirely and leave static behavior byte-unchanged.
+  if (adaptive_spec_controller_ == nullptr ||
+      !adaptive_spec_controller_->enabled()) {
+    return;
+  }
+  ProcessGroup* dp_group = parallel_args_.dp_local_process_group_;
+  if (dp_group == nullptr || dp_group->world_size() <= 1) {
+    return;
+  }
+  const int32_t dp_size = static_cast<int32_t>(dp_group->world_size());
+  // Gather each DP peer's true post-pruning validate token count. The engine
+  // pre-populates dp_global_token_nums assuming a uniform per-seq width; after
+  // per-seq pruning that assumption is stale, so the padded and raw vectors are
+  // both rewritten with the gathered per-rank counts. Every DP rank runs this,
+  // including ranks that did not prune this step, so the collective matches.
+  torch::Tensor local = torch::tensor(
+      {local_total_val_tokens},
+      torch::TensorOptions().dtype(torch::kInt32).device(device_.unwrap()));
+  torch::Tensor gathered = dp_group->allgather_base_sync(local);
+  torch::Tensor gathered_cpu =
+      safe_to(gathered.view({dp_size}), torch::kCPU).contiguous();
+  const int32_t* gathered_data = gathered_cpu.data_ptr<int32_t>();
+
+  std::vector<int32_t>& token_nums = input_params.parallel.dp_global_token_nums;
+  std::vector<int32_t>& raw_token_nums =
+      input_params.parallel.raw_dp_global_token_nums;
+  CHECK_EQ(static_cast<int32_t>(token_nums.size()), dp_size)
+      << "dp_global_token_nums size must match DP group world size";
+  for (int32_t dp_rank = 0; dp_rank < dp_size; ++dp_rank) {
+    token_nums[static_cast<size_t>(dp_rank)] = gathered_data[dp_rank];
+  }
+  if (!raw_token_nums.empty()) {
+    CHECK_EQ(static_cast<int32_t>(raw_token_nums.size()), dp_size)
+        << "raw_dp_global_token_nums size must match DP group world size";
+    for (int32_t dp_rank = 0; dp_rank < dp_size; ++dp_rank) {
+      raw_token_nums[static_cast<size_t>(dp_rank)] = gathered_data[dp_rank];
+    }
+  }
+}
+
+void SpeculativeWorkerImpl::sync_dp_global_token_nums_for_idle_rank(
+    ModelInputParams& input_params) {
+  if (adaptive_spec_controller_ == nullptr ||
+      !adaptive_spec_controller_->enabled()) {
+    return;
+  }
+  ProcessGroup* dp_group = parallel_args_.dp_local_process_group_;
+  if (dp_group == nullptr || dp_group->world_size() <= 1) {
+    return;
+  }
+  // The idle rank's own validate width is already materialized in its
+  // dp_global_token_nums entry (scaled to the uniform N+1 width by the caller).
+  // Contribute exactly that so the gathered vector stays consistent with the
+  // busy peers, which pass their pruned Σ per_seq_val_tokens.
+  const int32_t dp_rank = static_cast<int32_t>(dp_group->rank());
+  const std::vector<int32_t>& token_nums =
+      input_params.parallel.dp_global_token_nums;
+  CHECK_LT(dp_rank, static_cast<int32_t>(token_nums.size()))
+      << "DP rank out of range for dp_global_token_nums";
+  sync_dp_global_token_nums_after_prune(
+      input_params, token_nums[static_cast<size_t>(dp_rank)]);
 }
 
 void SpeculativeWorkerImpl::restore_json_object_states(ForwardInput& input) {

--- a/xllm/core/runtime/speculative_worker_impl.h
+++ b/xllm/core/runtime/speculative_worker_impl.h
@@ -160,6 +160,25 @@ class SpeculativeWorkerImpl : public WorkerImpl {
                                ForwardInput& validate_inputs,
                                const std::vector<int32_t>& per_seq_val_tokens);
 
+  // Overwrite dp_global_token_nums / raw_dp_global_token_nums with the true
+  // post-pruning validate token count of every DP peer, gathered over the DP
+  // group. Adaptive pruning makes each rank's validate token count
+  // data-dependent, so the engine-supplied global vector (which assumes a
+  // uniform per-seq width) no longer matches; DpEpPadding needs the real
+  // per-rank counts to compute matching MoE all-to-all pads. No-op when the DP
+  // group spans a single rank. MUST be called on every DP rank each validate
+  // step (both the pruned and the unpruned branch) so the collective stays in
+  // lockstep and does not deadlock.
+  void sync_dp_global_token_nums_after_prune(ModelInputParams& input_params,
+                                             int32_t local_total_val_tokens);
+
+  // Idle-rank counterpart: a DP rank whose shard is empty still runs the target
+  // validate forward (fake input) while busy peers run the pruned forward.
+  // Both must join the same DP allgather. This variant contributes the idle
+  // rank's own current dp_global_token_nums entry (already scaled to the
+  // uniform validate width) so it stays symmetric with the busy peers.
+  void sync_dp_global_token_nums_for_idle_rank(ModelInputParams& input_params);
+
   // Target-side cache budget after reserving storage for a colocated draft.
   // DeepSeek-V4's fixed SWA pools require both geometries to participate.
   std::tuple<int64_t, int64_t> estimate_kv_cache_capacity_with_draft(


### PR DESCRIPTION
## Description

Enable adaptive per-sequence speculative-decode pruning (MTP / DFlash / DSpark)
to run under **data parallelism (DP)** and **expert parallelism (EP)**. It
previously ran only without DP/EP. Two things blocked it:

1. **DP token-count divergence.** After the controller prunes each sequence's
   validate width, a rank's total validate token count changes. Under DP the
   MoE all-to-all pads every rank to a shared `dp_global_token_nums`, so
   divergent per-rank pruning desynchronized the collective. Fix: the worker
   allgathers each rank's true post-pruning validate token count over the DP
   group before the target forward (`sync_dp_global_token_nums_after_prune`),
   so `DpEpPadding` sees consistent counts across ranks.

2. **EP was pre-emptively disabled.** The controller was gated off whenever
   `ep_size > 1`. With the DP-group reconciliation above feeding the same
   `dp_global_token_nums` that `DpEpPadding` uses for the EP all-to-all pads,
   per-seq pruning and EP routing stay consistent, so the guard is removed.

## Test

Validated on DeepSeek-V4-Flash (self-contained DSpark), 8 NPUs, `dp_size=2`,
ShareGPT, static vs adaptive back-to-back, for both `ep_size=1` and
`ep_size=2`:

- Under both EP configs the controller engages (`adaptive_enabled=1`),
  profiling fits the validate-time predictor, and both static and adaptive
  serve all requests with **no crash and no HCCL hang** across all 8 ranks.
- `ep_size=2` exercises the MoE expert all-to-all concurrently with per-seq
  pruning; the DP-group allgather keeps `dp_global_token_nums` consistent so
  the collective stays aligned.
- Single-NPU (dp=1) paths are unchanged.
