### PR TITLE
bugfix: prevent installed xLLM package from shadowing TileLang AOT sources.

### DIFF
--- a/xllm/compiler/tilelang/common/toolchain.py
+++ b/xllm/compiler/tilelang/common/toolchain.py
@@ -60,12 +60,18 @@ def prepend_pythonpath(env: dict[str, str], path: str) -> None:
 def prepare_tilelang_import(tilelang_root: str | Path | None = None) -> Path:
     tl_root = Path(tilelang_root).resolve() if tilelang_root is not None else resolve_tilelang_root()
     import_path = tl_root.parent
+    source_root = repo_root()
+    import_paths = [
+        str(source_root),
+        str(source_root / "xllm"),
+        str(import_path),
+    ]
     os.environ["TL_ROOT"] = str(tl_root)
-    prepend_pythonpath(os.environ, str(import_path))
+    for path in reversed(import_paths):
+        prepend_pythonpath(os.environ, path)
 
-    import_path_str = str(import_path)
-    sys.path = [path for path in sys.path if path != import_path_str]
-    sys.path.insert(0, import_path_str)
+    sys.path = [path for path in sys.path if path not in import_paths]
+    sys.path[:0] = import_paths
     os.environ.setdefault("ACL_OP_INIT_MODE", "1")
     return tl_root
 


### PR DESCRIPTION
## Description

This PR fixes an import failure in Ascend TileLang AOT scripts when another xLLM package has been installed through pip:

```text
ModuleNotFoundError: No module named 'xllm.python'
```

## Root Cause

When a TileLang AOT script runs in a standalone process, the current xLLM repository root is not explicitly guaranteed to precede installed package directories.

As a result, Python may load the xllm package from site-packages instead of the current source tree. If the installed package does not contain xllm.python, the import fails.

## Changes

Update prepare_tilelang_import() to prepend the following paths to both sys.path and PYTHONPATH:

1. The current xLLM repository root
2. The current xLLM source package directory
3. The parent directory of the TileLang installation

Duplicate entries are removed to ensure the current source package takes precedence over the installed package while preserving TileLang imports.