### PR TITLE
refactor: extract VLMRequestFactory from VLMMaster in distributed runtime.

### DIFF
--- a/tests/core/framework/request/CMakeLists.txt
+++ b/tests/core/framework/request/CMakeLists.txt
@@ -2,6 +2,32 @@ include(cc_test)
 
 cc_test(
   NAME
+    vlm_request_factory_test
+  SRCS
+    vlm_request_factory_test.cpp
+  DEPS
+    :common
+    :config
+    :request
+    :processors
+    :jinja_chat_template
+    $<$<BOOL:${USE_MLU}>:torch_mlu>
+    $<$<BOOL:${USE_NPU}>:torch_npu>
+    GTest::gtest_main
+)
+target_link_libraries(vlm_request_factory_test
+                      PUBLIC
+                      Python::Python
+                      $<$<BOOL:${USE_NPU}>:ascendcl>
+                      $<$<BOOL:${USE_NPU}>:hccl>
+                      $<$<BOOL:${USE_NPU}>:c_sec>
+                      $<$<BOOL:${USE_NPU}>:nnopbase>)
+target_link_options(vlm_request_factory_test
+                    PRIVATE
+                    $<$<BOOL:${USE_MLU}>:-Wl,--no-as-needed>)
+
+cc_test(
+  NAME
     sample_slot_test
   SRCS
     sample_slot_test.cpp

--- a/tests/core/framework/request/vlm_request_factory_test.cpp
+++ b/tests/core/framework/request/vlm_request_factory_test.cpp
@@ -1,0 +1,333 @@
+/* Copyright 2025-2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "framework/request/vlm_request_factory.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "common/options.h"
+#include "common/rate_limiter.h"
+#include "core/common/message.h"
+#include "core/common/types.h"
+#include "core/framework/multimodal/mm_data.h"
+#include "framework/chat_template/jinja_chat_template.h"
+#include "framework/model/model_args.h"
+#include "framework/request/request_output.h"
+#include "framework/request/request_params.h"
+#include "framework/tokenizer/tokenizer.h"
+#include "framework/tokenizer/tokenizer_args.h"
+#include "xllm/processors/multimodal_processor.h"
+
+namespace xllm {
+namespace {
+
+// Deterministic tokenizer used for factory tests. It only participates in stop
+// sequence encoding here; encoding fails for any text containing "FAIL" so the
+// stop-sequence error path can be exercised independently.
+class FakeTokenizer final : public Tokenizer {
+ public:
+  explicit FakeTokenizer(int32_t vocab_size) : vocab_size_(vocab_size) {}
+
+  bool encode(const std::string_view& text,
+              std::vector<int32_t>* ids,
+              bool /*add_special_tokens*/ = true) const override {
+    if (text.find("FAIL") != std::string_view::npos) {
+      return false;
+    }
+    ids->clear();
+    for (const char c : text) {
+      ids->push_back(static_cast<int32_t>(static_cast<unsigned char>(c)) %
+                     vocab_size_);
+    }
+    if (ids->empty()) {
+      ids->push_back(1);
+    }
+    return true;
+  }
+
+  size_t vocab_size() const override {
+    return static_cast<size_t>(vocab_size_);
+  }
+
+  std::unique_ptr<Tokenizer> clone() const override {
+    return std::make_unique<FakeTokenizer>(*this);
+  }
+
+ private:
+  int32_t vocab_size_ = 1000;
+};
+
+// Fake multimodal processor that lets tests drive process_prompt success and
+// the tokens it emits, without pulling in any real vision/audio pipeline.
+class FakeProcessor final : public MultimodalProcessorBase {
+ public:
+  FakeProcessor() : MultimodalProcessorBase(/*tokenizer=*/nullptr) {}
+
+  bool process_prompt(std::string& /*prompt*/,
+                      MMData& /*mm_data*/,
+                      std::vector<int32_t>& token_ids) override {
+    if (!process_prompt_succeed_) {
+      return false;
+    }
+    token_ids = prompt_tokens_;
+    return true;
+  }
+
+  bool process_multimodal(const MMInput& /*inputs*/,
+                          MMData& /*data*/) const override {
+    return process_multimodal_succeed_;
+  }
+
+  void set_process_prompt_succeed(bool succeed) {
+    process_prompt_succeed_ = succeed;
+  }
+
+  void set_prompt_tokens(std::vector<int32_t> tokens) {
+    prompt_tokens_ = std::move(tokens);
+  }
+
+ private:
+  bool process_prompt_succeed_ = true;
+  bool process_multimodal_succeed_ = true;
+  std::vector<int32_t> prompt_tokens_{1, 2, 3};
+};
+
+// Jinja chat template stub. The base constructor parses a trivial literal
+// template (no Jinja tags, so it never fails to parse), while apply is
+// overridden to return a fixed prompt or report failure on demand.
+class FakeJinjaChatTemplate final : public JinjaChatTemplate {
+ public:
+  FakeJinjaChatTemplate() : JinjaChatTemplate(make_template_args()) {}
+
+  std::optional<std::string> apply(
+      const ChatMessages& /*messages*/,
+      const std::vector<xllm::JsonTool>& /*json_tools*/,
+      const nlohmann::ordered_json& /*chat_template_kwargs*/) const override {
+    if (!succeed_) {
+      return std::nullopt;
+    }
+    return rendered_prompt_;
+  }
+
+  void set_succeed(bool succeed) { succeed_ = succeed; }
+
+ private:
+  static TokenizerArgs make_template_args() {
+    TokenizerArgs args;
+    args.chat_template("hello");
+    return args;
+  }
+
+  bool succeed_ = true;
+  std::string rendered_prompt_ = "rendered prompt";
+};
+
+// Records the last error surfaced through the OutputCallback.
+struct CallbackCapture {
+  bool called = false;
+  std::optional<Status> status;
+};
+
+OutputCallback make_capture_callback(CallbackCapture* capture) {
+  return [capture](RequestOutput output) {
+    capture->called = true;
+    capture->status = output.status;
+    return false;
+  };
+}
+
+class VLMRequestFactoryTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Simulate the caller (service entry) having acquired a rate-limit slot.
+    rate_limiter_.is_limited();
+    ASSERT_EQ(rate_limiter_.get_num_concurrent_requests(), 1);
+  }
+
+  std::unique_ptr<VLMRequestFactory> make_factory(int32_t vocab_size = 1000,
+                                                  int32_t max_position = 2048) {
+    processor_ = std::make_unique<FakeProcessor>();
+    chat_template_ = std::make_unique<FakeJinjaChatTemplate>();
+    tokenizer_ = std::make_unique<FakeTokenizer>(vocab_size);
+    model_args_.vocab_size(vocab_size)
+        .max_position_embeddings(max_position)
+        .eos_token_id(-1);
+    // enable_chunked_prefill defaults true; keep it so the prompt length limit
+    // is exactly max_position_embeddings.
+    options_.enable_service_routing(false).num_speculative_tokens(0);
+    return std::make_unique<VLMRequestFactory>(processor_.get(),
+                                               chat_template_.get(),
+                                               tokenizer_.get(),
+                                               &model_args_,
+                                               &options_,
+                                               &rate_limiter_);
+  }
+
+  std::unique_ptr<FakeProcessor> processor_;
+  std::unique_ptr<FakeJinjaChatTemplate> chat_template_;
+  std::unique_ptr<FakeTokenizer> tokenizer_;
+  ModelArgs model_args_;
+  Options options_;
+  RateLimiter rate_limiter_;
+};
+
+TEST_F(VLMRequestFactoryTest,
+       RejectsEmptyPromptAndMmDataReleasesRateLimitSlot) {
+  auto factory = make_factory();
+  CallbackCapture capture;
+  RequestParams sp;
+
+  auto request = factory->create(/*prompt=*/"",
+                                 /*mm_data=*/MMData{},
+                                 sp,
+                                 make_capture_callback(&capture));
+
+  EXPECT_EQ(request, nullptr);
+  ASSERT_TRUE(capture.called);
+  ASSERT_TRUE(capture.status.has_value());
+  EXPECT_EQ(capture.status->code(), StatusCode::INVALID_ARGUMENT);
+  EXPECT_EQ(capture.status->message(),
+            "Prompt and multimodal data are both empty.");
+  // The factory must release the rate-limit slot on every early return.
+  EXPECT_EQ(rate_limiter_.get_num_concurrent_requests(), 0);
+}
+
+TEST_F(VLMRequestFactoryTest, FailsWhenProcessPromptFails) {
+  auto factory = make_factory();
+  processor_->set_process_prompt_succeed(false);
+  CallbackCapture capture;
+  RequestParams sp;
+
+  auto request = factory->create(/*prompt=*/"describe this",
+                                 /*mm_data=*/MMData{},
+                                 sp,
+                                 make_capture_callback(&capture));
+
+  EXPECT_EQ(request, nullptr);
+  ASSERT_TRUE(capture.status.has_value());
+  EXPECT_EQ(capture.status->code(), StatusCode::INVALID_ARGUMENT);
+  EXPECT_EQ(capture.status->message(), "Failed to process prompt.");
+  EXPECT_EQ(rate_limiter_.get_num_concurrent_requests(), 0);
+}
+
+TEST_F(VLMRequestFactoryTest, RejectsPromptLongerThanContext) {
+  auto factory = make_factory(/*vocab_size=*/1000, /*max_position=*/8);
+  processor_->set_prompt_tokens(std::vector<int32_t>{1, 2, 3, 4, 5, 6, 7, 8});
+  CallbackCapture capture;
+  RequestParams sp;
+
+  auto request = factory->create(/*prompt=*/"describe this",
+                                 /*mm_data=*/MMData{},
+                                 sp,
+                                 make_capture_callback(&capture));
+
+  EXPECT_EQ(request, nullptr);
+  ASSERT_TRUE(capture.status.has_value());
+  EXPECT_EQ(capture.status->message(), "Prompt is too long");
+  EXPECT_EQ(rate_limiter_.get_num_concurrent_requests(), 0);
+}
+
+TEST_F(VLMRequestFactoryTest, FailsWhenStopSequenceEncodingFails) {
+  auto factory = make_factory();
+  CallbackCapture capture;
+  RequestParams sp;
+  sp.stop = std::vector<std::string>{"FAIL-STOP"};
+
+  auto request = factory->create(/*prompt=*/"describe this",
+                                 /*mm_data=*/MMData{},
+                                 sp,
+                                 make_capture_callback(&capture));
+
+  EXPECT_EQ(request, nullptr);
+  ASSERT_TRUE(capture.status.has_value());
+  EXPECT_EQ(capture.status->message(), "Failed to encode stop sequence");
+  EXPECT_EQ(rate_limiter_.get_num_concurrent_requests(), 0);
+}
+
+TEST_F(VLMRequestFactoryTest,
+       CreatesRequestForValidPromptAndKeepsRateLimitSlot) {
+  auto factory = make_factory();
+  CallbackCapture capture;
+  RequestParams sp;
+  sp.request_id = "req-1";
+  sp.max_tokens = 16;
+
+  auto request = factory->create(/*prompt=*/"describe this",
+                                 /*mm_data=*/MMData{},
+                                 sp,
+                                 make_capture_callback(&capture));
+
+  ASSERT_NE(request, nullptr);
+  EXPECT_FALSE(capture.called);
+  // On success the slot stays held; it is later released when the request is
+  // completed/destroyed by the scheduler, not by the factory.
+  EXPECT_EQ(rate_limiter_.get_num_concurrent_requests(), 1);
+}
+
+TEST_F(VLMRequestFactoryTest, MessageOverloadFailsWhenTemplateRejects) {
+  auto factory = make_factory();
+  chat_template_->set_succeed(false);
+  CallbackCapture capture;
+  RequestParams sp;
+  // MMInputTransfer requires MMContentVec content; a text part is enough.
+  MMContentVec content;
+  content.emplace_back("text", std::string("hi"));
+  std::vector<Message> messages;
+  messages.emplace_back("user", content);
+
+  auto request = factory->create(messages,
+                                 sp,
+                                 /*payload=*/std::string{},
+                                 make_capture_callback(&capture));
+
+  EXPECT_EQ(request, nullptr);
+  ASSERT_TRUE(capture.status.has_value());
+  EXPECT_EQ(capture.status->code(), StatusCode::INVALID_ARGUMENT);
+  EXPECT_EQ(capture.status->message(),
+            "Failed to construct prompt from messages");
+  EXPECT_EQ(rate_limiter_.get_num_concurrent_requests(), 0);
+}
+
+TEST_F(VLMRequestFactoryTest, MessageOverloadCreatesRequestOnSuccess) {
+  auto factory = make_factory();
+  CallbackCapture capture;
+  RequestParams sp;
+  sp.request_id = "req-chat";
+  sp.max_tokens = 16;
+  // MMInputTransfer requires MMContentVec content; a text part is enough.
+  MMContentVec content;
+  content.emplace_back("text", std::string("hi"));
+  std::vector<Message> messages;
+  messages.emplace_back("user", content);
+
+  auto request = factory->create(messages,
+                                 sp,
+                                 /*payload=*/std::string{},
+                                 make_capture_callback(&capture));
+
+  ASSERT_NE(request, nullptr);
+  EXPECT_FALSE(capture.called);
+  EXPECT_EQ(rate_limiter_.get_num_concurrent_requests(), 1);
+}
+
+}  // namespace
+}  // namespace xllm

