### PR TITLE
refactor: unify DSpark heads and load the DeepSeek-V4 confidence head.

### DIFF
--- a/tests/core/runtime/dspark_confidence_head_test.cpp
+++ b/tests/core/runtime/dspark_confidence_head_test.cpp
@@ -59,15 +59,12 @@ DSparkConfidenceHead make_confidence_head(bool with_markov, int64_t seed) {
 
 DSparkMarkovHead make_markov_head(int64_t seed) {
   torch::manual_seed(seed + 999);
-  DSparkMarkovHead head;
-  head.initialize(f32_cpu(), kMarkovRank);
+  DSparkMarkovHead head(f32_cpu(), kMarkovRank);
   std::unordered_map<std::string, torch::Tensor> w;
   // markov_w1: [vocab, rank]; markov_w2: [draft_vocab, rank]. Only markov_w1 is
   // exercised by confidence (markov_embed); w2 just needs to satisfy load.
-  w["markov_head.markov_w1.weight"] =
-      torch::randn({kVocab, kMarkovRank}, f32_cpu());
-  w["markov_head.markov_w2.weight"] =
-      torch::randn({kVocab, kMarkovRank}, f32_cpu());
+  w["markov_w1.weight"] = torch::randn({kVocab, kMarkovRank}, f32_cpu());
+  w["markov_w2.weight"] = torch::randn({kVocab, kMarkovRank}, f32_cpu());
   StateDict sd(std::move(w));
   head.load_state_dict(sd);
   return head;

--- a/xllm/models/llm/deepseek_v4_dspark.h
+++ b/xllm/models/llm/deepseek_v4_dspark.h
@@ -22,10 +22,12 @@ limitations under the License.
 #include <string>
 #include <vector>
 
+#include "core/framework/config/speculative_config.h"
 #include "core/framework/model_loader.h"
 #include "core/layers/common/linear.h"
 #include "core/layers/common/rms_norm.h"
 #include "models/llm/deepseek_v4.h"
+#include "models/llm/dspark_confidence_head.h"
 #include "models/llm/dspark_markov_head.h"
 #include "models/llm/dspark_weight_source.h"
 #include "models/model_registry.h"
@@ -71,6 +73,19 @@ class DeepseekV4DSparkModelImpl final : public DeepseekV4ModelImpl {
     CHECK_GT(args.markov_rank(), 0)
         << "DeepSeek-V4 DSpark requires dspark_markov_rank > 0.";
 
+    // DeepSeek-V4 DSpark checkpoints carry a confidence head (with_markov, no
+    // bias) under mtp.<last>.confidence_head. Its config has no explicit enable
+    // flag, so presence is decided by whether the weight loads. Only stand it
+    // up under adaptive speculative decode, which is its sole consumer;
+    // otherwise its weights would occupy device memory unused.
+    if (SpeculativeConfig::get_instance()
+            .enable_adaptive_speculative_decode()) {
+      confidence_head_.initialize(context.get_tensor_options(),
+                                  args.hidden_size(),
+                                  args.markov_rank(),
+                                  /*with_markov=*/true);
+    }
+
     const auto options = context.get_tensor_options();
     main_proj_ = register_module(
         "main_proj",
@@ -115,6 +130,9 @@ class DeepseekV4DSparkModelImpl final : public DeepseekV4ModelImpl {
       norm_->load_state_dict(last.get_dict_with_prefix("norm."));
       load_hc_head_state_dict(last);
       markov_head_.load_state_dict(last.get_dict_with_prefix("markov_head."));
+      // confidence_head reads confidence_head.proj.{weight,bias}; DeepSeek-V4
+      // ships a bias-less weight. Loads only if present.
+      confidence_head_.load_state_dict(last);
     }
   }
 
@@ -126,6 +144,10 @@ class DeepseekV4DSparkModelImpl final : public DeepseekV4ModelImpl {
               << embedding_source_.source_name() << ".";
     markov_head_.verify_loaded_weights(
         "mtp." + std::to_string(layers_.size() - 1) + ".markov_head.");
+    if (confidence_head_.defined()) {
+      confidence_head_.verify_loaded_weights(
+          "mtp." + std::to_string(layers_.size() - 1) + ".confidence_head.");
+    }
   }
 
   int32_t last_dspark_layer_index() const {
@@ -135,6 +157,32 @@ class DeepseekV4DSparkModelImpl final : public DeepseekV4ModelImpl {
   torch::Tensor dspark_markov_bias(
       const torch::Tensor& previous_token_ids) const {
     return markov_head_.bias(previous_token_ids);
+  }
+
+  bool has_dspark_confidence_head() const { return confidence_head_.defined(); }
+
+  torch::Tensor dspark_confidence_probs(
+      const torch::Tensor& hidden,
+      const torch::Tensor& previous_token_ids) const {
+    CHECK(confidence_head_.defined())
+        << "DeepSeek-V4 DSpark ConfidenceHead is not loaded.";
+    torch::Tensor markov_embed;
+    if (previous_token_ids.defined()) {
+      markov_embed = markov_head_.markov_embed(previous_token_ids);
+    }
+    return confidence_head_.forward(hidden, markov_embed);
+  }
+
+  torch::Tensor dspark_confidence_probs_batched(
+      const torch::Tensor& hidden_all,
+      const torch::Tensor& prev_matrix) const {
+    CHECK(confidence_head_.defined())
+        << "DeepSeek-V4 DSpark ConfidenceHead is not loaded.";
+    torch::Tensor markov_embed_all;
+    if (prev_matrix.defined()) {
+      markov_embed_all = markov_head_.markov_embed(prev_matrix);
+    }
+    return confidence_head_.forward_batched(hidden_all, markov_embed_all);
   }
 
   ModelOutput write_context_kv(const torch::Tensor& target_hidden,
@@ -168,6 +216,7 @@ class DeepseekV4DSparkModelImpl final : public DeepseekV4ModelImpl {
   layer::ReplicatedLinear main_proj_{nullptr};
   layer::RMSNorm main_norm_{nullptr};
   DSparkMarkovHead markov_head_;
+  DSparkConfidenceHead confidence_head_;
   dspark_detail::VocabularyWeightSelector embedding_source_;
 };
 TORCH_MODULE(DeepseekV4DSparkModel);
@@ -202,6 +251,22 @@ class DeepseekV4DSparkForCausalLMImpl final
   torch::Tensor dspark_markov_bias(
       const torch::Tensor& previous_token_ids) const {
     return model_->dspark_markov_bias(previous_token_ids);
+  }
+
+  bool has_dspark_confidence_head() const {
+    return model_->has_dspark_confidence_head();
+  }
+
+  torch::Tensor dspark_confidence_probs(
+      const torch::Tensor& hidden,
+      const torch::Tensor& previous_token_ids) const {
+    return model_->dspark_confidence_probs(hidden, previous_token_ids);
+  }
+
+  torch::Tensor dspark_confidence_probs_batched(
+      const torch::Tensor& hidden_all,
+      const torch::Tensor& prev_matrix) const {
+    return model_->dspark_confidence_probs_batched(hidden_all, prev_matrix);
   }
 
   ModelOutput write_context_kv(const torch::Tensor& target_hidden,

--- a/xllm/models/llm/dspark_confidence_head.h
+++ b/xllm/models/llm/dspark_confidence_head.h
@@ -21,9 +21,9 @@ limitations under the License.
 #include <cstdint>
 #include <string>
 
-#include "framework/state_dict/state_dict.h"
+#include "core/framework/state_dict/state_dict.h"
 
-namespace xllm::npu::model {
+namespace xllm {
 
 // DSpark ConfidenceHead: given a draft-step hidden state and the previous
 // token id, produces an acceptance-prob logit. When
@@ -77,11 +77,8 @@ class DSparkConfidenceHead final {
   void verify_loaded_weights(const std::string& prefix) const {
     CHECK(proj_weight_.defined())
         << "Failed to find " << prefix << "confidence_head.proj.weight";
-    CHECK(proj_bias_.defined())
-        << "Failed to find " << prefix << "confidence_head.proj.bias";
     CHECK_EQ(proj_weight_.dim(), 2)
         << "confidence_head.proj.weight must be [1, in_dim]";
-    CHECK_EQ(proj_bias_.dim(), 1) << "confidence_head.proj.bias must be [1]";
     CHECK_EQ(proj_weight_.size(0), 1)
         << "confidence_head.proj.weight must output a single logit";
     const int64_t expected_in =
@@ -89,8 +86,13 @@ class DSparkConfidenceHead final {
     CHECK_EQ(proj_weight_.size(1), expected_in)
         << "confidence_head.proj.weight in_dim mismatch, expected "
         << expected_in << " got " << proj_weight_.size(1);
-    CHECK_EQ(proj_bias_.size(0), 1)
-        << "confidence_head.proj.bias size mismatch";
+    // Bias is optional: some checkpoints (e.g. DeepSeek-V4 DSpark) ship a
+    // bias-less confidence projection. Only validate it when present.
+    if (proj_bias_.defined()) {
+      CHECK_EQ(proj_bias_.dim(), 1) << "confidence_head.proj.bias must be [1]";
+      CHECK_EQ(proj_bias_.size(0), 1)
+          << "confidence_head.proj.bias size mismatch";
+    }
   }
 
   // hidden: [num_reqs, hidden_size]
@@ -171,9 +173,9 @@ class DSparkConfidenceHead final {
     return torch::sigmoid(logit).to(torch::kFloat32);
   }
 
-  bool defined() const {
-    return proj_weight_.defined() && proj_bias_.defined();
-  }
+  // Bias is optional (some checkpoints are bias-less), so presence of the
+  // projection weight alone defines the head.
+  bool defined() const { return proj_weight_.defined(); }
 
  private:
   // Optional temperature scaling on the confidence logit before sigmoid, shared
@@ -195,4 +197,4 @@ class DSparkConfidenceHead final {
   bool with_markov_ = false;
 };
 
-}  // namespace xllm::npu::model
+}  // namespace xllm

--- a/xllm/models/llm/dspark_markov_head.h
+++ b/xllm/models/llm/dspark_markov_head.h
@@ -73,6 +73,15 @@ class DSparkMarkovHead final {
     return F::linear(markov_embedding, markov_w2_);
   }
 
+  // Expose the shared markov_w1 embedding so a ConfidenceHead can reuse the
+  // same low-rank features without a redundant lookup-table copy.
+  torch::Tensor markov_embed(const torch::Tensor& previous_token_ids) const {
+    CHECK(markov_w1_.defined())
+        << "DSpark Markov head weights are not initialized.";
+    namespace F = torch::nn::functional;
+    return F::embedding(previous_token_ids, markov_w1_);
+  }
+
  private:
   torch::Tensor markov_w1_;
   torch::Tensor markov_w2_;

--- a/xllm/models/llm/npu/qwen3_dspark.h
+++ b/xllm/models/llm/npu/qwen3_dspark.h
@@ -23,92 +23,15 @@ limitations under the License.
 #include <string>
 #include <vector>
 
+#include "framework/config/speculative_config.h"
 #include "framework/model_loader.h"
 #include "framework/state_dict/state_dict.h"
-#include "models/llm/npu/dspark_confidence_head.h"
+#include "models/llm/dspark_confidence_head.h"
+#include "models/llm/dspark_markov_head.h"
 #include "models/llm/npu/qwen3_dflash.h"
 #include "models/model_registry.h"
 
 namespace xllm::npu::model {
-
-// Low-rank Markov head for DSpark block-diffusion drafting. The model owns the
-// trained projection weights, while DSparkWorkerImpl owns the sequential
-// sampling loop and distributed token synchronization.
-//
-// Weights (no bias, no activation):
-//   markov_w1: [vocab_size, markov_rank]        embedded by the target-vocab
-//                                               prev token id.
-//   markov_w2: [draft_vocab_size, markov_rank]  projects the embed to a
-//                                               draft-vocab bias.
-//   bias(prev) = markov_w1[prev] @ markov_w2^T   -> [num_reqs, draft_vocab]
-//
-// Both weights are replicated on every TP rank. Sharding would add an
-// all-reduce and a full-vocab gather for every sequential draft position.
-class DSparkMarkovHead final {
- public:
-  DSparkMarkovHead() = default;
-
-  void initialize(const torch::TensorOptions& options, int64_t markov_rank) {
-    tensor_options_ = options;
-    markov_rank_ = markov_rank;
-    CHECK_GT(markov_rank_, 0) << "DSpark requires markov_rank > 0.";
-  }
-
-  // vLLM keys: markov_head.markov_w1.weight [vocab, rank],
-  //            markov_head.markov_w2.weight [draft_vocab, rank].
-  void load_state_dict(const StateDict& state_dict) {
-    torch::Tensor w1 = state_dict.get_tensor("markov_head.markov_w1.weight");
-    torch::Tensor w2 = state_dict.get_tensor("markov_head.markov_w2.weight");
-    if (w1.defined()) {
-      markov_w1_ = w1.to(tensor_options_);
-    }
-    if (w2.defined()) {
-      markov_w2_ = w2.to(tensor_options_);
-    }
-  }
-
-  void verify_loaded_weights(const std::string& prefix) const {
-    CHECK(markov_w1_.defined()) << "Failed to find DSpark " << prefix
-                                << "markov_head.markov_w1.weight.";
-    CHECK(markov_w2_.defined()) << "Failed to find DSpark " << prefix
-                                << "markov_head.markov_w2.weight.";
-    CHECK_EQ(markov_w1_.dim(), 2)
-        << "DSpark markov_w1 must be two-dimensional.";
-    CHECK_EQ(markov_w2_.dim(), 2)
-        << "DSpark markov_w2 must be two-dimensional.";
-    CHECK_EQ(markov_w1_.size(1), markov_rank_)
-        << "DSpark markov_w1 rank mismatch.";
-    CHECK_EQ(markov_w2_.size(1), markov_rank_)
-        << "DSpark markov_w2 rank mismatch.";
-    CHECK_EQ(markov_w1_.size(0), markov_w2_.size(0))
-        << "DSpark reduced-vocab drafts need draft-to-target remapping, not "
-           "yet "
-           "implemented.";
-  }
-
-  torch::Tensor bias(const torch::Tensor& prev_token_ids) const {
-    CHECK(defined()) << "DSpark Markov head weights are not initialized.";
-    namespace F = torch::nn::functional;
-    torch::Tensor markov_embedding = F::embedding(prev_token_ids, markov_w1_);
-    return F::linear(markov_embedding, markov_w2_);
-  }
-
-  // Expose the shared markov_w1 embedding so ConfidenceHead can reuse the same
-  // rank-256 features without a redundant lookup table copy.
-  torch::Tensor markov_embed(const torch::Tensor& prev_token_ids) const {
-    CHECK(defined()) << "DSpark Markov head weights are not initialized.";
-    namespace F = torch::nn::functional;
-    return F::embedding(prev_token_ids, markov_w1_);
-  }
-
- private:
-  bool defined() const { return markov_w1_.defined() && markov_w2_.defined(); }
-
-  torch::Tensor markov_w1_;  // [vocab_size, markov_rank]
-  torch::Tensor markov_w2_;  // [draft_vocab_size, markov_rank]
-  torch::TensorOptions tensor_options_;
-  int64_t markov_rank_ = 0;
-};
 
 // DSpark draft model = DFlash block-diffusion backbone (context-K/V injection,
 // prefill, weight loading all inherited unchanged) + a low-rank Markov head
@@ -125,11 +48,16 @@ class DSparkQwen3ForCausalLMImpl final
     : public LlmForCausalLMImplBase<DSparkQwen3Model> {
  public:
   explicit DSparkQwen3ForCausalLMImpl(const ModelContext& context)
-      : LlmForCausalLMImplBase<DSparkQwen3Model>(context) {
+      : LlmForCausalLMImplBase<DSparkQwen3Model>(context),
+        markov_head_(context.get_tensor_options(),
+                     context.get_model_args().markov_rank()) {
     const ModelArgs& model_args = context.get_model_args();
-    markov_head_.initialize(context.get_tensor_options(),
-                            model_args.markov_rank());
-    if (model_args.enable_confidence_head()) {
+    // Only stand up the ConfidenceHead when adaptive speculative decode is on:
+    // it is consumed solely by the adaptive pruning controller, so under static
+    // decoding its weights would occupy device memory and never be read.
+    if (model_args.enable_confidence_head() &&
+        SpeculativeConfig::get_instance()
+            .enable_adaptive_speculative_decode()) {
       confidence_head_.initialize(context.get_tensor_options(),
                                   model_args.hidden_size(),
                                   model_args.markov_rank(),
@@ -188,7 +116,10 @@ class DSparkQwen3ForCausalLMImpl final
         sub_dict = state_dict->get_dict_with_prefix("");
       }
       model_->load_state_dict(sub_dict);
-      markov_head_.load_state_dict(sub_dict);
+      // The shared DSparkMarkovHead reads unprefixed markov_w1/markov_w2 keys,
+      // so strip the "markov_head." prefix the checkpoint stores them under.
+      markov_head_.load_state_dict(
+          sub_dict.get_dict_with_prefix("markov_head."));
       confidence_head_.load_state_dict(sub_dict);
     }
     model_->verify_loaded_weights("");


### PR DESCRIPTION
## Description

Two related DSpark head cleanups plus a fix that were split out of the DSpark
adaptive-decode work:

1. **Relocate the confidence head.** Move `dspark_confidence_head.h` from
   `models/llm/npu/` to `models/llm/` (namespace `xllm`), next to
   `dspark_markov_head.h`. It is plain torch code with no NPU dependency, so it
   does not belong under `npu/`.

2. **De-duplicate `DSparkMarkovHead`.** `qwen3_dspark.h` carried its own inline
   copy of the Markov head that had diverged from the shared
   `models/llm/dspark_markov_head.h`. Both the Qwen3 and DeepSeek-V4 drafts now
   use the shared head (which gains the `markov_embed()` helper the confidence
   head reuses); the Qwen3 loader strips the `markov_head.` prefix so the shared
   unprefixed keys match.

3. **Load the DeepSeek-V4 DSpark confidence head.** The DeepSeek-V4-Flash
   checkpoint ships `mtp.<last>.confidence_head.proj.weight` (with-markov,
   bias-less), but `DeepseekV4DSpark` never loaded it, so adaptive pruning
   silently fell back to sampler proposal probabilities instead of the trained
   confidence. `DSparkConfidenceHead` now treats the bias as optional, and the
   DeepSeek-V4 model loads and exposes the head through the same interface as
   Qwen3.

The confidence head is only stood up when adaptive speculative decode is enabled
(`SpeculativeConfig::enable_adaptive_speculative_decode()`); under static
decoding its weights are never loaded, since only the adaptive controller
consumes them.

## Test

- Builds cleanly (including the `dspark_confidence_head_test` numerical-parity
  unit test, which was updated for the shared Markov head's constructor and
  unprefixed keys).
- Runtime on DeepSeek-V4-Flash, 8 NPUs, `dp_size=2`, ShareGPT:
  - **static** (adaptive off): confidence head is not loaded (no verify failure)
    and serving is unaffected.
  - **adaptive** (adaptive on): the confidence head loads and is consumed by the
    controller; the run serves all requests with no crash or HCCL hang.
