### PR TITLE
feat: derive openai json ids from the shared client request id.

### DIFF
--- a/tests/api_service/request_id_test.cpp
+++ b/tests/api_service/request_id_test.cpp
@@ -24,6 +24,7 @@ limitations under the License.
 #include "api_service/non_stream_call.h"
 #include "chat.pb.h"
 #include "completion.pb.h"
+#include "core/common/instance_name.h"
 
 namespace xllm {
 namespace {
@@ -35,6 +36,20 @@ class NoopClosure final : public google::protobuf::Closure {
 
 using CompletionCallForTest =
     NonStreamCall<proto::CompletionRequest, proto::CompletionResponse>;
+
+using ChatCallForTest = NonStreamCall<proto::ChatRequest, proto::ChatResponse>;
+
+bool is_generated_numeric_id(const std::string& value) {
+  if (value.empty()) {
+    return false;
+  }
+  for (char character : value) {
+    if (character < '0' || character > '9') {
+      return false;
+    }
+  }
+  return true;
+}
 
 TEST(RequestIdTest, HeaderTakesPrecedenceOverBody) {
   brpc::Controller controller;
@@ -73,6 +88,78 @@ TEST(RequestIdTest, BodyIsUsedWhenHeaderIsMissing) {
   EXPECT_EQ(call.get_x_request_id(), "body-id");
   ASSERT_NE(controller.http_response().GetHeader("x-request-id"), nullptr);
   EXPECT_EQ(*controller.http_response().GetHeader("x-request-id"), "body-id");
+}
+
+TEST(RequestIdTest, ProtoRequestIdIsUsedWhenHeaderAndXRequestIdAreMissing) {
+  brpc::Controller controller;
+  proto::CompletionRequest request;
+  request.set_request_id("proto-id");
+  proto::CompletionResponse response;
+  NoopClosure done;
+
+  CompletionCallForTest call(&controller,
+                             &done,
+                             &request,
+                             &response,
+                             /*use_arena=*/true,
+                             /*is_http_request=*/true);
+
+  EXPECT_EQ(call.get_x_request_id(), "proto-id");
+  ASSERT_NE(controller.http_response().GetHeader("x-request-id"), nullptr);
+  EXPECT_EQ(*controller.http_response().GetHeader("x-request-id"), "proto-id");
+}
+
+TEST(RequestIdTest, HeaderTakesPrecedenceOverProtoRequestId) {
+  brpc::Controller controller;
+  controller.http_request().SetHeader("x-request-id", "header-id");
+  proto::CompletionRequest request;
+  request.set_request_id("proto-id");
+  proto::CompletionResponse response;
+  NoopClosure done;
+
+  CompletionCallForTest call(&controller,
+                             &done,
+                             &request,
+                             &response,
+                             /*use_arena=*/true,
+                             /*is_http_request=*/true);
+
+  EXPECT_EQ(call.get_x_request_id(), "header-id");
+}
+
+TEST(RequestIdTest, BodyXRequestIdTakesPrecedenceOverProtoRequestId) {
+  brpc::Controller controller;
+  proto::CompletionRequest request;
+  request.set_x_request_id("body-x-id");
+  request.set_request_id("proto-id");
+  proto::CompletionResponse response;
+  NoopClosure done;
+
+  CompletionCallForTest call(&controller,
+                             &done,
+                             &request,
+                             &response,
+                             /*use_arena=*/true,
+                             /*is_http_request=*/true);
+
+  EXPECT_EQ(call.get_x_request_id(), "body-x-id");
+}
+
+TEST(RequestIdTest, ChatProtoRequestIdIsUsedWhenXRequestIdIsMissing) {
+  brpc::Controller controller;
+  proto::ChatRequest request;
+  request.set_request_id("chat-proto-id");
+  proto::ChatResponse response;
+  NoopClosure done;
+
+  ChatCallForTest call(&controller,
+                       &done,
+                       &request,
+                       &response,
+                       /*use_arena=*/true,
+                       /*is_http_request=*/true);
+
+  EXPECT_EQ(call.get_x_request_id(), "chat-proto-id");
 }
 
 TEST(RequestIdTest, InvalidPrimaryHeaderFallsBackToSecondaryHeader) {
@@ -115,7 +202,7 @@ TEST(RequestIdTest, InvalidHeadersAreReplacedBeforeResponseHeader) {
                              /*use_arena=*/true,
                              /*is_http_request=*/true);
 
-  EXPECT_EQ(call.get_x_request_id().find("req-"), 0);
+  EXPECT_TRUE(is_generated_numeric_id(call.get_x_request_id()));
   EXPECT_NE(call.get_x_request_id(), invalid_primary_id);
   EXPECT_NE(call.get_x_request_id(), invalid_secondary_id);
   ASSERT_NE(controller.http_response().GetHeader("x-request-id"), nullptr);
@@ -158,7 +245,7 @@ TEST(RequestIdTest, MissingIdIsGeneratedAndReturned) {
                              /*use_arena=*/true,
                              /*is_http_request=*/true);
 
-  EXPECT_EQ(call.get_x_request_id().find("req-"), 0);
+  EXPECT_TRUE(is_generated_numeric_id(call.get_x_request_id()));
   ASSERT_NE(controller.http_response().GetHeader("x-request-id"), nullptr);
   EXPECT_EQ(*controller.http_response().GetHeader("x-request-id"),
             call.get_x_request_id());
@@ -178,7 +265,7 @@ TEST(RequestIdTest, InvalidBodyIdIsReplacedBeforeResponseHeader) {
                              /*use_arena=*/true,
                              /*is_http_request=*/true);
 
-  EXPECT_EQ(call.get_x_request_id().find("req-"), 0);
+  EXPECT_TRUE(is_generated_numeric_id(call.get_x_request_id()));
   EXPECT_EQ(call.get_x_request_id().find('\r'), std::string::npos);
   EXPECT_EQ(call.get_x_request_id().find('\n'), std::string::npos);
 }
@@ -220,15 +307,112 @@ TEST(RequestIdTest, EarlyHttpIdSurvivesSetFailed) {
 TEST(RequestIdTest, ExtractsIdFromSupportedRequestBodies) {
   proto::CompletionRequest completion;
   completion.set_x_request_id("completion-id");
-  EXPECT_EQ(request_body_x_request_id(&completion), "completion-id");
+  EXPECT_EQ(api_service::request_body_x_request_id(&completion),
+            "completion-id");
 
   proto::ChatRequest chat;
   chat.set_x_request_id("chat-id");
-  EXPECT_EQ(request_body_x_request_id(&chat), "chat-id");
+  EXPECT_EQ(api_service::request_body_x_request_id(&chat), "chat-id");
+
+  proto::ChatRequest chat_request_id_only;
+  chat_request_id_only.set_request_id("chat-request-id");
+  EXPECT_EQ(api_service::request_body_x_request_id(&chat_request_id_only),
+            "chat-request-id");
+
+  proto::ChatRequest chat_prefers_x_request_id;
+  chat_prefers_x_request_id.set_x_request_id("chat-x-id");
+  chat_prefers_x_request_id.set_request_id("chat-request-id");
+  EXPECT_EQ(api_service::request_body_x_request_id(&chat_prefers_x_request_id),
+            "chat-x-id");
 
   proto::AnthropicMessagesRequest anthropic;
   anthropic.set_x_request_id("anthropic-id");
-  EXPECT_EQ(request_body_x_request_id(&anthropic), "anthropic-id");
+  EXPECT_EQ(api_service::request_body_x_request_id(&anthropic), "anthropic-id");
+}
+
+TEST(RequestIdTest, EnsureReusesExistingValidResponseHeader) {
+  brpc::Controller controller;
+  controller.http_response().SetHeader("x-request-id", "already-set");
+  EXPECT_EQ(api_service::ensure_http_x_request_id(&controller), "already-set");
+  ASSERT_NE(controller.http_response().GetHeader("x-request-id"), nullptr);
+  EXPECT_EQ(*controller.http_response().GetHeader("x-request-id"),
+            "already-set");
+}
+
+TEST(RequestIdTest, EnsureReplacesInvalidResponseHeader) {
+  brpc::Controller controller;
+  controller.http_response().SetHeader("x-request-id", "bad\nid");
+  const std::string x_request_id =
+      api_service::ensure_http_x_request_id(&controller);
+  EXPECT_TRUE(is_generated_numeric_id(x_request_id));
+  EXPECT_EQ(x_request_id.find('\n'), std::string::npos);
+  ASSERT_NE(controller.http_response().GetHeader("x-request-id"), nullptr);
+  EXPECT_EQ(*controller.http_response().GetHeader("x-request-id"),
+            x_request_id);
+}
+
+TEST(RequestIdTest, HttpGuardFillsResponseHeaderWhenCallIsMissing) {
+  brpc::Controller controller;
+  {
+    api_service::HttpXRequestIdGuard x_request_id_guard(&controller);
+  }
+  ASSERT_NE(controller.http_response().GetHeader("x-request-id"), nullptr);
+  EXPECT_TRUE(is_generated_numeric_id(
+      *controller.http_response().GetHeader("x-request-id")));
+}
+
+TEST(RequestIdTest, HttpGuardKeepsCallResolvedBodyId) {
+  brpc::Controller controller;
+  proto::CompletionRequest request;
+  request.set_x_request_id("body-id");
+  proto::CompletionResponse response;
+  NoopClosure done;
+
+  CompletionCallForTest call(&controller,
+                             &done,
+                             &request,
+                             &response,
+                             /*use_arena=*/true,
+                             /*is_http_request=*/true);
+  {
+    api_service::HttpXRequestIdGuard x_request_id_guard(&controller);
+  }
+
+  EXPECT_EQ(call.get_x_request_id(), "body-id");
+  ASSERT_NE(controller.http_response().GetHeader("x-request-id"), nullptr);
+  EXPECT_EQ(*controller.http_response().GetHeader("x-request-id"), "body-id");
+}
+
+TEST(RequestIdTest, ReadsRequestTimeFromPrimaryThenFallbackHeader) {
+  brpc::Controller primary;
+  primary.http_request().SetHeader("x-request-time", "1000");
+  EXPECT_EQ(api_service::get_header_x_request_time(&primary), "1000");
+
+  brpc::Controller fallback;
+  fallback.http_request().SetHeader("x-request-timems", "2000");
+  EXPECT_EQ(api_service::get_header_x_request_time(&fallback), "2000");
+}
+
+TEST(RequestIdTest, NextRequestIdIsUniqueInt64) {
+  const int64_t first = next_request_id();
+  const int64_t second = next_request_id();
+  EXPECT_NE(first, second);
+}
+
+TEST(RequestIdTest, GenerateRequestIdEncodesNumericIdOnce) {
+  const std::string first = generate_request_id("cmpl-");
+  const std::string second = generate_request_id("cmpl-");
+  EXPECT_EQ(first.find("cmpl-"), 0);
+  EXPECT_EQ(second.find("cmpl-"), 0);
+  EXPECT_NE(first, second);
+
+  const std::string suffix = first.substr(5);
+  EXPECT_TRUE(is_generated_numeric_id(suffix));
+}
+
+TEST(RequestIdTest, GenerateRequestIdWithoutPrefixIsNumeric) {
+  const std::string generated = generate_request_id(/*prefix=*/"");
+  EXPECT_TRUE(is_generated_numeric_id(generated));
 }
 
 }  // namespace

--- a/tests/api_service/sample_service_impl_test.cpp
+++ b/tests/api_service/sample_service_impl_test.cpp
@@ -225,6 +225,17 @@ TEST(SampleServiceImplTest,
   EXPECT_EQ(params.sample_slots[1].token_position, 3);
 }
 
+TEST(SampleServiceImplTest,
+     BuildRequestParamsPrefixesGeneratedIdWithXRequestId) {
+  CharTokenizer tokenizer;
+  auto request = make_valid_request();
+
+  RequestParams params;
+  ASSERT_TRUE(sample_service_internal::build_request_params(
+      request, tokenizer, &params, /*x_request_id=*/"client-id"));
+  EXPECT_EQ(params.request_id, "sample-client-id");
+}
+
 TEST(SampleServiceImplTest, BuildRequestParamsRejectsUnstableLiteralToken) {
   UnstableLiteralTokenizer tokenizer;
   auto request = make_valid_request();

--- a/tests/core/framework/request/request_params_test.cpp
+++ b/tests/core/framework/request/request_params_test.cpp
@@ -18,6 +18,8 @@ limitations under the License.
 #include <google/protobuf/util/json_util.h>
 #include <gtest/gtest.h>
 
+#include <string>
+
 #include "anthropic.pb.h"
 #include "chat.pb.h"
 #include "completion.pb.h"
@@ -307,6 +309,67 @@ TEST(RequestParamsTest, AnthropicToolSchemaUsesPlainJson) {
   nlohmann::json expected_tool_choice = {
       {"type", "function"}, {"function", {{"name", "list_files"}}}};
   EXPECT_EQ(nlohmann::json::parse(params.tool_choice), expected_tool_choice);
+}
+
+TEST(RequestParamsTest, CompletionUsesXRequestIdAsOpenAiJsonIdSuffix) {
+  proto::CompletionRequest request;
+  RequestParams params(request, /*x_rid=*/"client-id", /*x_rtime=*/"");
+
+  EXPECT_EQ(params.x_request_id, "client-id");
+  EXPECT_EQ(params.request_id, "cmpl-client-id");
+}
+
+TEST(RequestParamsTest, CompletionUsesBodyRequestIdAsOpenAiJsonIdSuffix) {
+  proto::CompletionRequest request;
+  request.set_request_id("proto-id");
+  RequestParams params(request, /*x_rid=*/"", /*x_rtime=*/"");
+
+  EXPECT_EQ(params.x_request_id, "proto-id");
+  EXPECT_EQ(params.request_id, "cmpl-proto-id");
+}
+
+TEST(RequestParamsTest, CompletionGeneratesSharedNumericBaseId) {
+  proto::CompletionRequest request;
+  RequestParams params(request, /*x_rid=*/"", /*x_rtime=*/"");
+
+  EXPECT_FALSE(params.x_request_id.empty());
+  EXPECT_EQ(params.request_id, std::string("cmpl-") + params.x_request_id);
+}
+
+TEST(RequestParamsTest, ChatUsesBodyRequestIdAsOpenAiJsonIdSuffix) {
+  proto::ChatRequest request;
+  request.set_request_id("client-id");
+  RequestParams params(request, /*x_rid=*/"", /*x_rtime=*/"");
+
+  EXPECT_EQ(params.x_request_id, "client-id");
+  EXPECT_EQ(params.request_id, "chatcmpl-client-id");
+}
+
+TEST(RequestParamsTest, ChatHeaderIdWinsOverBodyRequestId) {
+  proto::ChatRequest request;
+  request.set_request_id("body-id");
+  RequestParams params(request, /*x_rid=*/"header-id", /*x_rtime=*/"");
+
+  EXPECT_EQ(params.x_request_id, "header-id");
+  EXPECT_EQ(params.request_id, "chatcmpl-header-id");
+}
+
+TEST(RequestParamsTest, ChatBodyXRequestIdWinsOverBodyRequestId) {
+  proto::ChatRequest request;
+  request.set_x_request_id("x-id");
+  request.set_request_id("body-id");
+  RequestParams params(request, /*x_rid=*/"", /*x_rtime=*/"");
+
+  EXPECT_EQ(params.x_request_id, "x-id");
+  EXPECT_EQ(params.request_id, "chatcmpl-x-id");
+}
+
+TEST(RequestParamsTest, ChatAlwaysPrefixesOpenAiJsonId) {
+  proto::ChatRequest request;
+  RequestParams params(request, /*x_rid=*/"chatcmpl-already", /*x_rtime=*/"");
+
+  EXPECT_EQ(params.x_request_id, "chatcmpl-already");
+  EXPECT_EQ(params.request_id, "chatcmpl-chatcmpl-already");
 }
 
 }  // namespace

--- a/xllm/api_service/api_service.cpp
+++ b/xllm/api_service/api_service.cpp
@@ -200,7 +200,7 @@ void APIService::CompletionsHttp(::google::protobuf::RpcController* controller,
       google::protobuf::Arena::CreateMessage<proto::CompletionResponse>(arena);
 
   auto ctrl = reinterpret_cast<brpc::Controller*>(controller);
-  api_service::ensure_http_x_request_id(ctrl);
+  api_service::HttpXRequestIdGuard x_request_id_guard(ctrl);
 
   auto [preprocess_status, processed_json] =
       preprocess_completion_prompt(ctrl->request_attachment().to_string());
@@ -279,7 +279,7 @@ void APIService::SampleHttp(::google::protobuf::RpcController* controller,
   }
 
   auto ctrl = reinterpret_cast<brpc::Controller*>(controller);
-  api_service::ensure_http_x_request_id(ctrl);
+  api_service::HttpXRequestIdGuard x_request_id_guard(ctrl);
   if (!sample_service_impl_) {
     ctrl->SetFailed(kSampleNotSupportedError);
     return;
@@ -455,7 +455,7 @@ void APIService::ChatCompletionsHttp(
   }
 
   auto ctrl = reinterpret_cast<brpc::Controller*>(controller);
-  api_service::ensure_http_x_request_id(ctrl);
+  api_service::HttpXRequestIdGuard x_request_id_guard(ctrl);
 
   if (!chat_completions_handler_) {
     LOG(ERROR) << "No chat completions handler registered";
@@ -528,7 +528,7 @@ void handle_embedding_request(std::unique_ptr<Service>& embedding_service_impl_,
           arena);
 
   auto ctrl = reinterpret_cast<brpc::Controller*>(controller);
-  api_service::ensure_http_x_request_id(ctrl);
+  api_service::HttpXRequestIdGuard x_request_id_guard(ctrl);
   std::string error;
   json2pb::Json2PbOptions options;
   butil::IOBuf& buf = ctrl->request_attachment();
@@ -607,7 +607,7 @@ void APIService::ImageGenerationHttp(
           arena);
 
   auto ctrl = reinterpret_cast<brpc::Controller*>(controller);
-  api_service::ensure_http_x_request_id(ctrl);
+  api_service::HttpXRequestIdGuard x_request_id_guard(ctrl);
   std::string error;
   json2pb::Json2PbOptions options;
   butil::IOBuf& buf = ctrl->request_attachment();
@@ -666,7 +666,7 @@ void APIService::AudioGenerationHttp(
           arena);
 
   brpc::Controller* ctrl = static_cast<brpc::Controller*>(controller);
-  api_service::ensure_http_x_request_id(ctrl);
+  api_service::HttpXRequestIdGuard x_request_id_guard(ctrl);
   std::string error;
   json2pb::Json2PbOptions options;
   butil::IOBuf& buf = ctrl->request_attachment();
@@ -725,7 +725,7 @@ void APIService::TextGenerationHttp(
           arena);
 
   brpc::Controller* ctrl = static_cast<brpc::Controller*>(controller);
-  api_service::ensure_http_x_request_id(ctrl);
+  api_service::HttpXRequestIdGuard x_request_id_guard(ctrl);
   std::string error;
   json2pb::Json2PbOptions options;
   butil::IOBuf& buf = ctrl->request_attachment();
@@ -784,7 +784,7 @@ void APIService::VideoGenerationHttp(
           arena);
 
   auto ctrl = reinterpret_cast<brpc::Controller*>(controller);
-  api_service::ensure_http_x_request_id(ctrl);
+  api_service::HttpXRequestIdGuard x_request_id_guard(ctrl);
   std::string error;
   json2pb::Json2PbOptions options;
   butil::IOBuf& buf = ctrl->request_attachment();
@@ -835,7 +835,7 @@ void APIService::RerankHttp(::google::protobuf::RpcController* controller,
       google::protobuf::Arena::CreateMessage<proto::RerankResponse>(arena);
 
   auto ctrl = reinterpret_cast<brpc::Controller*>(controller);
-  api_service::ensure_http_x_request_id(ctrl);
+  api_service::HttpXRequestIdGuard x_request_id_guard(ctrl);
   std::string error;
   json2pb::Json2PbOptions options;
   butil::IOBuf& buf = ctrl->request_attachment();
@@ -1000,7 +1000,7 @@ void APIService::AnthropicMessagesHttp(
   }
 
   auto ctrl = reinterpret_cast<brpc::Controller*>(controller);
-  api_service::ensure_http_x_request_id(ctrl);
+  api_service::HttpXRequestIdGuard x_request_id_guard(ctrl);
 
   if (anthropic_service_impl_) {
     handle_anthropic_messages(

--- a/xllm/api_service/call.cpp
+++ b/xllm/api_service/call.cpp
@@ -13,7 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "call.h"
+#include "api_service/call.h"
+
+#include <utility>
 
 #include "api_service/request_id.h"
 #include "core/common/constants.h"
@@ -29,13 +31,7 @@ Call::Call(brpc::Controller* controller,
 }
 
 void Call::init(std::string body_x_request_id, bool is_http_request) {
-  if (controller_->http_request().GetHeader("x-request-time")) {
-    x_request_time_ = *controller_->http_request().GetHeader("x-request-time");
-  } else if (controller_->http_request().GetHeader("x-request-timems")) {
-    x_request_time_ =
-        *controller_->http_request().GetHeader("x-request-timems");
-  }
-
+  x_request_time_ = api_service::get_header_x_request_time(controller_);
   x_request_id_ =
       api_service::resolve_x_request_id(controller_, body_x_request_id);
   if (is_http_request) {

--- a/xllm/api_service/call.h
+++ b/xllm/api_service/call.h
@@ -22,19 +22,6 @@ limitations under the License.
 
 namespace xllm {
 
-template <typename Request>
-std::string request_body_x_request_id(const Request* request) {
-  if constexpr (requires(const Request& value) {
-                  value.has_x_request_id();
-                  value.x_request_id();
-                }) {
-    if (request != nullptr && request->has_x_request_id()) {
-      return request->x_request_id();
-    }
-  }
-  return "";
-}
-
 class Call {
  public:
   Call(brpc::Controller* controller,

--- a/xllm/api_service/non_stream_call.h
+++ b/xllm/api_service/non_stream_call.h
@@ -25,7 +25,8 @@ limitations under the License.
 #include <optional>
 #include <string>
 
-#include "call.h"
+#include "api_service/call.h"
+#include "api_service/request_id.h"
 #include "core/common/types.h"
 #include "core/util/verbose_trace_logger.h"
 
@@ -42,7 +43,9 @@ class NonStreamCall : public Call {
                 Response* response,
                 bool use_arena = false,
                 bool is_http_request = false)
-      : Call(controller, request_body_x_request_id(request), is_http_request),
+      : Call(controller,
+             api_service::request_body_x_request_id(request),
+             is_http_request),
         done_(done),
         request_(request),
         response_(response),

--- a/xllm/api_service/request_id.cpp
+++ b/xllm/api_service/request_id.cpp
@@ -20,7 +20,6 @@ limitations under the License.
 #include <string_view>
 
 #include "core/common/instance_name.h"
-#include "core/util/uuid.h"
 
 namespace xllm::api_service {
 
@@ -68,10 +67,27 @@ std::string get_header_x_request_id(const brpc::Controller* controller) {
   return x_request_id;
 }
 
+std::string get_header_x_request_time(const brpc::Controller* controller) {
+  if (controller == nullptr) {
+    return "";
+  }
+
+  const std::string* request_time =
+      controller->http_request().GetHeader("x-request-time");
+  if (request_time != nullptr) {
+    return *request_time;
+  }
+  const std::string* request_time_ms =
+      controller->http_request().GetHeader("x-request-timems");
+  if (request_time_ms != nullptr) {
+    return *request_time_ms;
+  }
+  return "";
+}
+
+// Bare numeric id shared by the HTTP header and OpenAI JSON id suffix.
 std::string generate_x_request_id() {
-  thread_local ShortUUID short_uuid;
-  return "req-" + InstanceName::name()->get_name_hash() + "-" +
-         short_uuid.random();
+  return generate_request_id(/*prefix=*/"");
 }
 
 std::string resolve_x_request_id(const brpc::Controller* controller,
@@ -94,7 +110,12 @@ std::string ensure_http_x_request_id(brpc::Controller* controller) {
   if (controller == nullptr) {
     return generate_x_request_id();
   }
-  std::string x_request_id = resolve_x_request_id(controller);
+  std::string x_request_id =
+      get_valid_header(controller->http_response(), "x-request-id");
+  if (!x_request_id.empty()) {
+    return x_request_id;
+  }
+  x_request_id = resolve_x_request_id(controller);
   controller->http_response().SetHeader("x-request-id", x_request_id);
   return x_request_id;
 }

--- a/xllm/api_service/request_id.h
+++ b/xllm/api_service/request_id.h
@@ -22,9 +22,35 @@ limitations under the License.
 
 namespace xllm::api_service {
 
+template <typename Request>
+std::string request_body_x_request_id(const Request* request) {
+  if (request == nullptr) {
+    return "";
+  }
+  if constexpr (requires(const Request& value) {
+                  value.has_x_request_id();
+                  value.x_request_id();
+                }) {
+    if (request->has_x_request_id() && !request->x_request_id().empty()) {
+      return request->x_request_id();
+    }
+  }
+  if constexpr (requires(const Request& value) {
+                  value.has_request_id();
+                  value.request_id();
+                }) {
+    if (request->has_request_id() && !request->request_id().empty()) {
+      return request->request_id();
+    }
+  }
+  return "";
+}
+
 bool is_valid_x_request_id(std::string_view x_request_id);
 
 std::string get_header_x_request_id(const brpc::Controller* controller);
+
+std::string get_header_x_request_time(const brpc::Controller* controller);
 
 std::string generate_x_request_id();
 
@@ -32,6 +58,27 @@ std::string resolve_x_request_id(
     const brpc::Controller* controller,
     std::string_view body_x_request_id = std::string_view{});
 
+// Sets the HTTP response x-request-id if it is not already a valid value.
+// Reuses a header already written by Call, otherwise resolves inbound headers
+// and generates an id only when none is available.
 std::string ensure_http_x_request_id(brpc::Controller* controller);
+
+// Ensures the HTTP response has an x-request-id when the handler returns
+// without constructing a Call (parse errors, missing services, etc.).
+class HttpXRequestIdGuard final {
+ public:
+  explicit HttpXRequestIdGuard(brpc::Controller* controller)
+      : controller_(controller) {}
+
+  ~HttpXRequestIdGuard() { ensure_http_x_request_id(controller_); }
+
+  HttpXRequestIdGuard(const HttpXRequestIdGuard&) = delete;
+  HttpXRequestIdGuard& operator=(const HttpXRequestIdGuard&) = delete;
+  HttpXRequestIdGuard(HttpXRequestIdGuard&&) = delete;
+  HttpXRequestIdGuard& operator=(HttpXRequestIdGuard&&) = delete;
+
+ private:
+  brpc::Controller* controller_;
+};
 
 }  // namespace xllm::api_service

--- a/xllm/api_service/sample_service_impl.cpp
+++ b/xllm/api_service/sample_service_impl.cpp
@@ -23,23 +23,16 @@ limitations under the License.
 #include <condition_variable>
 #include <mutex>
 
-#include "common/instance_name.h"
+#include "core/common/instance_name.h"
 #include "core/distributed_runtime/llm_master.h"
 #include "core/framework/request/request_output.h"
 #include "core/framework/request/request_params.h"
 #include "core/framework/request/sample_slot.h"
-#include "core/util/uuid.h"
 
 namespace xllm {
 namespace {
-thread_local ShortUUID short_uuid;
 const std::string kSelectorMatchFinishReason = "selector_match";
 const std::string kEmptyLogprobsFinishReason = "empty_logprobs";
-
-std::string generate_sample_request_id() {
-  return "sample-" + InstanceName::name()->get_name_hash() + "-" +
-         short_uuid.random();
-}
 
 void initialize_response(const std::string& request_id,
                          const std::string& model,
@@ -161,14 +154,20 @@ Status validate_runtime_config(bool enable_schedule_overlap) {
 
 bool build_request_params(const proto::SampleRequest& request,
                           const Tokenizer& tokenizer,
-                          RequestParams* request_params) {
+                          RequestParams* request_params,
+                          const std::string& x_request_id) {
   if (request_params == nullptr) {
     return false;
   }
 
   RequestParams params;
-  params.request_id = request.has_request_id() ? request.request_id()
-                                               : generate_sample_request_id();
+  if (request.has_request_id() && !request.request_id().empty()) {
+    params.request_id = request.request_id();
+  } else if (!x_request_id.empty()) {
+    params.request_id = "sample-" + x_request_id;
+  } else {
+    params.request_id = generate_request_id("sample-");
+  }
   params.logprobs = true;
   params.top_logprobs =
       request.has_logprobs() ? request.logprobs() : kDefaultSampleLogprobs;
@@ -397,7 +396,10 @@ void SampleServiceImpl::process_async_impl(std::shared_ptr<SampleCall> call) {
 
   RequestParams request_params;
   if (!sample_service_internal::build_request_params(
-          request, master_->tokenizer(), &request_params)) {
+          request,
+          master_->tokenizer(),
+          &request_params,
+          call->get_x_request_id())) {
     call->finish_with_error(StatusCode::UNKNOWN,
                             "Failed to build sample selector runtime mapping");
     return;

--- a/xllm/api_service/sample_service_impl.h
+++ b/xllm/api_service/sample_service_impl.h
@@ -40,7 +40,8 @@ Status validate_runtime_config(bool enable_schedule_overlap);
 
 bool build_request_params(const proto::SampleRequest& request,
                           const Tokenizer& tokenizer,
-                          RequestParams* request_params);
+                          RequestParams* request_params,
+                          const std::string& x_request_id = "");
 
 bool build_empty_response(const proto::SampleRequest& request,
                           const Tokenizer& tokenizer,

--- a/xllm/api_service/stream_call.h
+++ b/xllm/api_service/stream_call.h
@@ -28,6 +28,7 @@ limitations under the License.
 #include "anthropic.pb.h"
 #include "api_service/anthropic_json.h"
 #include "api_service/call.h"
+#include "api_service/request_id.h"
 #include "core/common/types.h"
 #include "core/util/verbose_trace_logger.h"
 
@@ -45,7 +46,9 @@ class StreamCall : public Call {
              Response* response,
              bool use_arena = false,
              bool is_http_request = false)
-      : Call(controller, request_body_x_request_id(request), is_http_request),
+      : Call(controller,
+             api_service::request_body_x_request_id(request),
+             is_http_request),
         done_(done),
         request_(request),
         response_(response),

--- a/xllm/c_api/internal/helper.cpp
+++ b/xllm/c_api/internal/helper.cpp
@@ -23,20 +23,15 @@ limitations under the License.
 #include "core/framework/config/rec_config.h"
 #include "core/util/env_var.h"
 #include "core/util/rec_model_utils.h"
-#include "core/util/uuid.h"
 
 namespace xllm {
 namespace helper {
 namespace {
-thread_local ShortUUID short_uuid;
 static std::atomic<bool> g_glog_inited = false;
 static pthread_mutex_t g_log_init_mutex = PTHREAD_MUTEX_INITIALIZER;
 }  // namespace
 
-std::string generate_request_id() {
-  return "xllm-" + InstanceName::name()->get_name_hash() + "-" +
-         short_uuid.random();
-}
+std::string generate_request_id() { return xllm::generate_request_id("xllm-"); }
 
 void init_log(const std::string& log_dir) {
   if (g_glog_inited.load(std::memory_order_acquire)) {

--- a/xllm/cc_api/internal.h
+++ b/xllm/cc_api/internal.h
@@ -21,7 +21,6 @@ limitations under the License.
 #include "core/distributed_runtime/llm_master.h"
 #include "core/framework/request/request_output.h"
 #include "core/framework/request/request_params.h"
-#include "core/util/uuid.h"
 #include "types.h"
 
 namespace xllm {
@@ -39,12 +38,9 @@ struct LLMCore {
 
 namespace detail {
 namespace {
-thread_local ShortUUID short_uuid;
 
-std::string generate_request_id() {
-  return "xllm-" + InstanceName::name()->get_name_hash() + "-" +
-         short_uuid.random();
-}
+std::string generate_request_id() { return xllm::generate_request_id("xllm-"); }
+
 }  // namespace
 
 enum class InterfaceType { COMPLETIONS, CHAT_COMPLETIONS };

--- a/xllm/core/common/CMakeLists.txt
+++ b/xllm/core/common/CMakeLists.txt
@@ -20,6 +20,7 @@ cc_library(
     flash_comm1_context.h
   SRCS
     etcd_client.cpp
+    instance_name.cpp
     metrics.cpp
     $<$<BOOL:${USE_NPU}>:mspti_helper.cpp>
     options.cpp

--- a/xllm/core/common/instance_name.cpp
+++ b/xllm/core/common/instance_name.cpp
@@ -1,0 +1,50 @@
+/* Copyright 2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "core/common/instance_name.h"
+
+#include <atomic>
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace xllm {
+namespace {
+
+constexpr uint64_t kRequestIdCounterBits = 48;
+constexpr uint64_t kRequestIdCounterMask = (1ULL << kRequestIdCounterBits) - 1;
+
+std::atomic<uint64_t> g_request_id_seq{1};
+
+}  // namespace
+
+int64_t next_request_id() {
+  const uint64_t seq = g_request_id_seq.fetch_add(1, std::memory_order_relaxed);
+  const uint64_t instance_key =
+      InstanceName::name()->get_name_hash_value() & 0xFFFFULL;
+  return static_cast<int64_t>((instance_key << kRequestIdCounterBits) |
+                              (seq & kRequestIdCounterMask));
+}
+
+std::string generate_request_id(std::string_view prefix) {
+  const uint64_t request_id = static_cast<uint64_t>(next_request_id());
+  std::string encoded;
+  encoded.reserve(prefix.size() + 20);
+  encoded.append(prefix);
+  encoded.append(std::to_string(request_id));
+  return encoded;
+}
+
+}  // namespace xllm

--- a/xllm/core/common/instance_name.h
+++ b/xllm/core/common/instance_name.h
@@ -15,7 +15,10 @@ limitations under the License.
 
 #pragma once
 
+#include <cstdint>
+#include <functional>
 #include <string>
+#include <string_view>
 
 namespace xllm {
 
@@ -28,12 +31,15 @@ class InstanceName {
 
   void set_name(const std::string& name) {
     name_ = name;
-    name_hash_ = std::to_string(std::hash<std::string>{}(name_));
+    name_hash_value_ = static_cast<uint64_t>(std::hash<std::string>{}(name_));
+    name_hash_ = std::to_string(name_hash_value_);
   }
 
   std::string get_name() const { return name_; }
 
   std::string get_name_hash() const { return name_hash_; }
+
+  uint64_t get_name_hash_value() const { return name_hash_value_; }
 
  private:
   InstanceName() {}
@@ -43,6 +49,15 @@ class InstanceName {
  private:
   std::string name_;
   std::string name_hash_;
+  uint64_t name_hash_value_ = 0;
 };
+
+// Unique per-process request id. High 16 bits mix the instance hash so
+// concurrent instances are unlikely to collide; low 48 bits are a counter.
+int64_t next_request_id();
+
+// `{prefix}{id}`, e.g. "cmpl-123". Formats `next_request_id()` once for
+// OpenAI-compatible / HTTP string fields.
+std::string generate_request_id(std::string_view prefix);
 
 }  // namespace xllm

--- a/xllm/core/framework/request/dit_request_params.cpp
+++ b/xllm/core/framework/request/dit_request_params.cpp
@@ -22,18 +22,10 @@ limitations under the License.
 #include "core/framework/config/dit_config.h"
 #include "core/framework/multimodal/mm_codec.h"
 #include "core/util/utils.h"
-#include "core/util/uuid.h"
 #include "request.h"
 
 namespace xllm {
 namespace {
-thread_local ShortUUID short_uuid;
-
-std::string generate_request_id(const std::string& prefix) {
-  return prefix + InstanceName::name()->get_name_hash() + "-" +
-         short_uuid.random();
-}
-
 // Decode a base64-encoded WAV/audio blob into a float32 CPU tensor of shape
 // (1, num_samples) at the given sample rate (mono).
 // Returns true on success and writes to `out`; logs ERROR and returns false

--- a/xllm/core/framework/request/request_params.cpp
+++ b/xllm/core/framework/request/request_params.cpp
@@ -16,43 +16,17 @@ limitations under the License.
 
 #include "request_params.h"
 
+#include <string_view>
 #include <type_traits>
 
 #include "core/common/global_flags.h"
 #include "core/common/instance_name.h"
 #include "core/framework/config/model_config.h"
 #include "core/framework/config/service_config.h"
-#include "core/util/uuid.h"
 #include "request.h"
 
 namespace xllm {
 namespace {
-thread_local ShortUUID short_uuid;
-
-std::string generate_completion_request_id() {
-  return "cmpl-" + InstanceName::name()->get_name_hash() + "-" +
-         short_uuid.random();
-}
-
-std::string generate_embedding_request_id() {
-  return "embeddingcmpl-" + InstanceName::name()->get_name_hash() + "-" +
-         short_uuid.random();
-}
-
-std::string generate_chat_request_id() {
-  return "chatcmpl-" + InstanceName::name()->get_name_hash() + "-" +
-         short_uuid.random();
-}
-
-std::string generate_rerank_request_id() {
-  return "rerankcmpl-" + InstanceName::name()->get_name_hash() + "-" +
-         short_uuid.random();
-}
-
-std::string generate_anthropic_chat_request_id() {
-  return "anthropiccmpl-" + InstanceName::name()->get_name_hash() + "-" +
-         short_uuid.random();
-}
 
 void apply_beam_search_logprobs_default(
     RequestParams& params,
@@ -125,20 +99,65 @@ std::vector<JsonTool> handle_tools(
   return tools;
 }
 
+template <typename Request>
+void assign_x_request_identity(RequestParams& params,
+                               const Request& request,
+                               const std::string& x_rid,
+                               const std::string& x_rtime) {
+  params.x_request_id = x_rid;
+  params.x_request_time = x_rtime;
+  if constexpr (requires(const Request& value) {
+                  value.has_x_request_id();
+                  value.x_request_id();
+                }) {
+    if (params.x_request_id.empty() && request.has_x_request_id() &&
+        !request.x_request_id().empty()) {
+      params.x_request_id = request.x_request_id();
+    }
+  }
+  if constexpr (requires(const Request& value) {
+                  value.has_request_id();
+                  value.request_id();
+                }) {
+    if (params.x_request_id.empty() && request.has_request_id() &&
+        !request.request_id().empty()) {
+      params.x_request_id = request.request_id();
+    }
+  }
+  if constexpr (requires(const Request& value) {
+                  value.has_x_request_time();
+                  value.x_request_time();
+                }) {
+    if (params.x_request_time.empty() && request.has_x_request_time()) {
+      params.x_request_time = request.x_request_time();
+    }
+  }
+}
+
+// One client-facing base id (header / body / generated), then OpenAI JSON
+// id = `{prefix}{base}`, matching vLLM's chatcmpl-{X-Request-Id}.
+template <typename Request>
+void assign_openai_request_ids(RequestParams& params,
+                               const Request& request,
+                               const std::string& x_rid,
+                               const std::string& x_rtime,
+                               std::string_view prefix) {
+  assign_x_request_identity(params, request, x_rid, x_rtime);
+  if (params.x_request_id.empty()) {
+    params.x_request_id = generate_request_id(/*prefix=*/"");
+  }
+  params.request_id.clear();
+  params.request_id.reserve(prefix.size() + params.x_request_id.size());
+  params.request_id.append(prefix);
+  params.request_id.append(params.x_request_id);
+}
+
 }  // namespace
 
 RequestParams::RequestParams(const proto::CompletionRequest& request,
                              const std::string& x_rid,
                              const std::string& x_rtime) {
-  request_id = generate_completion_request_id();
-  x_request_id = x_rid;
-  x_request_time = x_rtime;
-  if (x_request_id.empty() && request.has_x_request_id()) {
-    x_request_id = request.x_request_id();
-  }
-  if (x_request_time.empty() && request.has_x_request_time()) {
-    x_request_time = request.x_request_time();
-  }
+  assign_openai_request_ids(*this, request, x_rid, x_rtime, "cmpl-");
   if (request.has_offline()) {
     offline = request.offline();
   }
@@ -337,9 +356,6 @@ void init_from_chat_request(RequestParams& params, const ChatRequest& request) {
       }
     }
   }
-  if (request.has_request_id()) {
-    params.request_id = request.request_id();
-  }
 
   if (request.has_offline()) {
     params.offline = request.offline();
@@ -475,15 +491,7 @@ void init_from_chat_request(RequestParams& params, const ChatRequest& request) {
 RequestParams::RequestParams(const proto::ChatRequest& request,
                              const std::string& x_rid,
                              const std::string& x_rtime) {
-  request_id = generate_chat_request_id();
-  x_request_id = x_rid;
-  x_request_time = x_rtime;
-  if (x_request_id.empty() && request.has_x_request_id()) {
-    x_request_id = request.x_request_id();
-  }
-  if (x_request_time.empty() && request.has_x_request_time()) {
-    x_request_time = request.x_request_time();
-  }
+  assign_openai_request_ids(*this, request, x_rid, x_rtime, "chatcmpl-");
 
   init_from_chat_request(*this, request);
 }
@@ -491,9 +499,7 @@ RequestParams::RequestParams(const proto::ChatRequest& request,
 RequestParams::RequestParams(const proto::MMChatRequest& request,
                              const std::string& x_rid,
                              const std::string& x_rtime) {
-  request_id = generate_chat_request_id();
-  x_request_id = x_rid;
-  x_request_time = x_rtime;
+  assign_openai_request_ids(*this, request, x_rid, x_rtime, "chatcmpl-");
 
   init_from_chat_request(*this, request);
 }
@@ -501,7 +507,7 @@ RequestParams::RequestParams(const proto::MMChatRequest& request,
 RequestParams::RequestParams(const proto::EmbeddingRequest& request,
                              const std::string& x_rid,
                              const std::string& x_rtime) {
-  request_id = generate_embedding_request_id();
+  assign_openai_request_ids(*this, request, x_rid, x_rtime, "embeddingcmpl-");
   if (request.has_service_request_id()) {
     service_request_id = request.service_request_id();
   }
@@ -510,8 +516,6 @@ RequestParams::RequestParams(const proto::EmbeddingRequest& request,
   } else {
     add_special_tokens = true;
   }
-  x_request_id = x_rid;
-  x_request_time = x_rtime;
   is_embeddings = true;
   max_tokens = 1;
   streaming = false;
@@ -522,8 +526,7 @@ RequestParams::RequestParams(const proto::MMEmbeddingRequest& request,
   if (request.has_service_request_id()) {
     service_request_id = request.service_request_id();
   }
-  x_request_id = x_rid;
-  x_request_time = x_rtime;
+  assign_x_request_identity(*this, request, x_rid, x_rtime);
   is_embeddings = true;
   max_tokens = 1;
   streaming = false;
@@ -532,12 +535,10 @@ RequestParams::RequestParams(const proto::MMEmbeddingRequest& request,
 RequestParams::RequestParams(const proto::RerankRequest& request,
                              const std::string& x_rid,
                              const std::string& x_rtime) {
-  request_id = generate_rerank_request_id();
+  assign_openai_request_ids(*this, request, x_rid, x_rtime, "rerankcmpl-");
   if (request.has_service_request_id()) {
     service_request_id = request.service_request_id();
   }
-  x_request_id = x_rid;
-  x_request_time = x_rtime;
   max_tokens = 1;
   streaming = false;
   if (::xllm::ModelConfig::get_instance().enable_qwen3_reranker()) {
@@ -550,15 +551,7 @@ RequestParams::RequestParams(const proto::RerankRequest& request,
 RequestParams::RequestParams(const proto::AnthropicMessagesRequest& request,
                              const std::string& x_rid,
                              const std::string& x_rtime) {
-  request_id = generate_anthropic_chat_request_id();
-  x_request_id = x_rid;
-  x_request_time = x_rtime;
-  if (x_request_id.empty() && request.has_x_request_id()) {
-    x_request_id = request.x_request_id();
-  }
-  if (x_request_time.empty() && request.has_x_request_time()) {
-    x_request_time = request.x_request_time();
-  }
+  assign_openai_request_ids(*this, request, x_rid, x_rtime, "anthropiccmpl-");
 
   if (request.has_service_request_id()) {
     service_request_id = request.service_request_id();


### PR DESCRIPTION
Resolve one base id from headers, body, or a generated numeric id, then prefix it for OpenAI JSON / engine ids.

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
