### PR TITLE
refactor: consolidate speculative-validate profiling gating and fitting.

### DIFF
--- a/xllm/core/scheduler/profile/profile_manager.cpp
+++ b/xllm/core/scheduler/profile/profile_manager.cpp
@@ -19,7 +19,6 @@ limitations under the License.
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 
-#include <Eigen/Dense>
 #include <algorithm>
 #include <chrono>
 #include <cmath>
@@ -72,10 +71,17 @@ ProfileManager::ProfileManager(Engine* engine, const Options& options)
       options.enable_profile_kv_blocks(), true /*is_prefill*/);
   decode_time_predictor_ = std::make_unique<TimePredictor>(
       options.enable_profile_kv_blocks(), false /*is_prefill*/);
+  speculative_validate_time_predictor_ = std::make_unique<TimePredictor>(
+      options.enable_profile_kv_blocks(), false /*is_prefill*/);
   if (options.enable_profile_step_time()) {
     LOG(INFO) << "Starting profiliing step time.";
     profile_step_time(false);
-    profile_speculative_validate_time();
+    // The validate-time predictor is only consumed by the adaptive
+    // speculative controller, so skip the whole prefix/query/batch sweep
+    // unless adaptive speculative decode is actually enabled.
+    if (should_profile_speculative_validate()) {
+      profile_speculative_validate_time();
+    }
     // test accuracy
     // eval_sequence_latency_prediction();
     // eval_batch_latency_prediction("only_prefill");
@@ -404,66 +410,20 @@ void ProfileManager::train_speculative_validate_time_predictor(
     return;
   }
 
-  // Fit T = intercept + query_token_ms*(batch*query) +
-  // query_prefix_ms*(batch*query*prefix). A standalone batch term was tried
-  // and dropped: it is pruning-invariant (does not depend on prefix) and only
-  // steals variance from the marginal query terms that drive pruning.
-  //
-  // TODO: dedup this Eigen least-squares + MAE/MAPE + negative-coefficient
-  // clamp with TimePredictor::fit_for_decode (same routine, different design
-  // matrix). Deferred to a follow-up commit to keep this PR focused.
-  constexpr int32_t kNumCoefficients = 3;
-  Eigen::MatrixXd matrix(time_profiling_data.size(), kNumCoefficients);
-  Eigen::VectorXd target(time_profiling_data.size());
-  for (int32_t i = 0; i < static_cast<int32_t>(time_profiling_data.size());
-       ++i) {
-    const int32_t batch_size = std::get<0>(time_profiling_data[i]);
-    const int32_t query_len = std::get<1>(time_profiling_data[i]);
-    const int32_t prefix_len = std::get<2>(time_profiling_data[i]);
-    const double batch = static_cast<double>(batch_size);
-    const double query = static_cast<double>(query_len);
-    const double prefix = static_cast<double>(prefix_len);
-    matrix(i, 0) = 1.0;
-    matrix(i, 1) = batch * query;
-    matrix(i, 2) = batch * query * prefix;
-    target(i) = std::get<3>(time_profiling_data[i]);
-  }
-
-  Eigen::VectorXd coefficients = matrix.colPivHouseholderQr().solve(target);
-  double sum_abs_error = 0.0;
-  double sum_percentage_error = 0.0;
-  for (int32_t i = 0; i < static_cast<int32_t>(time_profiling_data.size());
-       ++i) {
-    const double actual = std::get<3>(time_profiling_data[i]);
-    const double prediction = matrix.row(i).dot(coefficients);
-    const double abs_error = std::abs(prediction - actual);
-    sum_abs_error += abs_error;
-    if (actual > 0.0) {
-      sum_percentage_error += abs_error / actual;
-    }
-  }
-  const double mae =
-      sum_abs_error / static_cast<double>(time_profiling_data.size());
-  const double mape = sum_percentage_error /
-                      static_cast<double>(time_profiling_data.size()) * 100.0;
-
-  for (int32_t i = 0; i < kNumCoefficients; ++i) {
-    // NaN/Inf can escape a rank-deficient QR solve or slip in via a NaN
-    // latency sample; `NaN < 0.0` is false so a raw negative-only clamp
-    // would silently broadcast poison to workers. Sanitize non-finite
-    // and negative values consistently here (the local registry has the
-    // same sanitizer, but the RPC path sees the raw values).
-    if (!std::isfinite(coefficients(i)) || coefficients(i) < 0.0) {
-      LOG(ERROR) << "Invalid speculative validate coefficient[" << i
-                 << "]=" << coefficients(i) << ", clamping to 0.";
-      coefficients(i) = 0.0;
-    }
-  }
+  // The least-squares fit + error metrics + coefficient sanitization live in
+  // TimePredictor (shared with the prefill/decode predictors). Here we only
+  // map the fitted coefficients into the registry struct and publish them.
+  speculative_validate_time_predictor_->fit_for_speculative_validate(
+      time_profiling_data);
+  const std::vector<double> coefficients =
+      speculative_validate_time_predictor_->get_coefficients();
+  CHECK_EQ(coefficients.size(), 3u)
+      << "speculative validate predictor must have 3 coefficients";
 
   SpeculativeProfileRegistry::ValidateTimePredictor predictor;
-  predictor.intercept_ms = coefficients(0);
-  predictor.query_token_ms = coefficients(1);
-  predictor.query_prefix_ms = coefficients(2);
+  predictor.intercept_ms = coefficients[0];
+  predictor.query_token_ms = coefficients[1];
+  predictor.query_prefix_ms = coefficients[2];
   // Broadcast to workers FIRST, then commit locally. Workers gate the
   // adaptive path on their own SpeculativeProfileRegistry, so any rank
   // that misses the predictor will diverge from ranks that received it:
@@ -481,31 +441,36 @@ void ProfileManager::train_speculative_validate_time_predictor(
   }
   SpeculativeProfileRegistry::get_instance().set_validate_time_predictor(
       predictor);
-
-  LOG(INFO) << "Fitted speculative validate equation: time = "
-            << predictor.query_token_ms << " * batch_size * query_len + "
-            << predictor.query_prefix_ms
-            << " * batch_size * query_len * prefix_len + "
-            << predictor.intercept_ms << ", MAE: " << mae << ", MAPE: " << mape
-            << "%";
 }
 
