### PR TITLE
refactor: fold AssistantMaster into Master for non-leader ranks.

### DIFF
--- a/xllm/core/distributed_runtime/dit_master.cpp
+++ b/xllm/core/distributed_runtime/dit_master.cpp
@@ -20,7 +20,6 @@ limitations under the License.
 
 #include <atomic>
 #include <boost/algorithm/string.hpp>
-#include <csignal>
 #include <memory>
 #include <thread>
 #include <utility>
@@ -37,10 +36,12 @@ limitations under the License.
 #include "util/timer.h"
 
 namespace xllm {
-volatile bool DiTAssistantMaster::running_ = false;
-
 DiTMaster::DiTMaster(const Options& options)
     : Master(options, EngineType::DIT) {
+  if (!is_leader()) {
+    return;
+  }
+
   CHECK(engine_->init());
 
   DiTScheduler::Options scheduler_options;
@@ -132,6 +133,11 @@ void DiTMaster::handle_batch_request(std::vector<DiTRequestParams> params_vec,
 }
 
 void DiTMaster::run() {
+  if (!is_leader()) {
+    Master::run();
+    return;
+  }
+
   const bool already_running = running_.load(std::memory_order_relaxed);
   if (already_running) {
     LOG(WARNING) << "DiTMaster is already running.";
@@ -161,38 +167,6 @@ void DiTMaster::generate() {
   running_.store(true, std::memory_order_relaxed);
   scheduler_->generate();
   running_.store(false, std::memory_order_relaxed);
-}
-
-DiTAssistantMaster::DiTAssistantMaster(const Options& options)
-    : Master(options, EngineType::DIT) {
-  // setup process workers
-  auto master_node_addr = options_.master_node_addr().value_or("");
-  // TODO: support local unix domain socket later.
-  if (master_node_addr.empty()) {
-    LOG(FATAL)
-        << "MultiNodeEngine required master_node_addr, current value is empty.";
-    return;
-  }
-
-  running_ = true;
-}
-
-DiTAssistantMaster::~DiTAssistantMaster() {
-  // wait for the loop thread to finish
-  if (loop_thread_.joinable()) {
-    loop_thread_.join();
-  }
-}
-
-void DiTAssistantMaster::run() {
-  signal(SIGINT, DiTAssistantMaster::handle_signal);
-  signal(SIGTERM, DiTAssistantMaster::handle_signal);
-
-  loop_thread_ = std::thread([this]() {
-    while (running_) {
-      std::this_thread::sleep_for(std::chrono::seconds(5));
-    }
-  });
 }
 
 }  // namespace xllm

--- a/xllm/core/distributed_runtime/dit_master.h
+++ b/xllm/core/distributed_runtime/dit_master.h
@@ -68,17 +68,4 @@ class DiTMaster : public Master {
   std::atomic_bool running_{false};
 };
 
-class DiTAssistantMaster : public Master {
- public:
-  DiTAssistantMaster(const Options& options);
-  ~DiTAssistantMaster();
-  void run() override;
-
-  static void handle_signal(int signum) { running_ = false; }
-
- private:
-  std::thread loop_thread_;
-  static volatile bool running_;
-};
-
 }  // namespace xllm

--- a/xllm/core/distributed_runtime/llm_master.cpp
+++ b/xllm/core/distributed_runtime/llm_master.cpp
@@ -21,7 +21,6 @@ limitations under the License.
 
 #include <atomic>
 #include <boost/algorithm/string.hpp>
-#include <csignal>
 #include <memory>
 #include <thread>
 #include <utility>
@@ -91,12 +90,14 @@ std::shared_ptr<const JsonObjectGrammar> LLMMaster::get_json_object_grammar(
   return grammar;
 }
 
-volatile bool LLMAssistantMaster::running_ = false;
-
 LLMMaster::LLMMaster(const Options& options)
     : Master(
           options,
           should_use_ssm_engine(options) ? EngineType::SSM : EngineType::LLM) {
+  if (!is_leader()) {
+    return;
+  }
+
   CHECK(engine_->init(master_status_));
   task_type_ = options_.task_type();
 
@@ -303,6 +304,11 @@ void LLMMaster::handle_request(std::vector<Message> messages,
 }
 
 void LLMMaster::run() {
+  if (!is_leader()) {
+    Master::run();
+    return;
+  }
+
   const bool already_running = running_.load(std::memory_order_relaxed);
   if (already_running) {
     LOG(WARNING) << "LLMMaster is already running.";
@@ -686,40 +692,6 @@ bool LLMMaster::link_p2p(const std::vector<std::string>& remote_addrs) {
 
 bool LLMMaster::unlink_p2p(const std::vector<std::string>& remote_addrs) {
   return engine_->unlink_p2p(remote_addrs);
-}
-
-LLMAssistantMaster::LLMAssistantMaster(const Options& options)
-    : Master(
-          options,
-          should_use_ssm_engine(options) ? EngineType::SSM : EngineType::LLM) {
-  // setup process workers
-  auto master_node_addr = options_.master_node_addr().value_or("");
-  // TODO: support local unix domain socket later.
-  if (master_node_addr.empty()) {
-    LOG(FATAL)
-        << "MultiNodeEngine required master_node_addr, current value is empty.";
-    return;
-  }
-
-  running_ = true;
-}
-
-LLMAssistantMaster::~LLMAssistantMaster() {
-  // wait for the loop thread to finish
-  if (loop_thread_.joinable()) {
-    loop_thread_.join();
-  }
-}
-
-void LLMAssistantMaster::run() {
-  signal(SIGINT, LLMAssistantMaster::handle_signal);
-  signal(SIGTERM, LLMAssistantMaster::handle_signal);
-
-  loop_thread_ = std::thread([this]() {
-    while (running_) {
-      std::this_thread::sleep_for(std::chrono::seconds(5));
-    }
-  });
 }
 
 // ============== Async RL training support: Pause/Resume ==============

--- a/xllm/core/distributed_runtime/llm_master.h
+++ b/xllm/core/distributed_runtime/llm_master.h
@@ -16,6 +16,7 @@ limitations under the License.
 #pragma once
 
 #include <folly/Function.h>
+#include <glog/logging.h>
 
 #include <functional>
 #include <future>
@@ -75,7 +76,11 @@ class LLMMaster : public Master {
   std::vector<bool> handle_rpc_responses(
       const std::vector<RequestOutput>& outputs);
 
-  const Tokenizer& tokenizer() const { return *tokenizer_; }
+  const Tokenizer& tokenizer() const {
+    CHECK(tokenizer_ != nullptr)
+        << "tokenizer() is only available on the leader rank (node_rank == 0).";
+    return *tokenizer_;
+  }
 
   // start running loop
   void run() override;
@@ -153,19 +158,6 @@ class LLMMaster : public Master {
   std::atomic_bool running_{false};
 
   std::string task_type_;
-};
-
-class LLMAssistantMaster : public Master {
- public:
-  LLMAssistantMaster(const Options& options);
-  ~LLMAssistantMaster();
-  void run() override;
-
-  static void handle_signal(int signum) { running_ = false; }
-
- private:
-  std::thread loop_thread_;
-  static volatile bool running_;
 };
 
 }  // namespace xllm

--- a/xllm/core/distributed_runtime/master.cpp
+++ b/xllm/core/distributed_runtime/master.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 #include <array>
 #include <atomic>
 #include <boost/algorithm/string.hpp>
+#include <chrono>
 #include <csignal>
 #include <cstdio>
 #include <filesystem>
@@ -759,6 +760,46 @@ Master::Master(const Options& options, EngineType type)
     LOG(WARNING) << "Not supported llm engine type: "
                  << static_cast<size_t>(type);
   }
+
+  if (!is_leader()) {
+    const std::string master_node_addr =
+        options_.master_node_addr().value_or("");
+    if (master_node_addr.empty()) {
+      LOG(FATAL) << "Multi-node serving requires --master_node_addr, "
+                    "current value is empty.";
+    }
+  }
+}
+
+std::atomic<bool> Master::idle_running_{false};
+
+void Master::handle_shutdown_signal(int /*signum*/) {
+  idle_running_.store(false, std::memory_order_relaxed);
+}
+
+Master::~Master() {
+  idle_running_.store(false, std::memory_order_relaxed);
+  if (idle_thread_.joinable()) {
+    idle_thread_.join();
+  }
+}
+
+void Master::wait() {
+  if (idle_thread_.joinable()) {
+    idle_thread_.join();
+  }
+}
+
+void Master::run() {
+  idle_running_.store(true, std::memory_order_relaxed);
+  signal(SIGINT, Master::handle_shutdown_signal);
+  signal(SIGTERM, Master::handle_shutdown_signal);
+
+  idle_thread_ = std::thread([]() {
+    while (idle_running_.load(std::memory_order_relaxed)) {
+      std::this_thread::sleep_for(std::chrono::seconds(5));
+    }
+  });
 }
 
 std::unique_ptr<Master> create_master(const std::string& backend,
@@ -807,12 +848,8 @@ std::unique_ptr<Master> fork_master(Master* master, const Options& options) {
   if (options.dp_size() > 0 && new_options.dp_size() >= options.nnodes()) {
     new_options.dp_size() = options.dp_size();
   }
-  std::unique_ptr<Master> new_master;
-  if (new_options.node_rank() != 0) {
-    new_master = std::make_unique<LLMAssistantMaster>(new_options);
-  } else {
-    new_master = create_master(new_options.backend(), new_options);
-  }
+  std::unique_ptr<Master> new_master =
+      create_master(new_options.backend(), new_options);
   new_master->run();
 
   return new_master;

--- a/xllm/core/distributed_runtime/master.h
+++ b/xllm/core/distributed_runtime/master.h
@@ -17,8 +17,10 @@ limitations under the License.
 
 #include <folly/Function.h>
 
+#include <atomic>
 #include <functional>
 #include <future>
+#include <thread>
 #include <vector>
 
 #include "common/macros.h"
@@ -32,9 +34,16 @@ namespace xllm {
 class Master {
  public:
   explicit Master(const Options& options, EngineType type);
-  virtual ~Master() = default;
-  virtual void run() = 0;
+  virtual ~Master();
+  // Rank-0 masters override this to start the scheduler loop. Non-zero
+  // ranks use the default implementation, which starts a background idle
+  // thread. The destructor stops that thread.
+  virtual void run();
+  // Block until the idle thread exits (SIGINT/SIGTERM). Used by the
+  // binary when no HTTP server is started on a non-leader rank.
+  void wait();
   virtual const Options& options() const { return options_; }
+  bool is_leader() const { return options_.node_rank() == 0; }
   EngineType engine_type() const { return engine_type_; }
 
   virtual bool sleep() { return false; }
@@ -79,6 +88,11 @@ class Master {
   std::unique_ptr<Engine> engine_;
   RateLimiter rate_limiter_;
   MasterStatus master_status_{MasterStatus::WAKEUP};
+
+ private:
+  static void handle_shutdown_signal(int signum);
+  static std::atomic<bool> idle_running_;
+  std::thread idle_thread_;
 };
 
 std::unique_ptr<Master> create_master(const std::string& backend,

--- a/xllm/core/distributed_runtime/rec_engine.cpp
+++ b/xllm/core/distributed_runtime/rec_engine.cpp
@@ -34,6 +34,7 @@ limitations under the License.
 #include "master.h"  // For MasterStatus::WAKEUP constant
 #include "runtime/params_utils.h"
 #include "util/env_var.h"
+#include "util/model_config_utils.h"
 #include "util/net.h"
 #include "util/pretty_print.h"
 #include "util/rec_model_utils.h"
@@ -62,6 +63,42 @@ RecEngine::RecEngine(const runtime::Options& options,
   for (const auto device : devices) {
     CHECK_EQ(device.type(), device_type)
         << "All devices should be the same type";
+  }
+}
+
+void RecEngine::validate_multi_node_support() const {
+  // Single-node runs are always local; every REC pipeline is supported.
+  if (options_.nnodes() <= 1) {
+    return;
+  }
+
+  // Only the single-round LlmRec pipeline drives workers through DistManager.
+  // OneRec runs on local workers, and LlmRec multi-round mode selects
+  // RecMultiRoundEnginePipeline whose setup_workers() is local-only. For those
+  // kinds secondary ranks would spawn workers that rank 0 never collects, so
+  // fail fast instead of serving from an incomplete cluster.
+  const std::string model_type =
+      util::get_model_type(options_.model_path(), options_.backend());
+  const RecModelKind rec_model_kind = get_rec_model_kind(model_type);
+  CHECK(rec_model_kind == RecModelKind::kLlmRec)
+      << "Multi-node REC serving is only supported for LlmRec models, "
+         "got model_type: "
+      << model_type;
+  CHECK(!is_rec_multi_round_mode())
+      << "Multi-node REC serving is not supported in multi-round mode "
+         "(--max_decode_rounds > 0); RecMultiRoundEnginePipeline runs on "
+         "local workers only.";
+}
+
+void RecEngine::setup_distributed_workers() {
+  validate_multi_node_support();
+
+#if defined(USE_NPU)
+  FLAGS_enable_atb_comm_multiprocess =
+      options_.enable_offline_inference() || (options_.nnodes() > 1);
+#endif
+  if (!dist_manager_) {
+    dist_manager_ = std::make_shared<DistManager>(options_);
   }
 }
 
@@ -95,6 +132,9 @@ bool RecEngine::init_model() {
   rec_model_kind_ = get_rec_model_kind(args_.model_type());
   CHECK(rec_model_kind_ != RecModelKind::kNone)
       << "Unsupported rec model_type: " << args_.model_type();
+  // Reject unsupported multi-node REC configurations before selecting a
+  // pipeline, so the leader fails fast too (not only secondary ranks).
+  validate_multi_node_support();
   auto pipeline_type = get_rec_pipeline_type(rec_model_kind_);
   pipeline_ = create_pipeline(pipeline_type, *this);
   // LlmRec-specific initialization
@@ -250,9 +290,7 @@ RecEngine::LlmRecEnginePipeline::LlmRecEnginePipeline(RecEngine& engine)
     : RecEnginePipeline(engine) {}
 
 void RecEngine::LlmRecEnginePipeline::setup_workers() {
-  if (!engine_.dist_manager_) {
-    engine_.dist_manager_ = std::make_shared<DistManager>(engine_.options_);
-  }
+  engine_.setup_distributed_workers();
   engine_.worker_clients_ = engine_.dist_manager_->get_worker_clients();
   engine_.dp_size_ = engine_.options_.dp_size();
   engine_.worker_clients_num_ = engine_.worker_clients_.size();

--- a/xllm/core/distributed_runtime/rec_engine.h
+++ b/xllm/core/distributed_runtime/rec_engine.h
@@ -49,6 +49,11 @@ class RecEngine : public Engine {
 
   bool init() override;
 
+  // Start local WorkerServers without loading weights. Non-leader ranks
+  // call this so rank 0's DistManager can collect the cluster; LlmRec
+  // otherwise creates DistManager only inside init().
+  void setup_distributed_workers();
+
   void update_last_step_result(std::vector<Batch>& batch) override;
 
   std::vector<int64_t> get_active_activation_memory() const override;
@@ -183,6 +188,12 @@ class RecEngine : public Engine {
   // Private methods
   // ============================================================
   bool init_model();
+  // Reject REC configurations that cannot run across multiple nodes. Only the
+  // single-round LlmRec pipeline coordinates workers through DistManager;
+  // OneRec and LlmRec multi-round pipelines are local-only. This runs in
+  // common initialization (before pipeline selection) so the leader rejects
+  // the configuration too, not just secondary ranks. No-op when nnodes <= 1.
+  void validate_multi_node_support() const;
   KVCacheCapacity estimate_kv_cache_capacity();
   bool allocate_kv_cache(const KVCacheCapacity& kv_cache_cap);
 

--- a/xllm/core/distributed_runtime/rec_master.cpp
+++ b/xllm/core/distributed_runtime/rec_master.cpp
@@ -533,6 +533,16 @@ std::unique_ptr<RecMaster::RecMasterPipeline> RecMaster::create_pipeline(
 
 RecMaster::RecMaster(const Options& options)
     : Master(options, EngineType::REC) {
+  if (!is_leader()) {
+    // RecEngine does not create DistManager in its constructor. LlmRec
+    // starts workers in init(); skip that on non-leaders but still host
+    // the local WorkerServer so rank 0 can collect the cluster.
+    auto* rec_engine = dynamic_cast<RecEngine*>(engine_.get());
+    CHECK(rec_engine != nullptr);
+    rec_engine->setup_distributed_workers();
+    return;
+  }
+
   // Initialize with Rec engine type
   // The rest of the initialization follows the same pattern as LLMMaster
   CHECK(engine_->init());
@@ -600,6 +610,11 @@ RecMaster::RecMaster(const Options& options)
 }
 
 void RecMaster::run() {
+  if (!is_leader()) {
+    Master::run();
+    return;
+  }
+
   const bool already_running = running_.load(std::memory_order_relaxed);
   if (already_running) {
     LOG(WARNING) << "RecMaster is already running.";

--- a/xllm/core/distributed_runtime/vlm_master.cpp
+++ b/xllm/core/distributed_runtime/vlm_master.cpp
@@ -17,7 +17,6 @@ limitations under the License.
 
 #include <glog/logging.h>
 #include <pybind11/pybind11.h>
-#include <signal.h>
 
 #include <atomic>
 #include <chrono>
@@ -65,6 +64,10 @@ std::vector<Message> build_user_messages_from_image_urls(
 
 VLMMaster::VLMMaster(const Options& options)
     : Master(options, EngineType::VLM) {
+  if (!is_leader()) {
+    return;
+  }
+
   CHECK(engine_->init());
 
   model_args_ = engine_->model_args();
@@ -282,6 +285,11 @@ void VLMMaster::handle_batch_request(
 }
 
 void VLMMaster::run() {
+  if (!is_leader()) {
+    Master::run();
+    return;
+  }
+
   const bool already_running = running_.load(std::memory_order_relaxed);
   if (already_running) {
     LOG(WARNING) << "VLMMaster is already running.";
@@ -504,36 +512,6 @@ std::shared_ptr<Request> VLMMaster::generate_request(
                           std::move(mm_data),
                           std::move(sp),
                           std::move(callback));
-}
-
-volatile bool VLMAssistantMaster::running_ = false;
-
-VLMAssistantMaster::VLMAssistantMaster(const Options& options)
-    : Master(options, EngineType::VLM) {
-  auto master_node_addr = options_.master_node_addr().value_or("");
-  if (master_node_addr.empty()) {
-    LOG(FATAL)
-        << "MultiNodeEngine required master_node_addr, current value is empty.";
-    return;
-  }
-  running_ = true;
-}
-
-VLMAssistantMaster::~VLMAssistantMaster() {
-  if (loop_thread_.joinable()) {
-    loop_thread_.join();
-  }
-}
-
-void VLMAssistantMaster::run() {
-  signal(SIGINT, VLMAssistantMaster::handle_signal);
-  signal(SIGTERM, VLMAssistantMaster::handle_signal);
-
-  loop_thread_ = std::thread([this]() {
-    while (running_) {
-      std::this_thread::sleep_for(std::chrono::seconds(5));
-    }
-  });
 }
 
 }  // namespace xllm

--- a/xllm/core/distributed_runtime/vlm_master.h
+++ b/xllm/core/distributed_runtime/vlm_master.h
@@ -124,17 +124,4 @@ class VLMMaster : public Master {
   std::atomic_bool running_{false};
 };
 
-class VLMAssistantMaster : public Master {
- public:
-  explicit VLMAssistantMaster(const Options& options);
-  ~VLMAssistantMaster();
-  void run() override;
-
-  static void handle_signal(int signum) { running_ = false; }
-
- private:
-  std::thread loop_thread_;
-  static volatile bool running_;
-};
-
 }  // namespace xllm

--- a/xllm/xllm.cpp
+++ b/xllm/xllm.cpp
@@ -35,9 +35,7 @@ namespace py = pybind11;
 #include "core/common/metrics.h"
 #include "core/common/options.h"
 #include "core/common/types.h"
-#include "core/distributed_runtime/dit_master.h"
 #include "core/distributed_runtime/master.h"
-#include "core/distributed_runtime/vlm_master.h"
 #include "core/framework/config/beam_search_config.h"
 #include "core/framework/config/config_utils.h"
 #include "core/framework/config/disagg_pd_config.h"
@@ -544,20 +542,8 @@ int run() {
     LOG(INFO) << "XTensor initialized with " << num_pages << " physical pages";
   }
 
-  std::unique_ptr<Master> master;
-  // working node
-  if (options.node_rank() != 0) {
-    if (model_config.backend() == "dit") {
-      master = std::make_unique<DiTAssistantMaster>(options);
-    } else if (model_config.backend() == "vlm") {
-      master = std::make_unique<VLMAssistantMaster>(options);
-    } else {
-      master = std::make_unique<LLMAssistantMaster>(options);
-    }
-  } else {
-    // master node
-    master = create_master(model_config.backend(), options);
-  }
+  std::unique_ptr<Master> master =
+      create_master(model_config.backend(), options);
   master->run();
 
   // supported models
@@ -578,6 +564,10 @@ int run() {
                  << service_config.port();
       return -1;
     }
+  } else {
+    // No HTTP server on this rank. Stay alive until SIGINT/SIGTERM so
+    // the destructor can stop the idle thread instead of hanging on it.
+    master->wait();
   }
 
   return 0;


### PR DESCRIPTION
Non-zero node_rank now reuses LLM/VLM/DiT/Rec Master, skipping scheduler init and parking in Master::run().

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
