### PR TITLE
refactor: remove the dead non-batched DSpark confidence-probs path.

### DIFF
--- a/xllm/core/framework/model/causal_lm.h
+++ b/xllm/core/framework/model/causal_lm.h
@@ -193,17 +193,12 @@ class CausalLM : public torch::nn::Module {
   }
 
   // DSpark ConfidenceHead: acceptance-prob estimate for adaptive-speculative
-  // pruning. Returns [num_reqs] fp32 in [0, 1]. When the confidence head is
-  // absent (not built or feature disabled), returns an undefined tensor; the
-  // worker falls back to the sampler-gathered draft prob.
+  // pruning over the whole draft block. hidden_all [num_reqs, num_spec, H],
+  // prev_matrix [num_reqs, num_spec]; returns [num_reqs, num_spec] fp32 in
+  // [0, 1]. When the confidence head is absent (not built or feature disabled),
+  // returns an undefined tensor; the worker falls back to the sampler-gathered
+  // draft prob.
   virtual torch::Tensor dspark_confidence_probs(
-      const torch::Tensor& hidden,
-      const torch::Tensor& previous_token_ids) {
-    return {};
-  }
-  // Batched over the whole draft block: hidden [num_reqs, num_spec, H],
-  // prev_matrix [num_reqs, num_spec]; returns [num_reqs, num_spec] fp32.
-  virtual torch::Tensor dspark_confidence_probs_batched(
       const torch::Tensor& hidden_all,
       const torch::Tensor& prev_matrix) {
     return {};
@@ -328,21 +323,12 @@ class CausalLMImpl : public CausalLM {
   }
 
   torch::Tensor dspark_confidence_probs(
-      const torch::Tensor& hidden,
-      const torch::Tensor& previous_token_ids) override {
-    if constexpr (detail::has_dspark_confidence_probs<Model>::value) {
-      return model_->dspark_confidence_probs(hidden, previous_token_ids);
-    }
-    return CausalLM::dspark_confidence_probs(hidden, previous_token_ids);
-  }
-
-  torch::Tensor dspark_confidence_probs_batched(
       const torch::Tensor& hidden_all,
       const torch::Tensor& prev_matrix) override {
-    if constexpr (detail::has_dspark_confidence_probs_batched<Model>::value) {
-      return model_->dspark_confidence_probs_batched(hidden_all, prev_matrix);
+    if constexpr (detail::has_dspark_confidence_probs<Model>::value) {
+      return model_->dspark_confidence_probs(hidden_all, prev_matrix);
     }
-    return CausalLM::dspark_confidence_probs_batched(hidden_all, prev_matrix);
+    return CausalLM::dspark_confidence_probs(hidden_all, prev_matrix);
   }
 
   bool has_dspark_confidence_head() const override {

--- a/xllm/core/framework/model/model_traits.h
+++ b/xllm/core/framework/model/model_traits.h
@@ -281,16 +281,6 @@ struct has_dspark_confidence_probs<
         std::declval<const torch::Tensor&>()))>> : std::true_type {};
 
 template <typename T, typename = void>
-struct has_dspark_confidence_probs_batched : std::false_type {};
-
-template <typename T>
-struct has_dspark_confidence_probs_batched<
-    T,
-    std::void_t<decltype(std::declval<T>()->dspark_confidence_probs_batched(
-        std::declval<const torch::Tensor&>(),
-        std::declval<const torch::Tensor&>()))>> : std::true_type {};
-
-template <typename T, typename = void>
 struct has_has_dspark_confidence_head : std::false_type {};
 
 template <typename T>

--- a/xllm/core/runtime/dspark_worker_impl.cpp
+++ b/xllm/core/runtime/dspark_worker_impl.cpp
@@ -242,7 +242,7 @@ DSparkWorkerImpl::BlockSampleOutput DSparkWorkerImpl::sample_block(
          token_ids.slice(/*dim=*/1, /*start=*/0, num_speculative_tokens - 1)},
         /*dim=*/1);  // [num_reqs, num_spec]
     confidence_probs =
-        draft_impl_->dspark_confidence_probs_batched(last_hidden, prev_matrix);
+        draft_impl_->dspark_confidence_probs(last_hidden, prev_matrix);
     CHECK_EQ(confidence_probs.dim(), 2)
         << "batched confidence probs must be [num_reqs, num_spec]";
     CHECK_EQ(confidence_probs.size(0), num_reqs)

--- a/xllm/core/runtime/llm_worker_impl.h
+++ b/xllm/core/runtime/llm_worker_impl.h
@@ -104,15 +104,9 @@ class LLMWorkerImpl : public WorkerImpl {
     return model_->dspark_markov_bias(previous_token_ids);
   }
 