-void ProfileManager::profile_speculative_validate_time() {
+bool ProfileManager::should_profile_speculative_validate() const {
+  // The validate-time predictor is only consumed by the adaptive speculative
+  // controller: it needs adaptive explicitly enabled, more than one
+  // speculative token to prune, and a supported algorithm
+  // (MTP / DFlash / DSpark). Otherwise the prefix/query/batch sweep is wasted
+  // startup time.
   const SpeculativeConfig& speculative_config =
       ::xllm::SpeculativeConfig::get_instance();
-  // Only fit the validate-time predictor when the adaptive path can
-  // actually consume it: MTP/DFlash/DSpark with SL > 1 and adaptive
-  // explicitly enabled. Otherwise this whole prefix/query/batch sweep is
-  // wasted startup time.
   const std::string& speculative_algorithm =
       speculative_config.speculative_algorithm();
   const bool is_supported_algo =
       SpeculativeConfig::is_mtp_algorithm(speculative_algorithm) ||
       SpeculativeConfig::is_block_diffusion_algorithm(speculative_algorithm);
-  if (!speculative_config.enable_adaptive_speculative_decode() ||
-      speculative_config.num_speculative_tokens() <= 1 || !is_supported_algo) {
+  return speculative_config.enable_adaptive_speculative_decode() &&
+         speculative_config.num_speculative_tokens() > 1 && is_supported_algo;
+}
+
+void ProfileManager::profile_speculative_validate_time() {
+  // The adaptive gate lives at the call site (should_profile_speculative_
+  // validate); guard here too so a direct call cannot profile a config the
+  // adaptive controller would never consume.
+  if (!should_profile_speculative_validate()) {
     return;
   }
+  const SpeculativeConfig& speculative_config =
+      ::xllm::SpeculativeConfig::get_instance();
+  const std::string& speculative_algorithm =
+      speculative_config.speculative_algorithm();
   LOG(INFO) << "Starting speculative validate profile for "
             << speculative_algorithm << ", "
             << "adaptive_enabled="

--- a/xllm/core/scheduler/profile/profile_manager.h
+++ b/xllm/core/scheduler/profile/profile_manager.h
@@ -161,6 +161,11 @@ class ProfileManager {
 
   void profile_token_budget();
 
+  // True when the validate-time predictor should be profiled: adaptive
+  // speculative decode enabled, SL > 1, and a supported algorithm. The
+  // predictor has no consumer otherwise.
+  bool should_profile_speculative_validate() const;
+
   void profile_speculative_validate_time();
 
   // Warm up eager NPU operators before the service becomes ready.
@@ -202,6 +207,7 @@ class ProfileManager {
 
   std::unique_ptr<TimePredictor> prefill_time_predictor_;
   std::unique_ptr<TimePredictor> decode_time_predictor_;
+  std::unique_ptr<TimePredictor> speculative_validate_time_predictor_;
 
   const Options options_;
 

--- a/xllm/core/scheduler/profile/time_predictor.cpp
+++ b/xllm/core/scheduler/profile/time_predictor.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 #include <glog/logging.h>
 
 #include <cmath>
+#include <tuple>
 #include <vector>
 
 namespace xllm {
@@ -85,6 +86,60 @@ void TimePredictor::fit_for_decode(
   // output equation
   LOG(INFO) << "Fitted equation: time = " << coefficients_(1) << " * seq_num + "
             << coefficients_(2) << " * seq_num * prefix_length + "
+            << coefficients_(0);
+  LOG(INFO) << "MAE: " << mae << ", MAPE: " << mape << "%";
+
+  check_coefficients_non_neg(n);
+}
+
+void TimePredictor::fit_for_speculative_validate(
+    const std::vector<std::tuple<int32_t, int32_t, int32_t, double>>&
+        time_profiling_data) {
+  if (time_profiling_data.empty()) {
+    return;
+  }
+  trained_ = true;
+
+  // Design matrix columns: [1, batch*query, batch*query*prefix]. A standalone
+  // batch term was tried and dropped: it is pruning-invariant (does not depend
+  // on prefix) and only steals variance from the marginal query terms that
+  // drive pruning.
+  const int32_t m = static_cast<int32_t>(time_profiling_data.size());
+  const int32_t n = 3;
+  Eigen::MatrixXd matrix(m, n);
+  Eigen::VectorXd target(m);
+  for (int32_t i = 0; i < m; ++i) {
+    const double batch =
+        static_cast<double>(std::get<0>(time_profiling_data[i]));
+    const double query =
+        static_cast<double>(std::get<1>(time_profiling_data[i]));
+    const double prefix =
+        static_cast<double>(std::get<2>(time_profiling_data[i]));
+    matrix(i, 0) = 1.0;
+    matrix(i, 1) = batch * query;
+    matrix(i, 2) = batch * query * prefix;
+    target(i) = std::get<3>(time_profiling_data[i]);
+  }
+
+  coefficients_ = matrix.colPivHouseholderQr().solve(target);
+
+  double sum_abs_error = 0.0;
+  double sum_percentage_error = 0.0;
+  for (int32_t i = 0; i < m; ++i) {
+    const double actual = std::get<3>(time_profiling_data[i]);
+    const double prediction = matrix.row(i).dot(coefficients_);
+    const double abs_error = std::abs(prediction - actual);
+    sum_abs_error += abs_error;
+    if (actual > 0.0) {
+      sum_percentage_error += abs_error / actual;
+    }
+  }
+  const double mae = sum_abs_error / static_cast<double>(m);
+  const double mape = sum_percentage_error / static_cast<double>(m) * 100.0;
+
+  LOG(INFO) << "Fitted speculative validate equation: time = "
+            << coefficients_(1) << " * batch_size * query_len + "
+            << coefficients_(2) << " * batch_size * query_len * prefix_len + "
             << coefficients_(0);
   LOG(INFO) << "MAE: " << mae << ", MAPE: " << mape << "%";
 
@@ -259,8 +314,12 @@ void TimePredictor::fit_for_prefill(
 
 void TimePredictor::check_coefficients_non_neg(int32_t num) {
   for (int32_t i = 0; i < num; ++i) {
-    if (coefficients_(i) < 0) {
-      LOG(ERROR) << "Negative coefficient: " << coefficients_(i)
+    // Sanitize non-finite as well as negative values: a rank-deficient QR
+    // solve or a NaN latency sample can produce NaN/Inf, and `NaN < 0` is
+    // false, so a negative-only clamp would let poison through to consumers
+    // (e.g. broadcast to workers on the adaptive path).
+    if (!std::isfinite(coefficients_(i)) || coefficients_(i) < 0) {
+      LOG(ERROR) << "Invalid coefficient[" << i << "]: " << coefficients_(i)
                  << ", set it to 0.";
       coefficients_(i) = 0;
     }

--- a/xllm/core/scheduler/profile/time_predictor.h
+++ b/xllm/core/scheduler/profile/time_predictor.h
@@ -16,6 +16,10 @@ limitations under the License.
 #pragma once
 
 #include <Eigen/Dense>
+#include <cstdint>
+#include <tuple>
+#include <utility>
+#include <vector>
 
 namespace xllm {
 
@@ -32,6 +36,15 @@ class TimePredictor final {
 
   void fit_for_decode(const std::vector<std::tuple<int32_t, int32_t, double>>&
                           time_profiling_data);
+
+  // Fit the speculative validate-time model
+  //   T = c0 + c1 * (batch * query) + c2 * (batch * query * prefix)
+  // from (batch_size, query_len, prefix_len, latency_ms) samples. Used by the
+  // adaptive speculative controller to weigh the marginal cost of admitting a
+  // draft token. Coefficients are sanitized (non-finite / negative -> 0).
+  void fit_for_speculative_validate(
+      const std::vector<std::tuple<int32_t, int32_t, int32_t, double>>&
+          time_profiling_data);
 
   ~TimePredictor() = default;
 


### PR DESCRIPTION
## Description

Pure refactor of the speculative validate-time profiling in `ProfileManager`,
no behavior change to the adaptive speculative controller.

- **Hoist the adaptive gate to the call site.** The decision "only profile the
  validate-time predictor when adaptive speculative decode is enabled" now
  lives in `should_profile_speculative_validate()` and is checked at the
  `ProfileManager` ctor where profiling is orchestrated, instead of being
  buried inside `profile_speculative_validate_time()`. The function keeps a
  defensive self-guard so a direct call cannot profile a config the controller
  would never consume.
- **Move the fit into `TimePredictor`.** The least-squares fit + MAE/MAPE +
  coefficient sanitization moves into `TimePredictor::fit_for_speculative_
  validate`, matching the existing `fit_for_decode` / `fit_for_prefill`.
  `ProfileManager::train_speculative_validate_time_predictor` now only maps the
  fitted coefficients into the registry struct and keeps the
  broadcast-first-then-commit publish path (unchanged).
- **Strengthen `check_coefficients_non_neg`** to also clamp non-finite
  (NaN/Inf) coefficients, not just negatives. A rank-deficient QR solve or a
  NaN latency sample can otherwise slip through a negative-only check
  (`NaN < 0` is false). This matches the sanitizer the speculative path
  previously did inline and now benefits the prefill/decode predictors too.

## Test

- Builds clean (`xllm` + `all_tests`).
- Runtime check on DeepSeek-V4-Flash, dp=2, adaptive on: the validate-time
  predictor still fits and the fit now logs from
  `TimePredictor::fit_for_speculative_validate`
  (`Fitted speculative validate equation: ...`), confirming the delegation
  path. The adaptive controller consumes the predictor exactly as before.
