### PR TITLE
docs: align documentation with current implementation.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # xLLM Documentation
 
-[English](./README.md) | [简体中文](./README.zh-CN.md)
+[English](./README.md) | [简体中文](./README_zh.md)
 
 This repository contains the Astro + Starlight documentation site for
 [xLLM](https://github.com/xLLM-AI/xllm), an LLM inference framework for

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -1,6 +1,6 @@
 # xLLM 文档站
 
-[English](./README.md) | [简体中文](./README.zh-CN.md)
+[English](./README.md) | [简体中文](./README_zh.md)
 
 本仓库是 [xLLM](https://github.com/xLLM-AI/xllm) 的 Astro + Starlight
 文档站。xLLM 是面向国产 AI 加速器的高性能大语言模型推理框架。

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -197,12 +197,12 @@ export default defineConfig({
 										{
 											label: 'GLM-5.2',
 											translations: { 'zh-CN': 'GLM-5.2' },
-											slug: 'cookbook/autoregressive_models/glm/glm_5',
+											slug: 'cookbook/autoregressive_models/glm/glm_5_2',
 										},
 										{
 											label: 'GLM-5.1',
 											translations: { 'zh-CN': 'GLM-5.1' },
-											slug: 'cookbook/autoregressive_models/glm/glm_5',
+											slug: 'cookbook/autoregressive_models/glm/glm_5_1',
 										},
 										{
 											label: 'GLM-5',
@@ -303,6 +303,11 @@ export default defineConfig({
 											label: 'Wan2.1',
 											translations: { 'zh-CN': 'Wan2.1' },
 											slug: 'cookbook/diffusion_models/wan/wan2_1',
+										},
+										{
+											label: 'Wan2.2',
+											translations: { 'zh-CN': 'Wan2.2' },
+											slug: 'cookbook/diffusion_models/wan/wan2_2',
 										},
 									],
 								},

--- a/docs/src/content/docs/en/cli_reference.md
+++ b/docs/src/content/docs/en/cli_reference.md
@@ -4,7 +4,7 @@ sidebar:
   order: 100
 ---
 
-xLLM uses gflags to manage service startup parameters. `--model <PATH>` is the only required flag. When `--config_json_file` is used, values in the JSON file override command-line flag values. The tables below are grouped by the Config classes in `/xllm/core/framework/config`, with one Config per section. The `ConfigJsonUtils` section contains the common JSON config-file flags.
+xLLM uses gflags to manage service startup parameters. `--model <PATH>` is the only required flag. For native configuration, explicitly supplied command-line flags override JSON configuration values, which override compiled defaults. The tables below are grouped by the Config classes in `/xllm/core/framework/config`, with one Config per section. The `ConfigJsonUtils` section contains the common JSON config-file flags.
 
 > **Device selection**: xLLM no longer provides `--devices` / `--device_id` / `--draft_devices`. The available devices are determined by the visible-device mask environment variables (`ASCEND_RT_VISIBLE_DEVICES` for NPU, `CUDA_VISIBLE_DEVICES` for NVIDIA, `MLU_VISIBLE_DEVICES` for Cambricon, `HIP_VISIBLE_DEVICES` for DCU, `MUSA_VISIBLE_DEVICES` for Moore Threads). Each service process selects one runtime logical device from its visible devices according to its global `node_rank`; visible-device subsetting and reordering are resolved by the hardware runtime. The draft model always shares the selected device with the target model.
 
@@ -12,7 +12,7 @@ xLLM uses gflags to manage service startup parameters. `--model <PATH>` is the o
 
 | Parameter | Type | Default | Description |
 |:----------|:-----|:--------|:------------|
-| `config_json_file` | `string` | `""` | Path to a JSON config file. Values in the file override command-line flag values. |
+| `config_json_file` | `string` | `""` | Path to a JSON config file. For native configuration, explicit command-line flags take precedence over file values. |
 | `enable_dump_config_json` | `bool` | `false` | Whether to dump the resolved startup config as JSON. |
 | `dump_config_json_file` | `string` | `"xllm_config.json"` | Path to write the resolved startup config as JSON. Used only when `enable_dump_config_json=true`. |
 
@@ -97,7 +97,7 @@ xLLM uses gflags to manage service startup parameters. `--model <PATH>` is the o
 |:----------|:-----|:--------|:------------|
 | `enable_beam_search_kernel` | `bool` | `false` | Whether to enable the beam search kernel. |
 | `beam_width` | `int32` | `1` | Beam width for beam search. |
-| `enable_block_copy_kernel` | `bool` | `true` (NPU/CUDA); `false` (other backends) | Whether to use the block copy kernel on supported backends. |
+| `enable_block_copy_kernel` | `bool` | `true` (NPU/CUDA/MUSA/DCU); `false` (other backends) | Whether to use the block copy kernel on supported backends. |
 | `enable_topk_sorted` | `bool` | `true` | Whether to enable sorted top-k output. |
 
 ## SchedulerConfig
@@ -105,7 +105,7 @@ xLLM uses gflags to manage service startup parameters. `--model <PATH>` is the o
 | Parameter | Type | Default | Description |
 |:----------|:-----|:--------|:------------|
 | `max_tokens_per_batch` | `int32` | `10240` | Maximum number of tokens per batch. |
-| `max_seqs_per_batch` | `int32` | `1024` | Maximum number of sequences per batch. |
+| `max_seqs_per_batch` | `int32` | `200` | Maximum number of sequences per batch. |
 | `enable_schedule_overlap` | `bool` | `false` | Whether to enable schedule overlap, also known as asynchronous scheduling. See [Async Scheduling](/en/features/async_schedule/). |
 | `prefill_scheduling_memory_usage_threshold` | `double` | `0.95` | Memory usage threshold during prefill scheduling. |
 | `enable_chunked_prefill` | `bool` | `true` | Whether to enable chunked prefill. |
@@ -114,7 +114,7 @@ xLLM uses gflags to manage service startup parameters. `--model <PATH>` is the o
 | `use_zero_evict` | `bool` | `false` | Whether to use ZeroEvictionScheduler. See [Zero Evict Scheduler](/en/features/zero_evict_scheduler/). |
 | `max_decode_token_per_sequence` | `int32` | `256` | Maximum decode tokens per sequence for ZeroEvictionScheduler. |
 | `priority_strategy` | `string` | `"fcfs"` | Request priority strategy, for example `fcfs`, `priority`, or `deadline`. |
-| `use_mix_scheduler` | `bool` | `false` | Whether to use MixScheduler to handle prefill and decode uniformly. |
+| `enable_mix_batch` | `bool` | `true` | Whether to run prefill and decode in the same batch. Forced to `false` when CP or MTP is active. |
 | `enable_online_preempt_offline` | `bool` | `true` | Whether online requests can preempt offline requests. |
 | `aggressive_coeff` | `double` | `1.0` | Aggressive coefficient for MixScheduler urgency judgment. |
 | `starve_threshold` | `double` | `1.0` | Starvation threshold coefficient for MixScheduler. |

--- a/docs/src/content/docs/en/cookbook/diffusion_models.md
+++ b/docs/src/content/docs/en/cookbook/diffusion_models.md
@@ -10,5 +10,6 @@ Content will be added as the recipes are organized.
 ## Model Families
 
 - [Flux](/en/cookbook/diffusion_models/flux/flux/)
-- [Wan](/en/cookbook/diffusion_models/wan/wan2_1/)
+- [Wan2.1](/en/cookbook/diffusion_models/wan/wan2_1/)
+- [Wan2.2](/en/cookbook/diffusion_models/wan/wan2_2/)
 - [Qwen-Image](/en/cookbook/diffusion_models/qwen_image/qwen_image/)

--- a/docs/src/content/docs/en/cookbook/diffusion_models/wan/wan2_2.md
+++ b/docs/src/content/docs/en/cookbook/diffusion_models/wan/wan2_2.md
@@ -130,11 +130,13 @@ START_PORT=18013
 START_DEVICE=8
 LOG_DIR="log"
 NNODES=8
+LAST_DEVICE=$((START_DEVICE + NNODES - 1))
+# Make START_DEVICE through LAST_DEVICE visible to every rank.
+export ASCEND_RT_VISIBLE_DEVICES="$(seq -s, "$START_DEVICE" "$LAST_DEVICE")"
 
 for (( i=0; i<$NNODES; i++ ))
 do
   PORT=$((START_PORT + i))
-  DEVICE=$((START_DEVICE + i))
   LOG_FILE="$LOG_DIR/node_$i.log"
 
   ${XLLM_PATH} \
@@ -146,7 +148,6 @@ do
     --sp_size=4 \
     --vae_size=4 \
     --output_shm_size=1024 \
-    --devices="npu:$DEVICE" \
     --master_node_addr=$MASTER_NODE_ADDR \
     --nnodes=$NNODES \
     --port $PORT \
@@ -177,7 +178,7 @@ When "Brpc Server Started" appears in the log, the service has started successfu
 | `--vae_size` | VAE Spatial Parallel degree | `1` | Positive integer, e.g. `1`, `2`, `4`; can be set to the same value as `sp_size` |
 | `--tp_size` | Tensor Parallel degree | `1` | Positive integer, e.g. `2`, `4`; it is recommended not to enable this and use dynamic weight loading instead |
 | `--enable_rolling_load` | Enable dynamic weight loading | `false` | Bool, `true` or `false` |
-| `--rolling_load_num_rolling_slot` | Number of slots for dynamic weight loading | `2` | Positive integer, e.g. `2`, `3` |
+| `--rolling_load_num_rolling_slots` | Number of slots for dynamic weight loading | `2` | Positive integer, e.g. `2`, `3` |
 | `--dit_laser_attention_enable` | Enable Laser Attention | `false` | Bool, `true` or `false` |
 | `--dit_distill_enable` | Enable distilled model | `false` | Bool, `true` or `false` |
 | `--dit_sparse_attention_enabled` | Enable sparse attention | `false` | Bool, `true` or `false`; mutually exclusive with `laser_attention` |

--- a/docs/src/content/docs/en/design/generative_recommendation_design.md
+++ b/docs/src/content/docs/en/design/generative_recommendation_design.md
@@ -271,7 +271,7 @@ The current branch organizes the generative recommendation path as follows.
 External integration:
 - `xllm/c_api/rec.h`
 - `xllm/c_api/internal/rec.cpp`
-- `xllm/c_api/examples/simple_rec_completions.cpp`
+- `xllm/c_api/examples/test_query_rec_completions.cpp`
 
 Service entry:
 - `xllm/api_service/rec_completion_service_impl.cpp`
@@ -397,11 +397,11 @@ If the goal is to understand how `predictor` or the shared-library integration e
 - `xllm/c_api/internal/rec.cpp`
   - the actual CAPI implementation
   - useful for seeing how request parameters are wrapped and forwarded in `.so` mode
-- `xllm/c_api/examples/simple_rec_completions.cpp`
-  - the smallest runnable example
-  - useful when explaining what a dynamic-library integration looks like in practice
+- `xllm/c_api/examples/test_query_rec_completions.cpp`
+  - the current C API usage example for a recommendation token-completion request
+  - useful for tracing initialization and request construction in a dynamic-library integration
 
-If the technical-sharing version needs one “minimal usage example”, this is the best layer to cite first.
+If the technical-sharing version needs a C API usage example, this is the best layer to cite first.
 
 ### 8.2 Then read the service entry layer
 

--- a/docs/src/content/docs/en/dev_guide/tilelang_ascend_kernel_dev.md
+++ b/docs/src/content/docs/en/dev_guide/tilelang_ascend_kernel_dev.md
@@ -209,7 +209,7 @@ So these three fields must appear in both:
 - `DISPATCH_SCHEMA`
 - every `SPECIALIZATIONS` item
 
-At build time, Ascend build resolves the actual `bisheng_arch` from the `--device a2|a3` value passed by the main build path.
+The xLLM `setup.py` build and test commands use `--device npu` to select the NPU backend. In contrast, TileLang's `compile-kernels` command uses `--device a2` or `a3` to select the Ascend architecture and resolve `bisheng_arch`.
 
 ### 3.4 Inspect the Generated Ascend-C Source
 
@@ -399,7 +399,7 @@ python xllm/compiler/tilelang_launcher.py compile-kernels \
   --output-root build/cmake.linux-aarch64-cpython-311/xllm/compiler/tilelang \
   --kernels rope
 
-python setup.py test --test-name rope_wrapper_test --device a3
+python setup.py test --test-name rope_wrapper_test --device npu
 ```
 
 The first command generates `manifest.json`, `registry.inc`, and the object files. The second command validates the full integration path.

--- a/docs/src/content/docs/zh/cli_reference.md
+++ b/docs/src/content/docs/zh/cli_reference.md
@@ -4,7 +4,7 @@ sidebar:
   order: 100
 ---
 
-xLLM 使用 gflags 管理服务启动参数。`--model <PATH>` 是唯一必填参数。使用 `--config_json_file` 时，JSON 文件中的值会覆盖命令行 flag 值。下表按 `/xllm/core/framework/config` 下的 Config 类分组，一个 Config 对应一节；`ConfigJsonUtils` 一节包含配置文件相关的通用参数。
+xLLM 使用 gflags 管理服务启动参数。`--model <PATH>` 是唯一必填参数。对于原生配置，显式指定的命令行 flag 优先于 JSON 配置值，后者优先于编译时默认值。下表按 `/xllm/core/framework/config` 下的 Config 类分组，一个 Config 对应一节；`ConfigJsonUtils` 一节包含配置文件相关的通用参数。
 
 > **设备选择**：xLLM 不再提供 `--devices` / `--device_id` / `--draft_devices` 参数。可用设备由可见设备掩码环境变量决定（NPU 用 `ASCEND_RT_VISIBLE_DEVICES`，NVIDIA 用 `CUDA_VISIBLE_DEVICES`，寒武纪用 `MLU_VISIBLE_DEVICES`，DCU 用 `HIP_VISIBLE_DEVICES`，摩尔线程用 `MUSA_VISIBLE_DEVICES`）。每个服务进程根据全局 `node_rank` 从其可见设备中选择一个运行时逻辑设备；可见设备的子集化与重排由硬件运行时解析。draft 模型始终与 target 模型共享所选设备。
 
@@ -12,7 +12,7 @@ xLLM 使用 gflags 管理服务启动参数。`--model <PATH>` 是唯一必填�
 
 | 参数名称 | 类型 | 默认值 | 参数含义 |
 |:---------|:-----|:-------|:---------|
-| `config_json_file` | `string` | `""` | JSON 配置文件路径；文件中的值会覆盖命令行 flag 值。 |
+| `config_json_file` | `string` | `""` | JSON 配置文件路径；对于原生配置，显式指定的命令行 flag 优先于文件中的值。 |
 | `enable_dump_config_json` | `bool` | `false` | 是否将最终生效的启动配置导出为 JSON。 |
 | `dump_config_json_file` | `string` | `"xllm_config.json"` | 导出启动配置 JSON 的路径，仅在 `enable_dump_config_json=true` 时使用。 |
 
@@ -97,7 +97,7 @@ xLLM 使用 gflags 管理服务启动参数。`--model <PATH>` 是唯一必填�
 |:---------|:-----|:-------|:---------|
 | `enable_beam_search_kernel` | `bool` | `false` | 是否启用 beam search kernel。 |
 | `beam_width` | `int32` | `1` | Beam search 的 beam width。 |
-| `enable_block_copy_kernel` | `bool` | `true`（NPU/CUDA）；`false`（其他后端） | 是否在支持的后端使用 block copy kernel。 |
+| `enable_block_copy_kernel` | `bool` | `true`（NPU/CUDA/MUSA/DCU）；`false`（其他后端） | 是否在支持的后端使用 block copy kernel。 |
 | `enable_topk_sorted` | `bool` | `true` | 是否启用 top-k 结果排序输出。 |
 
 ## SchedulerConfig
@@ -105,7 +105,7 @@ xLLM 使用 gflags 管理服务启动参数。`--model <PATH>` 是唯一必填�
 | 参数名称 | 类型 | 默认值 | 参数含义 |
 |:---------|:-----|:-------|:---------|
 | `max_tokens_per_batch` | `int32` | `10240` | 每个 batch 可处理的最大 token 数。 |
-| `max_seqs_per_batch` | `int32` | `1024` | 每个 batch 可处理的最大 sequence 数。 |
+| `max_seqs_per_batch` | `int32` | `200` | 每个 batch 可处理的最大 sequence 数。 |
 | `enable_schedule_overlap` | `bool` | `false` | 是否启用 schedule overlap（异步调度）；详见 [异步调度](/zh/features/async_schedule/)。 |
 | `prefill_scheduling_memory_usage_threshold` | `double` | `0.95` | prefill 调度时的内存使用阈值。 |
 | `enable_chunked_prefill` | `bool` | `true` | 是否启用 chunked prefill。 |
@@ -114,7 +114,7 @@ xLLM 使用 gflags 管理服务启动参数。`--model <PATH>` 是唯一必填�
 | `use_zero_evict` | `bool` | `false` | 是否使用 ZeroEvictionScheduler；详见 [Zero Evict Scheduler](/zh/features/zero_evict_scheduler/)。 |
 | `max_decode_token_per_sequence` | `int32` | `256` | ZeroEvictionScheduler 中每个 sequence 的最大 decode token 数。 |
 | `priority_strategy` | `string` | `"fcfs"` | 请求优先级策略，例如 `fcfs`、`priority`、`deadline`。 |
-| `use_mix_scheduler` | `bool` | `false` | 是否使用 MixScheduler 统一处理 prefill 和 decode。 |
+| `enable_mix_batch` | `bool` | `true` | 是否在同一 batch 中运行 prefill 和 decode。启用 CP 或 MTP 时会被强制设为 `false`。 |
 | `enable_online_preempt_offline` | `bool` | `true` | 是否允许在线请求抢占离线请求。 |
 | `aggressive_coeff` | `double` | `1.0` | MixScheduler 紧急度判断的激进系数。 |
 | `starve_threshold` | `double` | `1.0` | MixScheduler 的饥饿阈值系数。 |

--- a/docs/src/content/docs/zh/cookbook/diffusion_models.md
+++ b/docs/src/content/docs/zh/cookbook/diffusion_models.md
@@ -10,5 +10,6 @@ description: "xLLM 扩散模型推理实践"
 ## 模型系列
 
 - [Flux](/zh/cookbook/diffusion_models/flux/flux/)
-- [Wan](/zh/cookbook/diffusion_models/wan/wan2_1/)
+- [Wan2.1](/zh/cookbook/diffusion_models/wan/wan2_1/)
+- [Wan2.2](/zh/cookbook/diffusion_models/wan/wan2_2/)
 - [Qwen-Image](/zh/cookbook/diffusion_models/qwen_image/qwen_image/)

--- a/docs/src/content/docs/zh/cookbook/diffusion_models/wan/wan2_2.md
+++ b/docs/src/content/docs/zh/cookbook/diffusion_models/wan/wan2_2.md
@@ -132,11 +132,13 @@ START_PORT=18013
 START_DEVICE=8
 LOG_DIR="log"
 NNODES=8
+LAST_DEVICE=$((START_DEVICE + NNODES - 1))
+# 向每个 rank 暴露从 START_DEVICE 到 LAST_DEVICE 的设备。
+export ASCEND_RT_VISIBLE_DEVICES="$(seq -s, "$START_DEVICE" "$LAST_DEVICE")"
 
 for (( i=0; i<$NNODES; i++ ))
 do
   PORT=$((START_PORT + i))
-  DEVICE=$((START_DEVICE + i))
   LOG_FILE="$LOG_DIR/node_$i.log"
 
   ${XLLM_PATH} \
@@ -148,7 +150,6 @@ do
     --sp_size=4 \
     --vae_size=4 \
     --output_shm_size=1024 \
-    --devices="npu:$DEVICE" \
     --master_node_addr=$MASTER_NODE_ADDR \
     --nnodes=$NNODES \
     --port $PORT \
@@ -182,7 +183,7 @@ done
 | `--vae_size` | Vae Sparital Parallel 并行度 | `1` | 正整数, 如 `1`、`2`、`4`,  可以与sp_size保持一致|
 | `--tp_size` | Tensor Parallel 并行度 | `1` | 正整数, 如 `2`、`4`,  建议不开启，使用动态权重加载|
 | `--enable_rolling_load` | 是否启动动态权重加载 | `false` | bool值, true 或者 false|
-| `--rolling_load_num_rolling_slot` | 动态权重加载分配槽数 | `2` | 正整数, , 如 `2`、`3`|
+| `--rolling_load_num_rolling_slots` | 动态权重加载分配槽数 | `2` | 正整数, , 如 `2`、`3`|
 | `--dit_laser_attention_enable` | 是否使能laser_attention | `false` | bool值, 如 true，false|
 | `--dit_distill_enable` | 是否使能蒸馏模型| `false` | bool值, 如 true，false|
 | `--dit_sparse_attention_enabled` | 是否使能稀疏attention| `false` | bool值, 如 true，false；与laser_attention互斥|

--- a/docs/src/content/docs/zh/design/generative_recommendation_design.md
+++ b/docs/src/content/docs/zh/design/generative_recommendation_design.md
@@ -281,7 +281,7 @@ xLLM 在 `backend=rec` 场景下提供了生成式推荐推理能力。其目标
 外部接入：
 - `xllm/c_api/rec.h`
 - `xllm/c_api/internal/rec.cpp`
-- `xllm/c_api/examples/simple_rec_completions.cpp`
+- `xllm/c_api/examples/test_query_rec_completions.cpp`
 
 服务入口：
 - `xllm/api_service/rec_completion_service_impl.cpp`
@@ -407,11 +407,11 @@ kernel / 算子热路径：
 - `xllm/c_api/internal/rec.cpp`
   - 这是真正的 CAPI 实现
   - 适合看 `.so` 模式下，request 参数是怎样被封装和转发的
-- `xllm/c_api/examples/simple_rec_completions.cpp`
-  - 是最短的调用示例
-  - 如果要给新人解释“动态库接入长什么样”，这里最直观
+- `xllm/c_api/examples/test_query_rec_completions.cpp`
+  - 是当前用于推荐 token-completion 请求的 C API 使用示例
+  - 适合跟踪动态库接入中的初始化与请求构造过程
 
-如果技术分享里想给一段“最小调用样例”，这一层最适合出现在开头。
+如果技术分享里需要给出一段 C API 使用示例，这一层最适合出现在开头。
 
 ### 8.2 从服务入口看统一分发
 

--- a/docs/src/content/docs/zh/dev_guide/tilelang_ascend_kernel_dev.md
+++ b/docs/src/content/docs/zh/dev_guide/tilelang_ascend_kernel_dev.md
@@ -209,7 +209,7 @@ class RopeKernel(TilelangKernel):
 - `DISPATCH_SCHEMA`
 - 每一项 `SPECIALIZATIONS`
 
-构建时，Ascend build 会根据主构建路径传入的 `--device a2|a3` 解析实际使用的 `bisheng_arch`。
+xLLM 的 `setup.py` 构建和测试命令使用 `--device npu` 选择 NPU 后端。与之不同，TileLang 的 `compile-kernels` 命令使用 `--device a2` 或 `a3` 选择 Ascend 架构并解析 `bisheng_arch`。
 
 ### 3.4 查看生成的 Ascend-C 源码
 
@@ -399,7 +399,7 @@ python xllm/compiler/tilelang_launcher.py compile-kernels \
   --output-root build/cmake.linux-aarch64-cpython-311/xllm/compiler/tilelang \
   --kernels rope
 
-python setup.py test --test-name rope_wrapper_test --device a3
+python setup.py test --test-name rope_wrapper_test --device npu
 ```
 
 第一条命令用于生成 `manifest.json`、`registry.inc` 和 object；第二条命令用于验证完整接入路径。


### PR DESCRIPTION
## Description

Correct stale documentation content so the bilingual guides, routes, CLI reference, and examples match the current implementation.

- Repair documentation language links and sidebar/cookbook routes for GLM-5.1, GLM-5.2, and Wan2.2.
- Align the CLI reference with native configuration precedence and current defaults for `max_seqs_per_batch`, `enable_mix_batch`, and block-copy kernels.
- Update the Wan2.2 recipe to use visible-device environment selection instead of the removed `--devices` flag.
- Distinguish xLLM backend selection (`setup.py --device npu`) from TileLang Ascend architecture selection (`compile-kernels --device a2|a3`).
- Point generative-recommendation documentation to the current C API usage example.

## Related Issues

None.

## Change Type

- [x] Documentation

## Pull Request Checklist

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

### Self Review

- [x] I have self-reviewed the documentation changes against their source definitions and referenced routes.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Validation

- `npm --prefix docs run check`
- `npm --prefix docs run build`
- Link, sidebar-route, localization-parity, and Wan2.2 shell-syntax audits
- `pre-commit run --from-ref origin/main --to-ref HEAD`

No accelerator build or test was run for this documentation-only change.

## Reviewer Notes

The native configuration precedence wording is intentionally scoped to native C++ configuration; it does not generalize launcher-owned settings such as service topology.