-  torch::Tensor dspark_confidence_probs(
-      const torch::Tensor& hidden,
-      const torch::Tensor& previous_token_ids) {
-    return model_->dspark_confidence_probs(hidden, previous_token_ids);
-  }
-  torch::Tensor dspark_confidence_probs_batched(
-      const torch::Tensor& hidden_all,
-      const torch::Tensor& prev_matrix) {
-    return model_->dspark_confidence_probs_batched(hidden_all, prev_matrix);
+  torch::Tensor dspark_confidence_probs(const torch::Tensor& hidden_all,
+                                        const torch::Tensor& prev_matrix) {
+    return model_->dspark_confidence_probs(hidden_all, prev_matrix);
   }
   bool has_dspark_confidence_head() const {
     return model_->has_dspark_confidence_head();

--- a/xllm/models/llm/deepseek_v4_dspark.h
+++ b/xllm/models/llm/deepseek_v4_dspark.h
@@ -162,18 +162,6 @@ class DeepseekV4DSparkModelImpl final : public DeepseekV4ModelImpl {
   bool has_dspark_confidence_head() const { return confidence_head_.defined(); }
 
   torch::Tensor dspark_confidence_probs(
-      const torch::Tensor& hidden,
-      const torch::Tensor& previous_token_ids) const {
-    CHECK(confidence_head_.defined())
-        << "DeepSeek-V4 DSpark ConfidenceHead is not loaded.";
-    torch::Tensor markov_embed;
-    if (previous_token_ids.defined()) {
-      markov_embed = markov_head_.markov_embed(previous_token_ids);
-    }
-    return confidence_head_.forward(hidden, markov_embed);
-  }
-
-  torch::Tensor dspark_confidence_probs_batched(
       const torch::Tensor& hidden_all,
       const torch::Tensor& prev_matrix) const {
     CHECK(confidence_head_.defined())
@@ -258,15 +246,9 @@ class DeepseekV4DSparkForCausalLMImpl final
   }
 
   torch::Tensor dspark_confidence_probs(
-      const torch::Tensor& hidden,
-      const torch::Tensor& previous_token_ids) const {
-    return model_->dspark_confidence_probs(hidden, previous_token_ids);
-  }
-
-  torch::Tensor dspark_confidence_probs_batched(
       const torch::Tensor& hidden_all,
       const torch::Tensor& prev_matrix) const {
-    return model_->dspark_confidence_probs_batched(hidden_all, prev_matrix);
+    return model_->dspark_confidence_probs(hidden_all, prev_matrix);
   }
 
   ModelOutput write_context_kv(const torch::Tensor& target_hidden,

--- a/xllm/models/llm/npu/qwen3_dspark.h
+++ b/xllm/models/llm/npu/qwen3_dspark.h
@@ -71,29 +71,13 @@ class DSparkQwen3ForCausalLMImpl final
   }
 
   // Compute per-request acceptance probability using the trained ConfidenceHead
-  // over the draft-step hidden state and the previous token embedding.
-  // hidden: [num_reqs, hidden_size], prev_token_ids: [num_reqs].
-  // Returns [num_reqs] fp32 in [0, 1]. Defined only when
-  // enable_confidence_head.
-  torch::Tensor dspark_confidence_probs(
-      const torch::Tensor& hidden,
-      const torch::Tensor& previous_token_ids) const {
-    CHECK(confidence_head_.defined())
-        << "DSpark ConfidenceHead is not initialized (enable_confidence_head?)";
-    torch::Tensor markov_embed;
-    if (previous_token_ids.defined()) {
-      markov_embed = markov_head_.markov_embed(previous_token_ids);
-    }
-    return confidence_head_.forward(hidden, markov_embed);
-  }
-
-  // Batched variant of dspark_confidence_probs over the whole draft block.
+  // over the whole draft block.
   //   hidden_all:  [num_reqs, num_spec, hidden_size]
   //   prev_matrix: [num_reqs, num_spec] int64 — column k is step k's "prev"
   //                token (col 0 = anchor, col k = draft token sampled at k-1).
   // Returns [num_reqs, num_spec] fp32 in [0, 1]. Defined only when
   // enable_confidence_head.
-  torch::Tensor dspark_confidence_probs_batched(
+  torch::Tensor dspark_confidence_probs(
       const torch::Tensor& hidden_all,
       const torch::Tensor& prev_matrix) const {
     CHECK(confidence_head_.defined())


### PR DESCRIPTION
## Summary

The DSpark ConfidenceHead is only ever consumed one way — the whole draft block is scored in a single batched `linear+sigmoid` from `DSparkWorkerImpl::sample_block` (`dspark_worker_impl.cpp`). The per-step **non-batched** `dspark_confidence_probs` family had **zero live callers** across every layer of the call chain:

- model impls (`qwen3_dspark.h`, `deepseek_v4_dspark.h`)
- the `CausalLM` virtual base + `CausalLMImpl<Model>` derived forwarder (`causal_lm.h`)
- the `has_dspark_confidence_probs` SFINAE trait (`model_traits.h`)
- the `LLMWorkerImpl` wrapper (`llm_worker_impl.h`)

So it was pure dead code. This PR deletes the non-batched overloads and renames `dspark_confidence_probs_batched` down to the clean name `dspark_confidence_probs` throughout.

**No behavior change** — the single live batched path is untouched, only renamed. Net `15 insertions(+), 79 deletions(-)`.

## Test plan

- [x] Container build clean (`python setup.py build`, EXIT=0).
- [x] `grep` confirms no `_batched` residue and no dangling non-batched references remain.
- [ ] Reviewer sanity check on the call-chain claim (no live non-batched caller).