--- a/xllm/core/distributed_runtime/vlm_master.cpp
+++ b/xllm/core/distributed_runtime/vlm_master.cpp
@@ -28,7 +28,6 @@ limitations under the License.
 #include "common/metrics.h"
 #include "core/common/message.h"
 #include "core/framework/multimodal/mm_data.h"
-#include "core/framework/multimodal/mm_input.h"
 #include "core/platform/device_name_utils.h"
 #include "framework/chat_template/jinja_chat_template.h"
 #include "framework/model/model_args.h"
@@ -115,6 +114,13 @@ VLMMaster::VLMMaster(const Options& options)
                                            options_.max_processor_cache_items(),
                                            engine_->tokenizer_args());
 
+  request_factory_ = std::make_unique<VLMRequestFactory>(processor_.get(),
+                                                         chat_template_.get(),
+                                                         tokenizer_.get(),
+                                                         &model_args_,
+                                                         &options_,
+                                                         get_rate_limiter());
+
   threadpool_ = std::make_unique<ThreadPool>(
       /*num_threads=*/options_.num_request_handling_threads(),
       /*cpu_binding=*/false,
@@ -123,6 +129,18 @@ VLMMaster::VLMMaster(const Options& options)
 
 VLMMaster::~VLMMaster() {
   stoped_.store(true, std::memory_order_relaxed);
+
+  // Drain and join the request thread pool before any of the members its
+  // worker lambdas touch are destroyed. Those lambdas dereference
+  // request_factory_ (as well as scheduler_ and the rate limiter), but
+  // request_factory_ is declared after threadpool_ in the header, so member
+  // destruction would otherwise free the factory while pool workers are still
+  // in flight. ~ThreadPool only signals/joins its workers when the pool is
+  // destroyed, so reset it here explicitly while all dependencies are alive.
+  // Done before joining loop_thread_ so the scheduler keeps advancing while the
+  // pool drains.
+  threadpool_.reset();
+
   // wait for the loop thread to finish
   if (loop_thread_.joinable()) {
     loop_thread_.join();
@@ -161,10 +179,8 @@ void VLMMaster::handle_request(std::string prompt,
     }
 
     rate_limit_guard.dismiss();
-    auto request = generate_request(std::move(prompt),
-                                    std::move(mm_data),
-                                    std::move(sp),
-                                    std::move(callback));
+    auto request = request_factory_->create(
+        std::move(prompt), std::move(mm_data), sp, std::move(callback));
     if (!request) {
       return;
     }
@@ -207,10 +223,8 @@ void VLMMaster::handle_request(std::vector<Message> messages,
     }
 
     rate_limit_guard.dismiss();
-    auto request = generate_request(std::move(messages),
-                                    std::move(sp),
-                                    std::move(payload),
-                                    std::move(callback));
+    auto request = request_factory_->create(
+        std::move(messages), sp, std::move(payload), std::move(callback));
     if (!request) {
       return;
     }
@@ -319,199 +333,6 @@ void VLMMaster::generate() {
   running_.store(true, std::memory_order_relaxed);
   scheduler_->generate();
   running_.store(false, std::memory_order_relaxed);
-}
-
-std::shared_ptr<Request> VLMMaster::generate_request(std::string prompt,
-                                                     MMData mm_data,
-                                                     RequestParams sp,
-                                                     OutputCallback callback) {
-  // Guard the rate-limit slot acquired at the service entry. build_request
-  // installs its own guard, so we dismiss ours before forwarding.
-  xllm::ScopeGuard rate_limit_guard(
-      [this] { get_rate_limiter()->decrease_one_request(); });
-
-  if (prompt.empty() && mm_data.empty()) {
-    LOG(ERROR) << "Prompt and multimodal data cannot be both empty.";
-    CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                        "Prompt and multimodal data are both empty.");
-    return nullptr;
-  }
-
-  std::vector<int32_t> prompt_tokens;
-  if (!processor_->process_prompt(prompt, mm_data, prompt_tokens)) {
-    CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                        "Failed to process prompt.");
-    return nullptr;
-  }
-
-  rate_limit_guard.dismiss();
-  return build_request(std::move(prompt),
-                       std::move(prompt_tokens),
-                       std::move(mm_data),
-                       std::move(sp),
-                       std::move(callback));
-}
-
-std::shared_ptr<Request> VLMMaster::build_request(
-    std::string prompt,
-    std::vector<int32_t> prompt_tokens,
-    MMData mm_data,
-    RequestParams sp,
-    OutputCallback callback) {
-  // Guard the rate-limit slot acquired at the service entry. Any early
-  // return below releases it; success path dismisses right before Request
-  // takes ownership.
-  xllm::ScopeGuard rate_limit_guard(
-      [this] { get_rate_limiter()->decrease_one_request(); });
-
-  const int32_t max_context_len = model_args_.max_position_embeddings();
-  int32_t prompt_token_limit = max_context_len;
-  if (!options_.enable_chunked_prefill()) {
-    prompt_token_limit =
-        std::min(prompt_token_limit, options_.max_tokens_per_batch());
-  }
-  if (prompt_tokens.size() >= static_cast<size_t>(prompt_token_limit)) {
-    LOG(ERROR) << "Prompt is too long: " << prompt_tokens.size();
-    CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT, "Prompt is too long");
-    return nullptr;
-  }
-
-  uint32_t max_tokens = sp.max_tokens;
-  if (max_tokens == 0) {
-    const uint32_t kDefaultMaxTokens = 5120;
-    max_tokens = kDefaultMaxTokens;
-  }
-
-  // allocate enough capacity for prompt tokens, max tokens, and speculative
-  // tokens, TODO: add image token size as well.
-  const size_t capacity = prompt_tokens.size() + max_tokens + 1;
-  const size_t best_of = sp.best_of.value_or(sp.n);
-
-  RequestSamplingParam sampling_param;
-  sampling_param.frequency_penalty = sp.frequency_penalty;
-  sampling_param.presence_penalty = sp.presence_penalty;
-  sampling_param.repetition_penalty = sp.repetition_penalty;
-  sampling_param.temperature = sp.temperature;
-  sampling_param.top_p = sp.top_p;
-  sampling_param.top_k = sp.top_k;
-  sampling_param.logprobs = sp.logprobs;
-  sampling_param.top_logprobs = sp.top_logprobs;
-  sampling_param.is_embeddings = sp.is_embeddings;
-  if (best_of > sp.n) {
-    // enable logprobs for best_of to generate sequence logprob
-    sampling_param.logprobs = true;
-  }
-  // sampling_param.do_sample = sp.do_sample;
-
-  std::unordered_set<int32_t> stop_tokens;
-  if (sp.stop_token_ids.has_value()) {
-    const auto& stop_token_ids = sp.stop_token_ids.value();
-    stop_tokens.insert(stop_token_ids.begin(), stop_token_ids.end());
-  } else if (!sp.ignore_eos) {
-    stop_tokens = model_args_.stop_token_ids();
-  }
-  std::vector<std::vector<int32_t>> stop_sequences;
-  if (sp.stop.has_value()) {
-    for (const auto& s : sp.stop.value()) {
-      std::vector<int32_t> tmp_tokens;
-      if (!tokenizer_->encode(s, &tmp_tokens)) {
-        CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                            "Failed to encode stop sequence");
-        LOG(ERROR) << "Failed to encode stop sequence: " << s;
-        return nullptr;
-      }
-      stop_sequences.push_back(std::move(tmp_tokens));
-    }
-  }
-
-  StoppingChecker stopping_checker(max_tokens,
-                                   max_context_len,
-                                   model_args_.eos_token_id(),
-                                   sp.ignore_eos,
-                                   std::move(stop_tokens),
-                                   std::move(stop_sequences));
-
-  // results cannot be streamed when best_of != n
-  bool stream = sp.streaming;
-  if (best_of != sp.n) {
-    stream = false;
-  }
-
-  RequestState req_state(std::move(prompt),
-                         std::move(prompt_tokens),
-                         std::move(mm_data),
-                         std::move(sampling_param),
-                         std::move(stopping_checker),
-                         capacity,
-                         sp.n,
-                         best_of,
-                         sp.logprobs,
-                         stream,
-                         sp.echo,
-                         sp.skip_special_tokens,
-                         options_.enable_schedule_overlap(),
-                         callback,
-                         nullptr);
-  req_state.include_stop_str_in_output = sp.include_stop_str_in_output;
-  rate_limit_guard.dismiss();
-  auto request = std::make_shared<Request>(sp.request_id,
-                                           sp.x_request_id,
-                                           sp.x_request_time,
-                                           std::move(req_state),
-                                           sp.service_request_id,
-                                           sp.source_xservice_addr,
-                                           get_rate_limiter());
-
-  // add one sequence, rest will be added by scheduler
-  return request;
-}
-
-std::shared_ptr<Request> VLMMaster::generate_request(
-    std::vector<Message> messages,
-    RequestParams sp,
-    std::string payload,
-    OutputCallback callback) {
-  // Guard the rate-limit slot acquired at the service entry. The next hop
-  // (generate_request(prompt, ...)) installs its own guard, so we dismiss
-  // ours before forwarding.
-  xllm::ScopeGuard rate_limit_guard(
-      [this] { get_rate_limiter()->decrease_one_request(); });
-
-  static MMInputTransfer mm_input_transfer;
-
-  MMInput mm_inputs(std::move(payload));
-  MMErrCode code = mm_input_transfer.trans(messages, mm_inputs);
-  if (code != MMErrCode::SUCCESS) {
-    std::string error_message = MMErrToString(code);
-    LOG(ERROR) << error_message;
-    CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT, error_message);
-    return nullptr;
-  }
-
-  MMData mm_data;
-  if (!mm_inputs.empty() &&
-      !processor_->process_multimodal(mm_inputs, mm_data)) {
-    CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                        "Failed to process multimodal input.");
-    return nullptr;
-  }
-
-  Timer timer;
-  std::optional<std::string> prompt =
-      chat_template_->apply(messages, sp.tools, sp.chat_template_kwargs);
-  if (!prompt.has_value()) {
-    std::string error_message = "Failed to construct prompt from messages";
-    LOG(ERROR) << error_message;
-    CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT, error_message);
-    return nullptr;
-  }
-  COUNTER_ADD(chat_template_latency_seconds, timer.elapsed_seconds());
-
-  rate_limit_guard.dismiss();
-  return generate_request(std::move(prompt.value()),
-                          std::move(mm_data),
-                          std::move(sp),
-                          std::move(callback));
 }
 
 }  // namespace xllm

