### PR TITLE
docs: import AGENTS.md from a real CLAUDE.md file.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md


### PR DESCRIPTION
## Description

Replace the root `CLAUDE.md` symlink with a tracked regular Markdown file whose only content is `@AGENTS.md`.

## Why

Claude Code reads `CLAUDE.md` and supports `@path/to/import`, but it does not read `AGENTS.md` directly. Importing `AGENTS.md` from a real `CLAUDE.md` lets Claude Code and other coding agents share one source of truth without duplicating project instructions. Using a regular file instead of a symlink also improves portability across platforms and Git tooling, while leaving room for future Claude-specific guidance.

For the official behavior, see the [Claude Code memory documentation](https://code.claude.com/docs/en/memory#agentsmd).

## Change Type

- [x] Documentation

## Validation

- [x] `git diff --check`
- [x] `pre-commit run --files CLAUDE.md`

This is a documentation-only change; no build or runtime tests are required.

## Reviewer Notes

- `AGENTS.md` is unchanged.
- The change is limited to replacing the symlink with a mode `100644` file containing the import directive.