### PR TITLE
feat: restore linear-state slots in base step_for_schedule_overlap.

### DIFF
--- a/tests/core/runtime/mlu_linear_state_restore_worker_test.cpp
+++ b/tests/core/runtime/mlu_linear_state_restore_worker_test.cpp
@@ -155,7 +155,7 @@ class OverlapLinearStateRestoreWorker final : public LLMWorkerImpl {
     }
   }
 
-  std::optional<ForwardOutput> run_overlap_forward(const ForwardInput& input,
+  std::optional<ForwardOutput> run_overlap_forward(ForwardInput& input,
                                                    int64_t destination_slot) {
     forward_destination_slot_ = destination_slot;
     return step_for_schedule_overlap(input);

--- a/xllm/core/runtime/llm_worker_impl.cpp
+++ b/xllm/core/runtime/llm_worker_impl.cpp
@@ -222,20 +222,18 @@ LLMWorkerImpl::step_async_no_sync(const ForwardInput& input) {
 }
 
 std::optional<ForwardOutput> LLMWorkerImpl::step_for_schedule_overlap(
-    const ForwardInput& input) {
+    ForwardInput& input) {
   // Restore live recurrent-state slots from saved checkpoints here (worker
   // thread, on compute_stream_) instead of in prepare_work_before_execute on
   // prepare_stream_. The single-threaded worker pool guarantees the previous
   // chunk's forward kernels are already enqueued on compute_stream_ before
   // this task runs, so the restore copy is automatically stream-ordered
-  // after those writes without needing a cross-stream barrier.
-  if (has_linear_attention_layers(context_.get_model_args())) {
+  // after those writes without needing a cross-stream barrier. The forward
+  // below re-enters compute_stream_ inside execute_no_sync_on_stream, so the
+  // restore-time guard scope is deliberately kept tight to the restore only.
+  {
     c10::StreamGuard restore_guard = compute_stream_->set_stream_guard();
-    ModelInputParams& mutable_params =
-        const_cast<ModelInputParams&>(input.input_params);
-    restore_linear_state_slots(kv_caches_,
-                               mutable_params.linear_state_cache_ops,
-                               mutable_params.linear_state_validity_mask);
+    try_restore_linear_state_slots(input.input_params);
   }
   return execute_no_sync_on_stream(input, *compute_stream_);
 }

--- a/xllm/core/runtime/llm_worker_impl.cpp
+++ b/xllm/core/runtime/llm_worker_impl.cpp
@@ -229,9 +229,10 @@ std::optional<ForwardOutput> LLMWorkerImpl::step_for_schedule_overlap(
   // chunk's forward kernels are already enqueued on compute_stream_ before
   // this task runs, so the restore copy is automatically stream-ordered
   // after those writes without needing a cross-stream barrier. The forward
-  // below re-enters compute_stream_ inside execute_no_sync_on_stream, so the
-  // restore-time guard scope is deliberately kept tight to the restore only.
-  {
+  // below re-enters compute_stream_ inside execute_no_sync_on_stream (which
+  // installs its own StreamGuard on the same stream), so the restore-time
+  // guard scope is deliberately kept tight to the restore only.
+  if (has_linear_attention_layers(context_.get_model_args())) {
     c10::StreamGuard restore_guard = compute_stream_->set_stream_guard();
     try_restore_linear_state_slots(input.input_params);
   }

--- a/xllm/core/runtime/llm_worker_impl.h
+++ b/xllm/core/runtime/llm_worker_impl.h
@@ -64,7 +64,7 @@ class LLMWorkerImpl : public WorkerImpl {
 
  protected:
   std::optional<ForwardOutput> step_for_schedule_overlap(
-      const ForwardInput& input) override;
+      ForwardInput& input) override;
   ForwardInput update_input_by_last_step_output_for_schedule_overlap(
       ForwardInput& input) override;
 

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -761,14 +761,24 @@ std::optional<ForwardOutput> WorkerImpl::step_for_schedule_overlap(
   // there). Every non-speculative worker that owns a recurrent cache must
   // therefore perform the restore here, on compute_stream_ in the worker
   // thread, so chunk N's checkpoint copy is stream-ordered after chunk N-1's
-  // forward. LLMWorkerImpl overrides this to also drop the default-stream
-  // sync via execute_no_sync_on_stream; other frontends (VLMWorkerImpl,
-  // future model-impl paths) inherit this base version. The StreamGuard here
-  // brackets BOTH the restore and step(input) so the forward is guaranteed to
-  // read the just-restored slots even if compute_stream_ becomes a distinct
-  // pooled stream in the future.
-  c10::StreamGuard compute_guard = compute_stream_->set_stream_guard();
-  try_restore_linear_state_slots(input.input_params);
+  // forward. LLMWorkerImpl overrides this to drop the default-stream sync
+  // via execute_no_sync_on_stream; other frontends (VLMWorkerImpl, future
+  // model-impl paths) inherit this base version. Only enter compute_stream_
+  // when the model actually needs the restore -- dense frontends must keep
+  // running step() on their historical stream.
+  if (has_linear_attention_layers(context_.get_model_args())) {
+    // The StreamGuard here brackets BOTH the restore and step(input) so the
+    // forward is guaranteed to read the just-restored slots even if
+    // compute_stream_ becomes a distinct pooled stream in the future.
+    c10::StreamGuard compute_guard = compute_stream_->set_stream_guard();
+    // step() will run on compute_stream_ inside this guard, so wait on the
+    // event that publishes prepare_stream_'s H2D copies before either the
+    // restore or the forward observes them.
+    CHECK(compute_stream_->wait_event(input.metadata_ready_event))
+        << "failed to wait input metadata ready event on compute stream";
+    try_restore_linear_state_slots(input.input_params);
+    return step(input);
+  }
 #endif
   return step(input);
 }
@@ -966,6 +976,9 @@ void WorkerImpl::prepare_work_before_execute_on_stream(
 #if defined(USE_NPU) || defined(USE_MLU) || defined(USE_CUDA)
     if (has_linear_attention_layers(context_.get_model_args())) {
       prepare_input_params_for_linear_attention(input_params);
+      // Non-overlap path: restore on the current prepare_stream_ (installed
+      // by the outer StreamGuard) so the restore copy is ordered with the
+      // subsequent metadata_ready_event that the forward will wait on.
       // Under schedule_overlap chunked prefill the previous chunk's forward
       // runs on compute_stream_ from a worker thread that may not have
       // enqueued its kernels yet when this prepare runs on the main thread.

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -409,8 +409,8 @@ bool WorkerImpl::allocate_kv_cache_storage(
   const bool enable_linear_attention = has_linear_attention_layers(args);
   const bool enable_lighting_indexer = args.index_n_heads() > 0;
   // A model may be BOTH linear-attention (KDA layers) AND have a lighting
-  // indexer (DSA layers) — e.g. glm5_3_flash. create_kv_cache_impl dispatches ONE
-  // impl per layer, each reading only its own shape, so coexistence is
+  // indexer (DSA layers) — e.g. glm5_3_flash. create_kv_cache_impl dispatches
+  // ONE impl per layer, each reading only its own shape, so coexistence is
   // harmless. The prior exclusivity CHECK guarded a non-problem.
 
   const int64_t num_layers = get_num_layers();
@@ -732,12 +732,32 @@ ForwardInput WorkerImpl::update_input_by_last_step_output(
 
 std::optional<ForwardOutput> WorkerImpl::step_for_schedule_overlap(
     const ForwardInput& input) {
-  // No linear-state restore here on purpose. LLMWorkerImpl overrides this to
-  // copy checkpoints on compute_stream_; speculative/MTP workers keep this base
-  // version but run every forward through an inner LLMWorkerImpl built with
-  // schedule-overlap off, so the checkpoint copy fires on that inner worker's
-  // non-overlap prepare_work_before_execute_on_stream path. The outer
-  // speculative worker owns no kv_caches_, so restoring here would be a no-op.
+#if defined(USE_NPU) || defined(USE_MLU) || defined(USE_CUDA)
+  // prepare_work_before_execute_on_stream defers the linear-state restore
+  // whenever schedule overlap is on (see the enable_schedule_overlap() gate
+  // there). Every non-speculative worker that owns a recurrent cache must
+  // therefore perform the restore here, on compute_stream_ in the worker
+  // thread, so chunk N's checkpoint copy is stream-ordered after chunk N-1's
+  // forward. LLMWorkerImpl overrides this to also drop the default-stream
+  // sync via execute_no_sync_on_stream; other frontends (VLMWorkerImpl,
+  // future model-impl paths) inherit this base version and still need the
+  // restore. Speculative/MTP outer workers own no kv_caches_ and fall through
+  // to the owns_recurrent_cache guard.
+  if (has_linear_attention_layers(context_.get_model_args())) {
+    const bool owns_recurrent_cache = std::any_of(
+        kv_caches_.begin(), kv_caches_.end(), [](const KVCache& kv_cache) {
+          return kv_cache.get_ssm_cache().defined();
+        });
+    if (owns_recurrent_cache && compute_stream_) {
+      c10::StreamGuard restore_guard = compute_stream_->set_stream_guard();
+      ModelInputParams& mutable_params =
+          const_cast<ModelInputParams&>(input.input_params);
+      restore_linear_state_slots(kv_caches_,
+                                 mutable_params.linear_state_cache_ops,
+                                 mutable_params.linear_state_validity_mask);
+    }
+  }
+#endif
   return step(input);
 }
 

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -730,8 +730,31 @@ ForwardInput WorkerImpl::update_input_by_last_step_output(
   return inputs;
 }
 
+void WorkerImpl::try_restore_linear_state_slots(ModelInputParams& params) {
+#if defined(USE_NPU) || defined(USE_MLU) || defined(USE_CUDA)
+  if (!has_linear_attention_layers(context_.get_model_args())) {
+    return;
+  }
+  // A composite worker (e.g. MTPWorkerImpl) carries the TARGET model args but
+  // never allocates its own kv_caches_ — its inner impls each own caches and
+  // run their own restore. Skip the restore when this worker holds no
+  // recurrent cache; restoring into an unallocated pool is a hard CHECK
+  // inside restore_linear_state_slots.
+  const bool owns_recurrent_cache = std::any_of(
+      kv_caches_.begin(), kv_caches_.end(), [](const KVCache& kv_cache) {
+        return kv_cache.get_ssm_cache().defined();
+      });
+  if (!owns_recurrent_cache) {
+    return;
+  }
+  restore_linear_state_slots(kv_caches_,
+                             params.linear_state_cache_ops,
+                             params.linear_state_validity_mask);
+#endif
+}
+
 std::optional<ForwardOutput> WorkerImpl::step_for_schedule_overlap(
-    const ForwardInput& input) {
+    ForwardInput& input) {
 #if defined(USE_NPU) || defined(USE_MLU) || defined(USE_CUDA)
   // prepare_work_before_execute_on_stream defers the linear-state restore
   // whenever schedule overlap is on (see the enable_schedule_overlap() gate
@@ -740,23 +763,12 @@ std::optional<ForwardOutput> WorkerImpl::step_for_schedule_overlap(
   // thread, so chunk N's checkpoint copy is stream-ordered after chunk N-1's
   // forward. LLMWorkerImpl overrides this to also drop the default-stream
   // sync via execute_no_sync_on_stream; other frontends (VLMWorkerImpl,
-  // future model-impl paths) inherit this base version and still need the
-  // restore. Speculative/MTP outer workers own no kv_caches_ and fall through
-  // to the owns_recurrent_cache guard.
-  if (has_linear_attention_layers(context_.get_model_args())) {
-    const bool owns_recurrent_cache = std::any_of(
-        kv_caches_.begin(), kv_caches_.end(), [](const KVCache& kv_cache) {
-          return kv_cache.get_ssm_cache().defined();
-        });
-    if (owns_recurrent_cache && compute_stream_) {
-      c10::StreamGuard restore_guard = compute_stream_->set_stream_guard();
-      ModelInputParams& mutable_params =
-          const_cast<ModelInputParams&>(input.input_params);
-      restore_linear_state_slots(kv_caches_,
-                                 mutable_params.linear_state_cache_ops,
-                                 mutable_params.linear_state_validity_mask);
-    }
-  }
+  // future model-impl paths) inherit this base version. The StreamGuard here
+  // brackets BOTH the restore and step(input) so the forward is guaranteed to
+  // read the just-restored slots even if compute_stream_ becomes a distinct
+  // pooled stream in the future.
+  c10::StreamGuard compute_guard = compute_stream_->set_stream_guard();
+  try_restore_linear_state_slots(input.input_params);
 #endif
   return step(input);
 }
@@ -954,25 +966,14 @@ void WorkerImpl::prepare_work_before_execute_on_stream(
 #if defined(USE_NPU) || defined(USE_MLU) || defined(USE_CUDA)
     if (has_linear_attention_layers(context_.get_model_args())) {
       prepare_input_params_for_linear_attention(input_params);
-      // A composite worker (e.g. MTPWorkerImpl) carries the TARGET model args
-      // but never allocates its own kv_caches_ — its inner impls each own
-      // caches and run their own restore. Skip the restore when this worker
-      // holds no recurrent cache; restoring into an unallocated pool is a
-      // hard CHECK inside restore_linear_state_slots.
-      const bool owns_recurrent_cache = std::any_of(
-          kv_caches_.begin(), kv_caches_.end(), [](const KVCache& kv_cache) {
-            return kv_cache.get_ssm_cache().defined();
-          });
       // Under schedule_overlap chunked prefill the previous chunk's forward
       // runs on compute_stream_ from a worker thread that may not have
       // enqueued its kernels yet when this prepare runs on the main thread.
       // Defer the slot-restore copy to step_for_schedule_overlap (worker
       // thread, on compute_stream_) so stream ordering between chunk N-1
       // writes and chunk N restore is automatic.
-      if (!enable_schedule_overlap() && owns_recurrent_cache) {
-        restore_linear_state_slots(kv_caches_,
-                                   input_params.linear_state_cache_ops,
-                                   input_params.linear_state_validity_mask);
+      if (!enable_schedule_overlap()) {
+        try_restore_linear_state_slots(input_params);
       }
     }
 #endif

--- a/xllm/core/runtime/worker_impl.h
+++ b/xllm/core/runtime/worker_impl.h
@@ -221,9 +221,17 @@ class WorkerImpl {
  protected:
   void update_last_step_output(const std::optional<ForwardOutput>& output);
   virtual std::optional<ForwardOutput> step_for_schedule_overlap(
-      const ForwardInput& input);
+      ForwardInput& input);
   virtual ForwardInput update_input_by_last_step_output_for_schedule_overlap(
       ForwardInput& input);
+  // Restore recurrent-state slots for linear-attention models on the current
+  // stream. No-op when the model has no linear-attention layers OR this worker
+  // owns no recurrent kv_cache (e.g., MTP outer worker carrying target args).
+  // The caller must install the desired stream (compute_stream_ in the
+  // schedule-overlap path, prepare_stream_ in the non-overlap path) before
+  // invoking; ordering between the previous chunk's forward and this restore
+  // then falls out of the stream FIFO.
+  void try_restore_linear_state_slots(ModelInputParams& params);
   // Only used for deepseek chunked prefill ops on npu device
   void prepare_mla_prefixcache_inputs(ModelInputParams& input_params);
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