--- a/xllm/core/distributed_runtime/vlm_master.h
+++ b/xllm/core/distributed_runtime/vlm_master.h
@@ -32,14 +32,13 @@ limitations under the License.
 #include "framework/chat_template/jinja_chat_template.h"
 #include "framework/request/request_output.h"
 #include "framework/request/request_params.h"
+#include "framework/request/vlm_request_factory.h"
 #include "framework/tokenizer/tokenizer.h"
 #include "master.h"
 #include "scheduler/continuous_scheduler.h"
 #include "xllm/processors/multimodal_processor.h"
 
 namespace xllm {
-
-struct MMData;
 
 class VLMMaster : public Master {
  public:
@@ -86,33 +85,23 @@ class VLMMaster : public Master {
 
  private:
   using Task = folly::Function<void()>;
-  std::shared_ptr<Request> build_request(std::string prompt,
-                                         std::vector<int32_t> prompt_tokens,
-                                         MMData mm_data,
-                                         RequestParams sp,
-                                         OutputCallback callback);
-
-  std::shared_ptr<Request> generate_request(std::string prompt,
-                                            MMData mm_data,
-                                            RequestParams sp,
-                                            OutputCallback callback);
-
-  std::shared_ptr<Request> generate_request(std::vector<Message> messages,
-                                            RequestParams sp,
-                                            std::string payload,
-                                            OutputCallback callback);
 
   std::unique_ptr<Scheduler> scheduler_;
 
   // model args
   ModelArgs model_args_;
 
-  // thread pool for handling requests
+  // thread pool for handling requests. Its worker lambdas dereference
+  // request_factory_ and scheduler_, so the pool is explicitly reset
+  // (drained/joined) in ~VLMMaster before those members are destroyed.
   std::unique_ptr<ThreadPool> threadpool_;
 
   std::unique_ptr<JinjaChatTemplate> chat_template_;
   std::unique_ptr<MultimodalProcessorBase> processor_;
   std::shared_ptr<Tokenizer> tokenizer_;
+
+  // builds Request aggregates from prompts/messages + multimodal data
+  std::unique_ptr<VLMRequestFactory> request_factory_;
 
   // thread for moving forward the scheduler
   std::thread loop_thread_;

--- a/xllm/core/framework/request/CMakeLists.txt
+++ b/xllm/core/framework/request/CMakeLists.txt
@@ -11,6 +11,7 @@ cc_library(
     request_base.h
     request.h
     llm_request_factory.h
+    vlm_request_factory.h
     dit_request.h
     request_output.h
     usage.h
@@ -33,6 +34,7 @@ cc_library(
     request.cpp
     request_base.cpp
     llm_request_factory.cpp
+    vlm_request_factory.cpp
     dit_request.cpp
     request_output.cpp
     dit_request_output.cpp

--- a/xllm/core/framework/request/vlm_request_factory.cpp
+++ b/xllm/core/framework/request/vlm_request_factory.cpp
@@ -1,0 +1,264 @@
+/* Copyright 2025-2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "vlm_request_factory.h"
+
+#include <glog/logging.h>
+
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "common/macros.h"
+#include "common/metrics.h"
+#include "core/common/message.h"
+#include "core/framework/multimodal/mm_data.h"
+#include "core/framework/multimodal/mm_input.h"
+#include "framework/tokenizer/tokenizer.h"
+#include "util/scope_guard.h"
+#include "util/timer.h"
+
+namespace xllm {
+
+VLMRequestFactory::VLMRequestFactory(MultimodalProcessorBase* processor,
+                                     JinjaChatTemplate* chat_template,
+                                     const Tokenizer* tokenizer,
+                                     const ModelArgs* model_args,
+                                     const Options* options,
+                                     RateLimiter* rate_limiter)
+    : processor_(processor),
+      chat_template_(chat_template),
+      tokenizer_(tokenizer),
+      model_args_(model_args),
+      options_(options),
+      rate_limiter_(rate_limiter) {
+  CHECK(processor_ != nullptr);
+  CHECK(chat_template_ != nullptr);
+  CHECK(tokenizer_ != nullptr);
+  CHECK(model_args_ != nullptr);
+  CHECK(options_ != nullptr);
+  CHECK(rate_limiter_ != nullptr);
+}
+
+std::shared_ptr<Request> VLMRequestFactory::create(std::string prompt,
+                                                   MMData mm_data,
+                                                   const RequestParams& sp,
+                                                   OutputCallback callback) {
+  // Guard the rate-limit slot acquired at the service entry. build_request
+  // installs its own guard, so we dismiss ours before forwarding.
+  xllm::ScopeGuard rate_limit_guard(
+      [this] { rate_limiter_->decrease_one_request(); });
+
+  if (prompt.empty() && mm_data.empty()) {
+    LOG(ERROR) << "Prompt and multimodal data cannot be both empty.";
+    CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
+                        "Prompt and multimodal data are both empty.");
+    return nullptr;
+  }
+
+  std::vector<int32_t> prompt_tokens;
+  if (!processor_->process_prompt(prompt, mm_data, prompt_tokens)) {
+    CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
+                        "Failed to process prompt.");
+    return nullptr;
+  }
+
+  rate_limit_guard.dismiss();
+  return build_request(std::move(prompt),
+                       std::move(prompt_tokens),
+                       std::move(mm_data),
+                       sp,
+                       std::move(callback));
+}
+
+std::shared_ptr<Request> VLMRequestFactory::build_request(
+    std::string prompt,
+    std::vector<int32_t> prompt_tokens,
+    MMData mm_data,
+    const RequestParams& sp,
+    OutputCallback callback) {
+  // Guard the rate-limit slot acquired at the service entry. Any early
+  // return below releases it; success path dismisses right before Request
+  // takes ownership.
+  xllm::ScopeGuard rate_limit_guard(
+      [this] { rate_limiter_->decrease_one_request(); });
+
+  const int32_t max_context_len = model_args_->max_position_embeddings();
+  int32_t prompt_token_limit = max_context_len;
+  if (!options_->enable_chunked_prefill()) {
+    prompt_token_limit =
+        std::min(prompt_token_limit, options_->max_tokens_per_batch());
+  }
+  if (prompt_tokens.size() >= static_cast<size_t>(prompt_token_limit)) {
+    LOG(ERROR) << "Prompt is too long: " << prompt_tokens.size();
+    CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT, "Prompt is too long");
+    return nullptr;
+  }
+
+  uint32_t max_tokens = sp.max_tokens;
+  if (max_tokens == 0) {
+    const uint32_t kDefaultMaxTokens = 5120;
+    max_tokens = kDefaultMaxTokens;
+  }
+
+  // allocate enough capacity for prompt tokens, max tokens, and speculative
+  // tokens, TODO: add image token size as well.
+  const size_t capacity = prompt_tokens.size() + max_tokens + 1;
+  const size_t best_of = sp.best_of.value_or(sp.n);
+
+  RequestSamplingParam sampling_param = build_sampling_param(sp, best_of);
+
+  std::optional<StoppingChecker> stopping_checker =
+      build_stopping_checker(sp, max_tokens, max_context_len, callback);
+  if (!stopping_checker.has_value()) {
+    return nullptr;
+  }
+
+  // results cannot be streamed when best_of != n
+  bool stream = sp.streaming;
+  if (best_of != sp.n) {
+    stream = false;
+  }
+
+  RequestState req_state(std::move(prompt),
+                         std::move(prompt_tokens),
+                         std::move(mm_data),
+                         std::move(sampling_param),
+                         std::move(stopping_checker.value()),
+                         capacity,
+                         sp.n,
+                         best_of,
+                         sp.logprobs,
+                         stream,
+                         sp.echo,
+                         sp.skip_special_tokens,
+                         options_->enable_schedule_overlap(),
+                         callback,
+                         nullptr);
+  req_state.include_stop_str_in_output = sp.include_stop_str_in_output;
+
+  rate_limit_guard.dismiss();
+  // add one sequence, rest will be added by scheduler
+  return std::make_shared<Request>(sp.request_id,
+                                   sp.x_request_id,
+                                   sp.x_request_time,
+                                   std::move(req_state),
+                                   sp.service_request_id,
+                                   sp.source_xservice_addr,
+                                   rate_limiter_);
+}
+
+RequestSamplingParam VLMRequestFactory::build_sampling_param(
+    const RequestParams& sp,
+    size_t best_of) const {
+  RequestSamplingParam sampling_param;
+  sampling_param.frequency_penalty = sp.frequency_penalty;
+  sampling_param.presence_penalty = sp.presence_penalty;
+  sampling_param.repetition_penalty = sp.repetition_penalty;
+  sampling_param.temperature = sp.temperature;
+  sampling_param.top_p = sp.top_p;
+  sampling_param.top_k = sp.top_k;
+  sampling_param.logprobs = sp.logprobs;
+  sampling_param.top_logprobs = sp.top_logprobs;
+  sampling_param.is_embeddings = sp.is_embeddings;
+  if (best_of > sp.n) {
+    // enable logprobs for best_of to generate sequence logprob
+    sampling_param.logprobs = true;
+  }
+  // sampling_param.do_sample = sp.do_sample;
+  return sampling_param;
+}
+
+std::optional<StoppingChecker> VLMRequestFactory::build_stopping_checker(
+    const RequestParams& sp,
+    uint32_t max_tokens,
+    int32_t max_context_len,
+    const OutputCallback& callback) {
+  std::unordered_set<int32_t> stop_tokens;
+  if (sp.stop_token_ids.has_value()) {
+    const auto& stop_token_ids = sp.stop_token_ids.value();
+    stop_tokens.insert(stop_token_ids.begin(), stop_token_ids.end());
+  } else if (!sp.ignore_eos) {
+    stop_tokens = model_args_->stop_token_ids();
+  }
+  std::vector<std::vector<int32_t>> stop_sequences;
+  if (sp.stop.has_value()) {
+    for (const auto& s : sp.stop.value()) {
+      std::vector<int32_t> tmp_tokens;
+      if (!tokenizer_->encode(s, &tmp_tokens)) {
+        CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
+                            "Failed to encode stop sequence");
+        LOG(ERROR) << "Failed to encode stop sequence: " << s;
+        return std::nullopt;
+      }
+      stop_sequences.push_back(std::move(tmp_tokens));
+    }
+  }
+
+  return StoppingChecker(max_tokens,
+                         max_context_len,
+                         model_args_->eos_token_id(),
+                         sp.ignore_eos,
+                         std::move(stop_tokens),
+                         std::move(stop_sequences));
+}
+
+std::shared_ptr<Request> VLMRequestFactory::create(
+    std::vector<Message> messages,
+    const RequestParams& sp,
+    std::string payload,
+    OutputCallback callback) {
+  // Guard the rate-limit slot acquired at the service entry. The next hop
+  // (create(prompt, ...)) installs its own guard, so we dismiss ours before
+  // forwarding.
+  xllm::ScopeGuard rate_limit_guard(
+      [this] { rate_limiter_->decrease_one_request(); });
+
+  static MMInputTransfer mm_input_transfer;
+
+  MMInput mm_inputs(std::move(payload));
+  MMErrCode code = mm_input_transfer.trans(messages, mm_inputs);
+  if (code != MMErrCode::SUCCESS) {
+    std::string error_message = MMErrToString(code);
+    LOG(ERROR) << error_message;
+    CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT, error_message);
+    return nullptr;
+  }
+
+  MMData mm_data;
+  if (!mm_inputs.empty() &&
+      !processor_->process_multimodal(mm_inputs, mm_data)) {
+    CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
+                        "Failed to process multimodal input.");
+    return nullptr;
+  }
+
+  Timer timer;
+  std::optional<std::string> prompt =
+      chat_template_->apply(messages, sp.tools, sp.chat_template_kwargs);
+  if (!prompt.has_value()) {
+    std::string error_message = "Failed to construct prompt from messages";
+    LOG(ERROR) << error_message;
+    CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT, error_message);
+    return nullptr;
+  }
+  COUNTER_ADD(chat_template_latency_seconds, timer.elapsed_seconds());
+
+  rate_limit_guard.dismiss();
+  return create(
+      std::move(prompt.value()), std::move(mm_data), sp, std::move(callback));
+}
+
+}  // namespace xllm

--- a/xllm/core/framework/request/vlm_request_factory.h
+++ b/xllm/core/framework/request/vlm_request_factory.h
@@ -1,0 +1,100 @@
+/* Copyright 2025-2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "common/message.h"
+#include "common/options.h"
+#include "common/rate_limiter.h"
+#include "core/framework/multimodal/mm_data.h"
+#include "framework/chat_template/jinja_chat_template.h"
+#include "framework/model/model_args.h"
+#include "framework/request/request.h"
+#include "framework/request/request_output.h"
+#include "framework/request/request_params.h"
+#include "framework/request/request_state.h"
+#include "framework/request/stopping_checker.h"
+#include "framework/sampling/sampling_params.h"
+#include "xllm/processors/multimodal_processor.h"
+
+namespace xllm {
+
+class Tokenizer;
+
+// Factory that assembles a domain Request aggregate for the VLM path from raw
+// user input (a text prompt with multimodal data, or chat messages plus a
+// multimodal payload) and RequestParams. It encapsulates multimodal
+// preprocessing, prompt tokenization via the processor, chat-template
+// rendering, length validation, and sampling/stopping parameter assembly.
+//
+// The factory holds non-owning references to model configuration owned by
+// VLMMaster (processor, chat template, tokenizer, model args, options, rate
+// limiter); the owner must outlive the factory.
+class VLMRequestFactory final {
+ public:
+  VLMRequestFactory(MultimodalProcessorBase* processor,
+                    JinjaChatTemplate* chat_template,
+                    const Tokenizer* tokenizer,
+                    const ModelArgs* model_args,
+                    const Options* options,
+                    RateLimiter* rate_limiter);
+
+  // completion: a text prompt plus already-decoded multimodal data.
+  std::shared_ptr<Request> create(std::string prompt,
+                                  MMData mm_data,
+                                  const RequestParams& sp,
+                                  OutputCallback callback);
+
+  // chat: decodes the multimodal payload and renders messages into a prompt,
+  // then delegates to the completion overload above.
+  std::shared_ptr<Request> create(std::vector<Message> messages,
+                                  const RequestParams& sp,
+                                  std::string payload,
+                                  OutputCallback callback);
+
+ private:
+  std::shared_ptr<Request> build_request(std::string prompt,
+                                         std::vector<int32_t> prompt_tokens,
+                                         MMData mm_data,
+                                         const RequestParams& sp,
+                                         OutputCallback callback);
+
+  RequestSamplingParam build_sampling_param(const RequestParams& sp,
+                                            size_t best_of) const;
+
+  // Builds the stopping checker, encoding any stop sequences. Returns
+  // std::nullopt after firing an error callback when a stop sequence fails to
+  // encode.
+  std::optional<StoppingChecker> build_stopping_checker(
+      const RequestParams& sp,
+      uint32_t max_tokens,
+      int32_t max_context_len,
+      const OutputCallback& callback);
+
+  MultimodalProcessorBase* processor_ = nullptr;
+  JinjaChatTemplate* chat_template_ = nullptr;
+  const Tokenizer* tokenizer_ = nullptr;
+  const ModelArgs* model_args_ = nullptr;
+  const Options* options_ = nullptr;
+  RateLimiter* rate_limiter_ = nullptr;
+};
+
+}  // namespace xllm


### PR DESCRIPTION
Move VLM request-building logic (generate_request/build_request) out of VLMMaster into a dedicated VLMRequestFactory. The factory encapsulates multimodal preprocessing, prompt tokenization, chat-template rendering, length validation, and sampling/stopping parameter assembly, splitting build_sampling_param and build_stopping_checker into focused helpers. VLMMaster now owns the factory and delegates from handle_request.

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
