### PR TITLE
refactor: extract RecRequestFactory from RecMaster in distributed runtime.

### DIFF
--- a/tests/core/framework/request/CMakeLists.txt
+++ b/tests/core/framework/request/CMakeLists.txt
@@ -28,6 +28,31 @@ target_link_options(vlm_request_factory_test
 
 cc_test(
   NAME
+    rec_request_factory_test
+  SRCS
+    rec_request_factory_test.cpp
+  DEPS
+    :common
+    :config
+    :request
+    :util
+    $<$<BOOL:${USE_MLU}>:torch_mlu>
+    $<$<BOOL:${USE_NPU}>:torch_npu>
+    GTest::gtest_main
+)
+target_link_libraries(rec_request_factory_test
+                      PUBLIC
+                      Python::Python
+                      $<$<BOOL:${USE_NPU}>:ascendcl>
+                      $<$<BOOL:${USE_NPU}>:hccl>
+                      $<$<BOOL:${USE_NPU}>:c_sec>
+                      $<$<BOOL:${USE_NPU}>:nnopbase>)
+target_link_options(rec_request_factory_test
+                    PRIVATE
+                    $<$<BOOL:${USE_MLU}>:-Wl,--no-as-needed>)
+
+cc_test(
+  NAME
     sample_slot_test
   SRCS
     sample_slot_test.cpp

--- a/tests/core/framework/request/rec_request_factory_test.cpp
+++ b/tests/core/framework/request/rec_request_factory_test.cpp
@@ -1,0 +1,347 @@
+/* Copyright 2025-2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "framework/request/rec_request_factory.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "common/options.h"
+#include "common/rate_limiter.h"
+#include "core/common/types.h"
+#include "framework/model/model_args.h"
+#include "framework/request/rec_type.h"
+#include "framework/request/request_output.h"
+#include "framework/request/request_params.h"
+#include "framework/tokenizer/tokenizer.h"
+#include "rec.pb.h"
+#include "util/rec_model_utils.h"
+
+namespace xllm {
+namespace {
+
+// Deterministic tokenizer for factory tests. Encoding fails for any text that
+// contains the marker "FAIL", so tokenize/stop-sequence error paths can be
+// exercised independently.
+class FakeTokenizer final : public Tokenizer {
+ public:
+  explicit FakeTokenizer(int32_t vocab_size) : vocab_size_(vocab_size) {}
+
+  bool encode(const std::string_view& text,
+              std::vector<int32_t>* ids,
+              bool /*add_special_tokens*/ = true) const override {
+    if (text.find("FAIL") != std::string_view::npos) {
+      return false;
+    }
+    ids->clear();
+    for (const char c : text) {
+      ids->push_back(static_cast<int32_t>(static_cast<unsigned char>(c)) %
+                     vocab_size_);
+    }
+    if (ids->empty()) {
+      ids->push_back(1);
+    }
+    return true;
+  }
+
+  size_t vocab_size() const override {
+    return static_cast<size_t>(vocab_size_);
+  }
+
+  std::unique_ptr<Tokenizer> clone() const override {
+    return std::make_unique<FakeTokenizer>(*this);
+  }
+
+ private:
+  int32_t vocab_size_ = 1000;
+};
+
+// Records the last error surfaced through the OutputCallback.
+struct CallbackCapture {
+  bool called = false;
+  std::optional<Status> status;
+};
+
+OutputCallback make_capture_callback(CallbackCapture* capture) {
+  return [capture](RequestOutput output) {
+    capture->called = true;
+    capture->status = output.status;
+    return false;
+  };
+}
+
+class RecRequestFactoryTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Simulate the caller (service entry) having acquired a rate-limit slot.
+    rate_limiter_.is_limited();
+    ASSERT_EQ(rate_limiter_.get_num_concurrent_requests(), 1);
+  }
+
+  void configure_model(int32_t vocab_size, int32_t max_position) {
+    model_args_.vocab_size(vocab_size)
+        .max_position_embeddings(max_position)
+        .hidden_size(4)
+        .eos_token_id(-1)
+        .bos_token_id(0);
+    // enable_chunked_prefill defaults true; keep it so the prompt length limit
+    // is exactly max_position_embeddings.
+    options_.enable_service_routing(false).num_speculative_tokens(0);
+  }
+
+  std::unique_ptr<RecRequestFactory> make_llmrec_factory(
+      int32_t vocab_size = 1000,
+      int32_t max_position = 2048) {
+    configure_model(vocab_size, max_position);
+    tokenizer_ = std::make_unique<FakeTokenizer>(vocab_size);
+    return std::make_unique<RecRequestFactory>(&model_args_,
+                                               tokenizer_.get(),
+                                               &options_,
+                                               &rate_limiter_,
+                                               RecType::kLlmRec,
+                                               RecPipelineType::kLlmRecDefault);
+  }
+
+  std::unique_ptr<RecRequestFactory> make_onerec_factory(
+      int32_t max_position = 2048) {
+    configure_model(/*vocab_size=*/1000, max_position);
+    // OneRec models do not require a tokenizer for the input paths tested here.
+    return std::make_unique<RecRequestFactory>(&model_args_,
+                                               /*tokenizer=*/nullptr,
+                                               &options_,
+                                               &rate_limiter_,
+                                               RecType::kOneRec,
+                                               RecPipelineType::kOneRecDefault);
+  }
+
+  std::unique_ptr<FakeTokenizer> tokenizer_;
+  ModelArgs model_args_;
+  Options options_;
+  RateLimiter rate_limiter_;
+};
+
+// -------------------------- LlmRec: prompt overload -------------------------
+
+TEST_F(RecRequestFactoryTest, LlmRecRejectsEmptyInputReleasesRateLimitSlot) {
+  auto factory = make_llmrec_factory();
+  CallbackCapture capture;
+  RequestParams sp;
+
+  auto request = factory->create(/*prompt=*/"",
+                                 /*prompt_tokens=*/std::nullopt,
+                                 /*input_tensors=*/std::nullopt,
+                                 sp,
+                                 make_capture_callback(&capture));
+
+  EXPECT_EQ(request, nullptr);
+  ASSERT_TRUE(capture.called);
+  ASSERT_TRUE(capture.status.has_value());
+  EXPECT_EQ(capture.status->code(), StatusCode::INVALID_ARGUMENT);
+  EXPECT_EQ(capture.status->message(),
+            "LlmRec requires prompt or prompt_tokens to be provided");
+  EXPECT_EQ(rate_limiter_.get_num_concurrent_requests(), 0);
+}
+
+TEST_F(RecRequestFactoryTest, LlmRecFailsWhenPromptTokenizationFails) {
+  auto factory = make_llmrec_factory();
+  CallbackCapture capture;
+  RequestParams sp;
+
+  auto request = factory->create(/*prompt=*/"please FAIL here",
+                                 /*prompt_tokens=*/std::nullopt,
+                                 /*input_tensors=*/std::nullopt,
+                                 sp,
+                                 make_capture_callback(&capture));
+
+  EXPECT_EQ(request, nullptr);
+  ASSERT_TRUE(capture.status.has_value());
+  EXPECT_EQ(capture.status->message(), "Failed to tokenize prompt");
+  EXPECT_EQ(rate_limiter_.get_num_concurrent_requests(), 0);
+}
+
+TEST_F(RecRequestFactoryTest, LlmRecRejectsPromptLongerThanContext) {
+  auto factory = make_llmrec_factory(/*vocab_size=*/1000, /*max_position=*/8);
+  CallbackCapture capture;
+  RequestParams sp;
+
+  auto request = factory->create(
+      /*prompt=*/"",
+      /*prompt_tokens=*/std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8},
+      /*input_tensors=*/std::nullopt,
+      sp,
+      make_capture_callback(&capture));
+
+  EXPECT_EQ(request, nullptr);
+  ASSERT_TRUE(capture.status.has_value());
+  EXPECT_EQ(capture.status->message(), "Prompt is too long");
+  EXPECT_EQ(rate_limiter_.get_num_concurrent_requests(), 0);
+}
+
+TEST_F(RecRequestFactoryTest, LlmRecFailsWhenStopSequenceEncodingFails) {
+  auto factory = make_llmrec_factory();
+  CallbackCapture capture;
+  RequestParams sp;
+  sp.stop = std::vector<std::string>{"FAIL-STOP"};
+
+  auto request = factory->create(/*prompt=*/"",
+                                 /*prompt_tokens=*/std::vector<int>{1, 2, 3},
+                                 /*input_tensors=*/std::nullopt,
+                                 sp,
+                                 make_capture_callback(&capture));
+
+  EXPECT_EQ(request, nullptr);
+  ASSERT_TRUE(capture.status.has_value());
+  EXPECT_EQ(capture.status->message(), "Failed to encode stop sequence");
+  EXPECT_EQ(rate_limiter_.get_num_concurrent_requests(), 0);
+}
+
+TEST_F(RecRequestFactoryTest, LlmRecCreatesRequestForValidPromptTokens) {
+  auto factory = make_llmrec_factory();
+  CallbackCapture capture;
+  RequestParams sp;
+  sp.request_id = "req-tokens";
+  sp.max_tokens = 16;
+
+  auto request = factory->create(/*prompt=*/"",
+                                 /*prompt_tokens=*/std::vector<int>{1, 2, 3},
+                                 /*input_tensors=*/std::nullopt,
+                                 sp,
+                                 make_capture_callback(&capture));
+
+  ASSERT_NE(request, nullptr);
+  EXPECT_FALSE(capture.called);
+  // On success the slot stays held; released later by the scheduler.
+  EXPECT_EQ(rate_limiter_.get_num_concurrent_requests(), 1);
+}
+
+TEST_F(RecRequestFactoryTest, LlmRecCreatesRequestForValidPromptString) {
+  auto factory = make_llmrec_factory();
+  CallbackCapture capture;
+  RequestParams sp;
+  sp.request_id = "req-prompt";
+  sp.max_tokens = 16;
+
+  auto request = factory->create(/*prompt=*/"hello world",
+                                 /*prompt_tokens=*/std::nullopt,
+                                 /*input_tensors=*/std::nullopt,
+                                 sp,
+                                 make_capture_callback(&capture));
+
+  ASSERT_NE(request, nullptr);
+  EXPECT_FALSE(capture.called);
+  EXPECT_EQ(rate_limiter_.get_num_concurrent_requests(), 1);
+}
+
+// ------------------------- LlmRec: mm_data overload -------------------------
+
+TEST_F(RecRequestFactoryTest, LlmRecMmDataOverloadCreatesRequestWithoutMmData) {
+  auto factory = make_llmrec_factory();
+  CallbackCapture capture;
+  RequestParams sp;
+  sp.request_id = "req-mm";
+  sp.max_tokens = 16;
+
+  auto request = factory->create(/*prompt_tokens=*/std::vector<int>{1, 2, 3},
+                                 /*mm_data=*/std::nullopt,
+                                 sp,
+                                 make_capture_callback(&capture));
+
+  ASSERT_NE(request, nullptr);
+  EXPECT_FALSE(capture.called);
+  EXPECT_EQ(rate_limiter_.get_num_concurrent_requests(), 1);
+}
+
+// -------------------------- OneRec: prompt overload -------------------------
+
+TEST_F(RecRequestFactoryTest, OneRecRejectsBothPromptTokensAndInputTensors) {
+  auto factory = make_onerec_factory();
+  CallbackCapture capture;
+  RequestParams sp;
+
+  auto request = factory->create(
+      /*prompt=*/"",
+      /*prompt_tokens=*/std::vector<int>{1},
+      /*input_tensors=*/std::vector<proto::InferInputTensor>{},
+      sp,
+      make_capture_callback(&capture));
+
+  EXPECT_EQ(request, nullptr);
+  ASSERT_TRUE(capture.status.has_value());
+  EXPECT_EQ(capture.status->message(),
+            "prompt_tokens and input_tensors cannot both be set");
+  EXPECT_EQ(rate_limiter_.get_num_concurrent_requests(), 0);
+}
+
+TEST_F(RecRequestFactoryTest, OneRecRejectsEmptyInput) {
+  auto factory = make_onerec_factory();
+  CallbackCapture capture;
+  RequestParams sp;
+
+  auto request = factory->create(/*prompt=*/"",
+                                 /*prompt_tokens=*/std::nullopt,
+                                 /*input_tensors=*/std::nullopt,
+                                 sp,
+                                 make_capture_callback(&capture));
+
+  EXPECT_EQ(request, nullptr);
+  ASSERT_TRUE(capture.status.has_value());
+  EXPECT_EQ(capture.status->message(),
+            "Rec model requires prompt_tokens or input_tensors to be provided");
+  EXPECT_EQ(rate_limiter_.get_num_concurrent_requests(), 0);
+}
+
+TEST_F(RecRequestFactoryTest, OneRecRejectsEmptyInputTensors) {
+  auto factory = make_onerec_factory();
+  CallbackCapture capture;
+  RequestParams sp;
+
+  auto request = factory->create(
+      /*prompt=*/"",
+      /*prompt_tokens=*/std::nullopt,
+      /*input_tensors=*/std::vector<proto::InferInputTensor>{},
+      sp,
+      make_capture_callback(&capture));
+
+  EXPECT_EQ(request, nullptr);
+  ASSERT_TRUE(capture.status.has_value());
+  EXPECT_EQ(capture.status->message(), "OneRec input_tensors cannot be empty");
+  EXPECT_EQ(rate_limiter_.get_num_concurrent_requests(), 0);
+}
+
+TEST_F(RecRequestFactoryTest, OneRecCreatesRequestForPromptTokens) {
+  auto factory = make_onerec_factory();
+  CallbackCapture capture;
+  RequestParams sp;
+  sp.request_id = "req-onerec";
+  sp.max_tokens = 16;
+
+  auto request = factory->create(/*prompt=*/"",
+                                 /*prompt_tokens=*/std::vector<int>{1, 2, 3},
+                                 /*input_tensors=*/std::nullopt,
+                                 sp,
+                                 make_capture_callback(&capture));
+
+  ASSERT_NE(request, nullptr);
+  EXPECT_FALSE(capture.called);
+  EXPECT_EQ(rate_limiter_.get_num_concurrent_requests(), 1);
+}
+
+}  // namespace
+}  // namespace xllm

--- a/xllm/core/distributed_runtime/rec_master.cpp
+++ b/xllm/core/distributed_runtime/rec_master.cpp
@@ -15,16 +15,12 @@ limitations under the License.
 
 #include "rec_master.h"
 
-#include <absl/strings/str_join.h>
 #include <absl/time/time.h>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <pybind11/pybind11.h>
-#include <torch/torch.h>
 
-#include <limits>
 #include <string>
-#include <unordered_set>
 #include <vector>
 
 #include "common/macros.h"
@@ -38,25 +34,11 @@ limitations under the License.
 #include "util/rec_model_utils.h"
 #include "util/scope_guard.h"
 #include "util/threadpool.h"
-#include "util/utils.h"
+#include "util/timer.h"
 
 namespace xllm {
 
 namespace {
-
-constexpr int32_t kDefaultPlaceholderToken = 20152019;
-constexpr const char* kOneRecSparseEmbeddingName = "sparse_embedding";
-constexpr const char* kOneRecDecoderContextEmbeddingName =
-    "decoder_context_embedding";
-
-std::string format_tensor_shape(const proto::InferInputTensor& tensor) {
-  std::vector<std::string> dims;
-  dims.reserve(tensor.shape_size());
-  for (int i = 0; i < tensor.shape_size(); ++i) {
-    dims.emplace_back(std::to_string(tensor.shape(i)));
-  }
-  return "[" + absl::StrJoin(dims, ", ") + "]";
-}
 
 RecType get_rec_type(const ModelArgs& model_args) {
   const auto kind = get_rec_model_kind(model_args.model_type());
@@ -71,465 +53,7 @@ RecType get_rec_type(const ModelArgs& model_args) {
   return RecType::kNone;
 }
 
-bool process_onerec_inputs(
-    const std::optional<std::vector<int>>& prompt_tokens,
-    const std::optional<std::vector<proto::InferInputTensor>>& input_tensors,
-    const ModelArgs& model_args,
-    std::vector<int32_t>* local_prompt_tokens,
-    MMData* processed_mm_data,
-    OutputCallback callback) {
-  if (prompt_tokens.has_value() && input_tensors.has_value()) {
-    CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                        "prompt_tokens and input_tensors cannot both be set");
-    return false;
-  }
-
-  if (prompt_tokens.has_value()) {
-    local_prompt_tokens->assign(prompt_tokens.value().begin(),
-                                prompt_tokens.value().end());
-  }
-
-  if (input_tensors.has_value()) {
-    if (input_tensors->empty()) {
-      CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                          "OneRec input_tensors cannot be empty");
-      return false;
-    }
-
-    MMDict mm_dict;
-    mm_dict.reserve(input_tensors->size());
-    bool has_sparse_embedding = false;
-    bool has_decoder_context_embedding = false;
-    int64_t sparse_embedding_hidden_size = -1;
-    int64_t decoder_context_hidden_size = -1;
-
-    for (const auto& tensor : input_tensors.value()) {
-      const auto& tensor_name = tensor.name();
-      if (tensor_name != kOneRecSparseEmbeddingName &&
-          tensor_name != kOneRecDecoderContextEmbeddingName) {
-        CALLBACK_WITH_ERROR(
-            StatusCode::INVALID_ARGUMENT,
-            "OneRec input_tensors only supports 'sparse_embedding' and "
-            "'decoder_context_embedding', got '" +
-                tensor_name + "'");
-        return false;
-      }
-      if (mm_dict.find(tensor_name) != mm_dict.end()) {
-        CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                            "Duplicate OneRec input tensor: " + tensor_name);
-        return false;
-      }
-      if (!tensor.has_contents()) {
-        CALLBACK_WITH_ERROR(
-            StatusCode::INVALID_ARGUMENT,
-            "OneRec input tensor '" + tensor_name + "' has no contents");
-        return false;
-      }
-      if (tensor.data_type() != proto::DataType::FLOAT) {
-        CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                            "OneRec input tensor '" + tensor_name +
-                                "' must use FLOAT(fp32), got " +
-                                proto::DataType_Name(tensor.data_type()));
-        return false;
-      }
-      if (tensor.shape_size() != 2) {
-        CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                            "OneRec input tensor '" + tensor_name +
-                                "' must be 2-D [len, hidden], got " +
-                                format_tensor_shape(tensor));
-        return false;
-      }
-
-      const int64_t len = tensor.shape(0);
-      const int64_t hidden = tensor.shape(1);
-      if (len <= 0 || hidden <= 0) {
-        CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                            "OneRec input tensor '" + tensor_name +
-                                "' must have positive shape, got " +
-                                format_tensor_shape(tensor));
-        return false;
-      }
-      if (hidden != model_args.hidden_size()) {
-        CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                            "OneRec input tensor '" + tensor_name +
-                                "' hidden size mismatch, expected " +
-                                std::to_string(model_args.hidden_size()) +
-                                ", got " + std::to_string(hidden));
-        return false;
-      }
-
-      if (len > std::numeric_limits<int64_t>::max() / hidden) {
-        CALLBACK_WITH_ERROR(
-            StatusCode::INVALID_ARGUMENT,
-            "OneRec input tensor '" + tensor_name + "' shape is too large");
-        return false;
-      }
-
-      const int64_t expected_numel = len * hidden;
-      const int64_t actual_numel =
-          static_cast<int64_t>(tensor.contents().fp32_contents_size());
-      if (expected_numel != actual_numel) {
-        CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                            "OneRec input tensor '" + tensor_name +
-                                "' fp32 contents size mismatch, expected " +
-                                std::to_string(expected_numel) + ", got " +
-                                std::to_string(actual_numel));
-        return false;
-      }
-
-      try {
-        mm_dict[tensor_name] =
-            util::convert_rec_tensor_to_torch(tensor).to(torch::kBFloat16);
-      } catch (const std::exception& e) {
-        CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                            "Failed to parse OneRec input tensor '" +
-                                tensor_name + "': " + e.what());
-        return false;
-      }
-
-      if (tensor_name == kOneRecSparseEmbeddingName) {
-        has_sparse_embedding = true;
-        sparse_embedding_hidden_size = hidden;
-      } else {
-        has_decoder_context_embedding = true;
-        decoder_context_hidden_size = hidden;
-      }
-    }
-
-    if (!has_sparse_embedding) {
-      CALLBACK_WITH_ERROR(
-          StatusCode::INVALID_ARGUMENT,
-          "OneRec input_tensors must include 'sparse_embedding'");
-      return false;
-    }
-    if (has_decoder_context_embedding &&
-        sparse_embedding_hidden_size != decoder_context_hidden_size) {
-      CALLBACK_WITH_ERROR(
-          StatusCode::INVALID_ARGUMENT,
-          "OneRec tensor hidden size mismatch: sparse_embedding=" +
-              std::to_string(sparse_embedding_hidden_size) +
-              ", decoder_context_embedding=" +
-              std::to_string(decoder_context_hidden_size));
-      return false;
-    }
-
-    *processed_mm_data = MMData(MMType::EMBEDDING, mm_dict);
-  }
-
-  if (local_prompt_tokens->empty() && !processed_mm_data->valid()) {
-    CALLBACK_WITH_ERROR(
-        StatusCode::INVALID_ARGUMENT,
-        "Rec model requires prompt_tokens or input_tensors to be provided");
-    return false;
-  }
-
-  return true;
-}
-
-bool process_llmrec_with_mm_data_inputs(
-    const std::vector<int>& prompt_tokens,
-    std::optional<MMData> mm_data,
-    std::vector<int32_t>* local_prompt_tokens,
-    MMData* processed_mm_data,
-    int32_t hidden_size,
-    OutputCallback callback) {
-  local_prompt_tokens->assign(prompt_tokens.begin(), prompt_tokens.end());
-
-  if (!mm_data.has_value()) {
-    return true;
-  }
-
-  std::vector<torch::Tensor> all_indices_list;
-  std::vector<torch::Tensor> all_values_list;
-
-  MMData mm_data_s = mm_data.value();
-  if (!mm_data_s.hold<MMItemVec>()) {
-    CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                        "MMData need be item vec type");
-    return false;
-  }
-
-  int64_t last_end = 0;
-  MMItemVec mm_items = mm_data_s.items<MMItemVec>();
-  for (auto& mm_item : mm_items) {
-    const MMItemState::TokenPos token_pos = mm_item.state().token_pos();
-    std::optional<torch::Tensor> mm_value =
-        mm_item.get<torch::Tensor>("tensor");
-
-    if (!mm_value.has_value()) {
-      CALLBACK_WITH_ERROR(
-          StatusCode::INVALID_ARGUMENT,
-          "Rec model requires embedding in mm data to be provided");
-      return false;
-    }
-
-    int64_t start = static_cast<int64_t>(token_pos.offset);
-    int64_t end = static_cast<int64_t>(token_pos.offset + token_pos.length);
-    torch::Tensor tensor = mm_value.value();
-
-    if (start < last_end || end >= local_prompt_tokens->size()) {
-      CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                          "Token pos in mm data is wrong");
-      return false;
-    }
-
-    last_end = end;
-
-    if (tensor.dim() != 2) {
-      CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                          "Embedding in mm data is invalid");
-      return false;
-    }
-
-    if (tensor.size(0) != token_pos.length) {
-      CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                          "Token length is not match to embedding");
-      return false;
-    }
-
-    if (tensor.size(1) != hidden_size) {
-      CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                          "Embedding size is not match to model hidden size");
-      return false;
-    }
-
-    torch::Tensor range_indices = torch::arange(start, end);
-    all_indices_list.push_back(range_indices);
-    all_values_list.push_back(tensor);
-  }
-
-  torch::Tensor total_indices = torch::cat(all_indices_list, 0);
-  torch::Tensor total_values = torch::cat(all_values_list, 0);
-
-  MMDict mm_dict;
-  mm_dict["MULTI_MODAL_INDICES"] = total_indices;
-  mm_dict["MULTI_MODAL_VALUES"] = total_values;
-  *processed_mm_data = MMData(MMType::EMBEDDING, mm_dict);
-
-  return true;
-}
-
 }  // namespace
-
-// ============================================================
-// RecMasterPipeline base class default implementations
-// ============================================================
-std::shared_ptr<Request> RecMaster::RecMasterPipeline::generate_request(
-    std::string /*prompt*/,
-    std::optional<std::vector<int>> /*prompt_tokens*/,
-    std::optional<std::vector<proto::InferInputTensor>> /*input_tensors*/,
-    const RequestParams& /*sp*/,
-    OutputCallback callback) {
-  master_.get_rate_limiter()->decrease_one_request();
-  CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                      "This pipeline does not support prompt-based input");
-  return nullptr;
-}
-
-std::shared_ptr<Request> RecMaster::RecMasterPipeline::generate_request(
-    const std::vector<int>& prompt_tokens,
-    std::optional<MMData> mm_data,
-    const RequestParams& sp,
-    OutputCallback callback) {
-  master_.get_rate_limiter()->decrease_one_request();
-  CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                      "This pipeline does not support raw input");
-  return nullptr;
-}
-
-std::shared_ptr<Request>
-RecMaster::RecMasterPipeline::generate_onerec_request_common(
-    std::string prompt,
-    std::optional<std::vector<int>> prompt_tokens,
-    std::optional<std::vector<proto::InferInputTensor>> input_tensors,
-    const RequestParams& sp,
-    OutputCallback callback,
-    bool build_stop_checker) {
-  xllm::ScopeGuard rate_limit_guard(
-      [this] { master_.get_rate_limiter()->decrease_one_request(); });
-
-  Timer timer;
-  std::vector<int32_t> local_prompt_tokens;
-  MMData processed_mm_data;
-
-  if (!process_onerec_inputs(prompt_tokens,
-                             input_tensors,
-                             master_.model_args_,
-                             &local_prompt_tokens,
-                             &processed_mm_data,
-                             callback)) {
-    return nullptr;
-  }
-
-  COUNTER_ADD(tokenization_latency_seconds, timer.elapsed_seconds());
-
-  rate_limit_guard.dismiss();
-  return master_.build_request_common(std::move(prompt),
-                                      std::move(local_prompt_tokens),
-                                      std::move(processed_mm_data),
-                                      sp,
-                                      callback,
-                                      build_stop_checker);
-}
-
-// ============================================================
-// LlmRecMasterPipeline implementation (pure qwen3, no mm_data)
-// ============================================================
-RecMaster::LlmRecMasterPipeline::LlmRecMasterPipeline(RecMaster& master)
-    : RecMasterPipeline(master) {}
-
-std::shared_ptr<Request> RecMaster::LlmRecMasterPipeline::generate_request(
-    std::string prompt,
-    std::optional<std::vector<int>> prompt_tokens,
-    std::optional<std::vector<proto::InferInputTensor>> /*input_tensors*/,
-    const RequestParams& sp,
-    OutputCallback callback) {
-  // Guard the rate-limit slot acquired at the service entry. Dismissed
-  // before we forward to build_request_common (which installs its own guard).
-  xllm::ScopeGuard rate_limit_guard(
-      [this] { master_.get_rate_limiter()->decrease_one_request(); });
-
-  Timer timer;
-  std::vector<int32_t> local_prompt_tokens;
-  MMData processed_mm_data;
-
-  // LlmRec without mm_data: use prompt_tokens or tokenize prompt string
-  if (prompt_tokens.has_value()) {
-    local_prompt_tokens.assign(prompt_tokens.value().begin(),
-                               prompt_tokens.value().end());
-  } else if (!prompt.empty()) {
-    // Tokenize prompt string if prompt_tokens not provided
-    if (!master_.tokenizer_) {
-      CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                          "Tokenizer is required for prompt-based input");
-      return nullptr;
-    }
-    std::vector<int> tmp_tokens;
-    if (!master_.tokenizer_->encode(
-            prompt, &tmp_tokens, sp.add_special_tokens)) {
-      CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                          "Failed to tokenize prompt");
-      return nullptr;
-    }
-    local_prompt_tokens.assign(tmp_tokens.begin(), tmp_tokens.end());
-  }
-
-  if (local_prompt_tokens.empty()) {
-    CALLBACK_WITH_ERROR(
-        StatusCode::INVALID_ARGUMENT,
-        "LlmRec requires prompt or prompt_tokens to be provided");
-    return nullptr;
-  }
-
-  COUNTER_ADD(tokenization_latency_seconds, timer.elapsed_seconds());
-
-  rate_limit_guard.dismiss();
-  return master_.build_request_common(std::move(prompt),
-                                      std::move(local_prompt_tokens),
-                                      std::move(processed_mm_data),
-                                      sp,
-                                      callback,
-                                      /*build_stop_checker=*/true);
-}
-
-// ============================================================
-// LlmRecWithMmDataMasterPipeline implementation (qwen3 with embedding)
-// ============================================================
-RecMaster::LlmRecWithMmDataMasterPipeline::LlmRecWithMmDataMasterPipeline(
-    RecMaster& master)
-    : RecMasterPipeline(master) {}
-
-std::shared_ptr<Request>
-RecMaster::LlmRecWithMmDataMasterPipeline::generate_request(
-    const std::vector<int>& prompt_tokens,
-    std::optional<MMData> mm_data,
-    const RequestParams& sp,
-    OutputCallback callback) {
-  xllm::ScopeGuard rate_limit_guard(
-      [this] { master_.get_rate_limiter()->decrease_one_request(); });
-
-  std::vector<int32_t> local_prompt_tokens;
-  MMData processed_mm_data;
-
-  int32_t hidden_size = master_.model_args_.hidden_size();
-  bool ret = process_llmrec_with_mm_data_inputs(prompt_tokens,
-                                                mm_data,
-                                                &local_prompt_tokens,
-                                                &processed_mm_data,
-                                                hidden_size,
-                                                callback);
-  if (!ret) {
-    return nullptr;
-  }
-
-  rate_limit_guard.dismiss();
-  return master_.build_request_common(std::string(""),
-                                      std::move(local_prompt_tokens),
-                                      std::move(processed_mm_data),
-                                      sp,
-                                      callback,
-                                      /*build_stop_checker=*/true);
-}
-
-// ============================================================
-// OneRecPrefillOnlyMasterPipeline implementation (OneRec with input_tensors)
-// ============================================================
-RecMaster::OneRecPrefillOnlyMasterPipeline::OneRecPrefillOnlyMasterPipeline(
-    RecMaster& master)
-    : RecMasterPipeline(master) {}
-
-std::shared_ptr<Request>
-RecMaster::OneRecPrefillOnlyMasterPipeline::generate_request(
-    std::string prompt,
-    std::optional<std::vector<int>> prompt_tokens,
-    std::optional<std::vector<proto::InferInputTensor>> input_tensors,
-    const RequestParams& sp,
-    OutputCallback callback) {
-  return generate_onerec_request_common(std::move(prompt),
-                                        std::move(prompt_tokens),
-                                        std::move(input_tensors),
-                                        sp,
-                                        callback,
-                                        /*build_stop_checker=*/false);
-}
-
-std::shared_ptr<Request>
-RecMaster::OneRecXAttentionMasterPipeline::generate_request(
-    std::string prompt,
-    std::optional<std::vector<int>> prompt_tokens,
-    std::optional<std::vector<proto::InferInputTensor>> input_tensors,
-    const RequestParams& sp,
-    OutputCallback callback) {
-  return generate_onerec_request_common(std::move(prompt),
-                                        std::move(prompt_tokens),
-                                        std::move(input_tensors),
-                                        sp,
-                                        callback,
-                                        /*build_stop_checker=*/true);
-}
-
-// ============================================================
-// RecMaster pipeline factory (static method)
-// ============================================================
-std::unique_ptr<RecMaster::RecMasterPipeline> RecMaster::create_pipeline(
-    RecPipelineType type,
-    RecMaster& master) {
-  switch (type) {
-    case RecPipelineType::kLlmRecDefault:
-    case RecPipelineType::kLlmRecMultiRoundPipeline:
-      return std::make_unique<LlmRecMasterPipeline>(master);
-    case RecPipelineType::kLlmRecWithMmData:
-      return std::make_unique<LlmRecWithMmDataMasterPipeline>(master);
-    case RecPipelineType::kOneRecDefault:
-      return std::make_unique<OneRecPrefillOnlyMasterPipeline>(master);
-    case RecPipelineType::kOneRecXAttentionPipeline:
-      return std::make_unique<OneRecXAttentionMasterPipeline>(master);
-    default:
-      LOG(FATAL) << "Unknown RecMaster pipeline type: "
-                 << static_cast<int>(type);
-      return nullptr;
-  }
-}
 
 RecMaster::RecMaster(const Options& options)
     : Master(options, EngineType::REC) {
@@ -595,18 +119,17 @@ RecMaster::RecMaster(const Options& options)
       /*cpu_binding=*/false,
       /*pool_name=*/"RecMaster.request");
 
-  // Create pipelines based on rec_type
+  // Create the request factory with the pipeline selected from the model kind.
   auto rec_model_kind = get_rec_model_kind(model_args_.model_type());
   CHECK(rec_model_kind != RecModelKind::kNone)
       << "Unsupported rec model_type: " << model_args_.model_type();
   auto pipeline_type = get_rec_pipeline_type(rec_model_kind);
-  pipeline_ = create_pipeline(pipeline_type, *this);
-
-  // For LlmRec, also create mm_data pipeline for raw input interface
-  if (rec_type_ == RecType::kLlmRec) {
-    mm_data_pipeline_ =
-        create_pipeline(RecPipelineType::kLlmRecWithMmData, *this);
-  }
+  request_factory_ = std::make_unique<RecRequestFactory>(&model_args_,
+                                                         tokenizer_.get(),
+                                                         &options_,
+                                                         get_rate_limiter(),
+                                                         rec_type_,
+                                                         pipeline_type);
 }
 
 void RecMaster::run() {
@@ -636,6 +159,17 @@ void RecMaster::run() {
 RecMaster::~RecMaster() {
   // set stop flag
   stopped_.store(true, std::memory_order_relaxed);
+
+  // Drain and join the request thread pool before any of the members its
+  // scheduled closures touch are destroyed. Those closures dereference
+  // request_factory_ (as well as scheduler_), but request_factory_ is declared
+  // after threadpool_ in the header, so member destruction would otherwise free
+  // the factory while pool tasks are still in flight. ~ThreadPool only
+  // signals/joins its workers when the pool is destroyed, so reset it here
+  // explicitly while all dependencies are alive. Done before joining
+  // loop_thread_ so the scheduler keeps advancing while the pool drains.
+  threadpool_.reset();
+
   // wait for the loop thread to finish
   if (loop_thread_.joinable()) {
     loop_thread_.join();
@@ -661,12 +195,11 @@ void RecMaster::handle_request(
                     prompt_tokens = std::move(prompt_tokens),
                     input_tensors = std::move(input_tensors)](
                        const RequestParams& params, OutputCallback cb) mutable {
-                     return pipeline_->generate_request(
-                         std::move(prompt),
-                         std::move(prompt_tokens),
-                         std::move(input_tensors),
-                         params,
-                         std::move(cb));
+                     return request_factory_->create(std::move(prompt),
+                                                     std::move(prompt_tokens),
+                                                     std::move(input_tensors),
+                                                     params,
+                                                     std::move(cb));
                    });
 }
 
@@ -709,12 +242,11 @@ void RecMaster::handle_request(
                     prompt_tokens = std::move(prompt_tokens),
                     input_tensors = std::move(input_tensors)](
                        const RequestParams& params, OutputCallback cb) mutable {
-                     return pipeline_->generate_request(
-                         std::move(prompt),
-                         std::move(prompt_tokens),
-                         std::move(input_tensors),
-                         params,
-                         std::move(cb));
+                     return request_factory_->create(std::move(prompt),
+                                                     std::move(prompt_tokens),
+                                                     std::move(input_tensors),
+                                                     params,
+                                                     std::move(cb));
                    });
 }
 
@@ -734,11 +266,10 @@ void RecMaster::handle_request(const std::vector<int>& prompt_tokens,
                     prompt_tokens = std::move(prompt_tokens),
                     mm_data = std::move(mm_data)](const RequestParams& params,
                                                   OutputCallback cb) mutable {
-                     return mm_data_pipeline_->generate_request(
-                         std::move(prompt_tokens),
-                         std::move(mm_data),
-                         params,
-                         std::move(cb));
+                     return request_factory_->create(std::move(prompt_tokens),
+                                                     std::move(mm_data),
+                                                     params,
+                                                     std::move(cb));
                    });
 }
 
@@ -774,136 +305,6 @@ void RecMaster::schedule_request(RequestParams sp,
                           "No available resources to schedule request");
     }
   });
-}
-
-std::shared_ptr<Request> RecMaster::build_request_common(
-    std::string prompt,
-    std::vector<int32_t> prompt_tokens,
-    MMData mm_data,
-    const RequestParams& sp,
-    OutputCallback callback,
-    bool build_stop_checker) {
-  // Guard the rate-limit slot acquired at the service entry. Dismissed
-  // right before Request takes ownership.
-  xllm::ScopeGuard rate_limit_guard(
-      [this] { get_rate_limiter()->decrease_one_request(); });
-
-  int32_t max_context_len = model_args_.max_position_embeddings();
-  if (!options_.enable_chunked_prefill()) {
-    int32_t max_tokens_per_req = options_.max_tokens_per_batch();
-    if (rec_type_ == RecType::kLlmRec && is_rec_multi_round_mode()) {
-      CHECK_GT(options_.max_seqs_per_batch(), 0)
-          << "max_seqs_per_batch must be greater than 0 in multi-round mode";
-      max_tokens_per_req /= options_.max_seqs_per_batch();
-    }
-    max_context_len = std::min(max_context_len, max_tokens_per_req);
-  }
-  if (prompt_tokens.size() >= max_context_len) {
-    LOG(ERROR) << "Prompt is too long: " << prompt_tokens.size();
-    CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT, "Prompt is too long");
-    return nullptr;
-  }
-
-  uint32_t max_tokens = sp.max_tokens;
-  if (max_tokens == 0) {
-    const uint32_t kDefaultMaxTokens = 5120;
-    max_tokens = kDefaultMaxTokens;
-  }
-
-  size_t capacity = prompt_tokens.size() + max_tokens +
-                    options_.num_speculative_tokens() + /*bonus_token*/ 1;
-  if (options_.enable_schedule_overlap()) {
-    capacity += options_.num_speculative_tokens() + 1;
-  }
-  const size_t best_of = sp.best_of.value_or(sp.n);
-
-  RequestSamplingParam sampling_param;
-  sampling_param.frequency_penalty = sp.frequency_penalty;
-  sampling_param.presence_penalty = sp.presence_penalty;
-  sampling_param.repetition_penalty = sp.repetition_penalty;
-  sampling_param.temperature = sp.temperature;
-  sampling_param.top_p = sp.top_p;
-  sampling_param.top_k = sp.top_k;
-  sampling_param.logprobs = sp.logprobs;
-  sampling_param.top_logprobs = sp.top_logprobs;
-  sampling_param.is_embeddings = sp.is_embeddings;
-  sampling_param.beam_width = sp.beam_width;
-  sampling_param.num_return_sequences = sp.num_return_sequences;
-  if (best_of > sp.n) {
-    sampling_param.logprobs = true;
-  }
-
-  bool stream = sp.streaming;
-  if (best_of != sp.n) {
-    stream = false;
-  }
-
-  StoppingChecker stopping_checker;
-  if (build_stop_checker) {
-    std::unordered_set<int32_t> stop_tokens;
-    if (sp.stop_token_ids.has_value()) {
-      const auto& stop_token_ids = sp.stop_token_ids.value();
-      stop_tokens.insert(stop_token_ids.begin(), stop_token_ids.end());
-    } else {
-      stop_tokens = model_args_.stop_token_ids();
-    }
-
-    std::vector<std::vector<int32_t>> stop_sequences;
-    if (sp.stop.has_value()) {
-      if (!tokenizer_) {
-        CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                            "Tokenizer is required for stop sequences");
-        return nullptr;
-      }
-      for (const auto& s : sp.stop.value()) {
-        std::vector<int> tmp_tokens;
-        if (!tokenizer_->encode(s, &tmp_tokens)) {
-          CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                              "Failed to encode stop sequence");
-          LOG(ERROR) << "Failed to encode stop sequence: " << s;
-          return nullptr;
-        }
-        stop_sequences.push_back(std::move(tmp_tokens));
-      }
-    }
-
-    stopping_checker =
-        StoppingChecker(max_tokens,
-                        max_context_len - options_.num_speculative_tokens(),
-                        model_args_.eos_token_id(),
-                        sp.ignore_eos,
-                        std::move(stop_tokens),
-                        std::move(stop_sequences));
-  }
-
-  RequestState req_state(std::move(prompt),
-                         std::move(prompt_tokens),
-                         std::move(mm_data),
-                         std::move(sampling_param),
-                         std::move(stopping_checker),
-                         capacity,
-                         sp.n,
-                         best_of,
-                         sp.logprobs,
-                         stream,
-                         sp.echo,
-                         sp.skip_special_tokens,
-                         options_.enable_schedule_overlap(),
-                         callback,
-                         nullptr,
-                         sp.decode_address);
-  req_state.include_stop_str_in_output = sp.include_stop_str_in_output;
-  req_state.rec_type = rec_type_;
-  req_state.bos_token_id = model_args_.bos_token_id();
-  rate_limit_guard.dismiss();
-  auto request = std::make_shared<Request>(sp.request_id,
-                                           sp.x_request_id,
-                                           sp.x_request_time,
-                                           std::move(req_state),
-                                           sp.service_request_id,
-                                           sp.source_xservice_addr,
-                                           get_rate_limiter());
-  return request;
 }
 
 }  // namespace xllm

--- a/xllm/core/distributed_runtime/rec_master.h
+++ b/xllm/core/distributed_runtime/rec_master.h
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "framework/chat_template/jinja_chat_template.h"
 #include "framework/model/model_args.h"
+#include "framework/request/rec_request_factory.h"
 #include "framework/request/rec_type.h"
 #include "master.h"
 #include "rec.pb.h"
@@ -70,120 +71,26 @@ class RecMaster : public Master {
       std::function<std::shared_ptr<Request>(const RequestParams&,
                                              OutputCallback)>;
 
-  // ============================================================
-  // RecMasterPipeline: Abstract base class for request processing
-  // ============================================================
-  class RecMasterPipeline {
-   public:
-    explicit RecMasterPipeline(RecMaster& master) : master_(master) {}
-    virtual ~RecMasterPipeline() = default;
-
-    // For prompt-based input (OneRec and LlmRec without mm_data)
-    virtual std::shared_ptr<Request> generate_request(
-        std::string prompt,
-        std::optional<std::vector<int>> prompt_tokens,
-        std::optional<std::vector<proto::InferInputTensor>> input_tensors,
-        const RequestParams& sp,
-        OutputCallback callback);
-
-    // For raw input (LlmRec with mm_data)
-    virtual std::shared_ptr<Request> generate_request(
-        const std::vector<int>& prompt_tokens,
-        std::optional<MMData> mm_data,
-        const RequestParams& sp,
-        OutputCallback callback);
-
-   protected:
-    std::shared_ptr<Request> generate_onerec_request_common(
-        std::string prompt,
-        std::optional<std::vector<int>> prompt_tokens,
-        std::optional<std::vector<proto::InferInputTensor>> input_tensors,
-        const RequestParams& sp,
-        OutputCallback callback,
-        bool build_stop_checker);
-
-    RecMaster& master_;
-  };
-
-  // LlmRecMasterPipeline - pure qwen3 (prompt-based, no mm_data)
-  class LlmRecMasterPipeline final : public RecMasterPipeline {
-   public:
-    explicit LlmRecMasterPipeline(RecMaster& master);
-    std::shared_ptr<Request> generate_request(
-        std::string prompt,
-        std::optional<std::vector<int>> prompt_tokens,
-        std::optional<std::vector<proto::InferInputTensor>> input_tensors,
-        const RequestParams& sp,
-        OutputCallback callback) override;
-  };
-
-  // LlmRecWithMmDataMasterPipeline - qwen3 with embedding (raw input)
-  class LlmRecWithMmDataMasterPipeline final : public RecMasterPipeline {
-   public:
-    explicit LlmRecWithMmDataMasterPipeline(RecMaster& master);
-    std::shared_ptr<Request> generate_request(
-        const std::vector<int>& prompt_tokens,
-        std::optional<MMData> mm_data,
-        const RequestParams& sp,
-        OutputCallback callback) override;
-  };
-
-  // OneRecPrefillOnlyMasterPipeline - legacy OneRec without stop checker.
-  class OneRecPrefillOnlyMasterPipeline final : public RecMasterPipeline {
-   public:
-    explicit OneRecPrefillOnlyMasterPipeline(RecMaster& master);
-    std::shared_ptr<Request> generate_request(
-        std::string prompt,
-        std::optional<std::vector<int>> prompt_tokens,
-        std::optional<std::vector<proto::InferInputTensor>> input_tensors,
-        const RequestParams& sp,
-        OutputCallback callback) override;
-  };
-
-  // OneRecXAttentionMasterPipeline - OneRec xattention with stop checker for
-  // device-side multi-round decode.
-  class OneRecXAttentionMasterPipeline final : public RecMasterPipeline {
-   public:
-    explicit OneRecXAttentionMasterPipeline(RecMaster& master)
-        : RecMasterPipeline(master) {}
-
-    std::shared_ptr<Request> generate_request(
-        std::string prompt,
-        std::optional<std::vector<int>> prompt_tokens,
-        std::optional<std::vector<proto::InferInputTensor>> input_tensors,
-        const RequestParams& sp,
-        OutputCallback callback) override;
-  };
-
-  // Factory method to create pipeline (can access private classes)
-  static std::unique_ptr<RecMasterPipeline> create_pipeline(
-      RecPipelineType type,
-      RecMaster& master);
-
   void schedule_request(RequestParams sp,
                         OutputCallback callback,
                         RequestBuilder build_request);
-
-  std::shared_ptr<Request> build_request_common(
-      std::string prompt,
-      std::vector<int32_t> prompt_tokens,
-      MMData mm_data,
-      const RequestParams& sp,
-      OutputCallback callback,
-      bool build_stop_checker);
-
-  // Pipeline instances
-  std::unique_ptr<RecMasterPipeline> pipeline_;
-  std::unique_ptr<RecMasterPipeline> mm_data_pipeline_;
 
   std::unique_ptr<FixedStepsScheduler> scheduler_;
   // model args
   ModelArgs model_args_;
   RecType rec_type_ = RecType::kNone;
+  // Scheduled request closures dereference request_factory_ and scheduler_, so
+  // the pool is explicitly reset (drained/joined) in ~RecMaster before those
+  // members are destroyed.
   std::unique_ptr<ThreadPool> threadpool_;
   std::unique_ptr<Tokenizer> tokenizer_;
   // chat template instance
   std::unique_ptr<JinjaChatTemplate> chat_template_;
+
+  // builds Request aggregates from prompts/tokens/tensors + multimodal data;
+  // holds non-owning pointers to model_args_/tokenizer_, so declare it after
+  // them to guarantee it is destroyed first.
+  std::unique_ptr<RecRequestFactory> request_factory_;
   // thread for moving forward the scheduler
   std::thread loop_thread_;
   // flag to stop the loop

--- a/xllm/core/framework/request/CMakeLists.txt
+++ b/xllm/core/framework/request/CMakeLists.txt
@@ -12,6 +12,7 @@ cc_library(
     request.h
     llm_request_factory.h
     vlm_request_factory.h
+    rec_request_factory.h
     dit_request.h
     request_output.h
     usage.h
@@ -35,6 +36,7 @@ cc_library(
     request_base.cpp
     llm_request_factory.cpp
     vlm_request_factory.cpp
+    rec_request_factory.cpp
     dit_request.cpp
     request_output.cpp
     dit_request_output.cpp

--- a/xllm/core/framework/request/rec_request_factory.cpp
+++ b/xllm/core/framework/request/rec_request_factory.cpp
@@ -1,0 +1,684 @@
+/* Copyright 2025-2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "rec_request_factory.h"
+
+#include <absl/strings/str_join.h>
+#include <glog/logging.h>
+#include <torch/torch.h>
+
+#include <limits>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "common/macros.h"
+#include "common/metrics.h"
+#include "core/framework/multimodal/mm_data.h"
+#include "framework/request/request_state.h"
+#include "framework/request/stopping_checker.h"
+#include "framework/sampling/sampling_params.h"
+#include "framework/tokenizer/tokenizer.h"
+#include "util/rec_model_utils.h"
+#include "util/scope_guard.h"
+#include "util/timer.h"
+#include "util/utils.h"
+
+namespace xllm {
+
+namespace {
+
+constexpr const char* kOneRecSparseEmbeddingName = "sparse_embedding";
+constexpr const char* kOneRecDecoderContextEmbeddingName =
+    "decoder_context_embedding";
+
+std::string format_tensor_shape(const proto::InferInputTensor& tensor) {
+  std::vector<std::string> dims;
+  dims.reserve(tensor.shape_size());
+  for (int i = 0; i < tensor.shape_size(); ++i) {
+    dims.emplace_back(std::to_string(tensor.shape(i)));
+  }
+  return "[" + absl::StrJoin(dims, ", ") + "]";
+}
+
+bool process_onerec_inputs(
+    const std::optional<std::vector<int>>& prompt_tokens,
+    const std::optional<std::vector<proto::InferInputTensor>>& input_tensors,
+    const ModelArgs& model_args,
+    std::vector<int32_t>* local_prompt_tokens,
+    MMData* processed_mm_data,
+    OutputCallback callback) {
+  if (prompt_tokens.has_value() && input_tensors.has_value()) {
+    CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
+                        "prompt_tokens and input_tensors cannot both be set");
+    return false;
+  }
+
+  if (prompt_tokens.has_value()) {
+    local_prompt_tokens->assign(prompt_tokens.value().begin(),
+                                prompt_tokens.value().end());
+  }
+
+  if (input_tensors.has_value()) {
+    if (input_tensors->empty()) {
+      CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
+                          "OneRec input_tensors cannot be empty");
+      return false;
+    }
+
+    MMDict mm_dict;
+    mm_dict.reserve(input_tensors->size());
+    bool has_sparse_embedding = false;
+    bool has_decoder_context_embedding = false;
+    int64_t sparse_embedding_hidden_size = -1;
+    int64_t decoder_context_hidden_size = -1;
+
+    for (const auto& tensor : input_tensors.value()) {
+      const auto& tensor_name = tensor.name();
+      if (tensor_name != kOneRecSparseEmbeddingName &&
+          tensor_name != kOneRecDecoderContextEmbeddingName) {
+        CALLBACK_WITH_ERROR(
+            StatusCode::INVALID_ARGUMENT,
+            "OneRec input_tensors only supports 'sparse_embedding' and "
+            "'decoder_context_embedding', got '" +
+                tensor_name + "'");
+        return false;
+      }
+      if (mm_dict.find(tensor_name) != mm_dict.end()) {
+        CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
+                            "Duplicate OneRec input tensor: " + tensor_name);
+        return false;
+      }
+      if (!tensor.has_contents()) {
+        CALLBACK_WITH_ERROR(
+            StatusCode::INVALID_ARGUMENT,
+            "OneRec input tensor '" + tensor_name + "' has no contents");
+        return false;
+      }
+      if (tensor.data_type() != proto::DataType::FLOAT) {
+        CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
+                            "OneRec input tensor '" + tensor_name +
+                                "' must use FLOAT(fp32), got " +
+                                proto::DataType_Name(tensor.data_type()));
+        return false;
+      }
+      if (tensor.shape_size() != 2) {
+        CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
+                            "OneRec input tensor '" + tensor_name +
+                                "' must be 2-D [len, hidden], got " +
+                                format_tensor_shape(tensor));
+        return false;
+      }
+
+      const int64_t len = tensor.shape(0);
+      const int64_t hidden = tensor.shape(1);
+      if (len <= 0 || hidden <= 0) {
+        CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
+                            "OneRec input tensor '" + tensor_name +
+                                "' must have positive shape, got " +
+                                format_tensor_shape(tensor));
+        return false;
+      }
+      if (hidden != model_args.hidden_size()) {
+        CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
+                            "OneRec input tensor '" + tensor_name +
+                                "' hidden size mismatch, expected " +
+                                std::to_string(model_args.hidden_size()) +
+                                ", got " + std::to_string(hidden));
+        return false;
+      }
+
+      if (len > std::numeric_limits<int64_t>::max() / hidden) {
+        CALLBACK_WITH_ERROR(
+            StatusCode::INVALID_ARGUMENT,
+            "OneRec input tensor '" + tensor_name + "' shape is too large");
+        return false;
+      }
+
+      const int64_t expected_numel = len * hidden;
+      const int64_t actual_numel =
+          static_cast<int64_t>(tensor.contents().fp32_contents_size());
+      if (expected_numel != actual_numel) {
+        CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
+                            "OneRec input tensor '" + tensor_name +
+                                "' fp32 contents size mismatch, expected " +
+                                std::to_string(expected_numel) + ", got " +
+                                std::to_string(actual_numel));
+        return false;
+      }
+
+      try {
+        mm_dict[tensor_name] =
+            util::convert_rec_tensor_to_torch(tensor).to(torch::kBFloat16);
+      } catch (const std::exception& e) {
+        CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
+                            "Failed to parse OneRec input tensor '" +
+                                tensor_name + "': " + e.what());
+        return false;
+      }
+
+      if (tensor_name == kOneRecSparseEmbeddingName) {
+        has_sparse_embedding = true;
+        sparse_embedding_hidden_size = hidden;
+      } else {
+        has_decoder_context_embedding = true;
+        decoder_context_hidden_size = hidden;
+      }
+    }
+
+    if (!has_sparse_embedding) {
+      CALLBACK_WITH_ERROR(
+          StatusCode::INVALID_ARGUMENT,
+          "OneRec input_tensors must include 'sparse_embedding'");
+      return false;
+    }
+    if (has_decoder_context_embedding &&
+        sparse_embedding_hidden_size != decoder_context_hidden_size) {
+      CALLBACK_WITH_ERROR(
+          StatusCode::INVALID_ARGUMENT,
+          "OneRec tensor hidden size mismatch: sparse_embedding=" +
+              std::to_string(sparse_embedding_hidden_size) +
+              ", decoder_context_embedding=" +
+              std::to_string(decoder_context_hidden_size));
+      return false;
+    }
+
+    *processed_mm_data = MMData(MMType::EMBEDDING, mm_dict);
+  }
+
+  if (local_prompt_tokens->empty() && !processed_mm_data->valid()) {
+    CALLBACK_WITH_ERROR(
+        StatusCode::INVALID_ARGUMENT,
+        "Rec model requires prompt_tokens or input_tensors to be provided");
+    return false;
+  }
+
+  return true;
+}
+
+bool process_llmrec_with_mm_data_inputs(
+    const std::vector<int>& prompt_tokens,
+    std::optional<MMData> mm_data,
+    std::vector<int32_t>* local_prompt_tokens,
+    MMData* processed_mm_data,
+    int32_t hidden_size,
+    OutputCallback callback) {
+  local_prompt_tokens->assign(prompt_tokens.begin(), prompt_tokens.end());
+
+  if (!mm_data.has_value()) {
+    return true;
+  }
+
+  std::vector<torch::Tensor> all_indices_list;
+  std::vector<torch::Tensor> all_values_list;
+
+  MMData mm_data_s = mm_data.value();
+  if (!mm_data_s.hold<MMItemVec>()) {
+    CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
+                        "MMData need be item vec type");
+    return false;
+  }
+
+  int64_t last_end = 0;
+  MMItemVec mm_items = mm_data_s.items<MMItemVec>();
+  for (auto& mm_item : mm_items) {
+    const MMItemState::TokenPos token_pos = mm_item.state().token_pos();
+    std::optional<torch::Tensor> mm_value =
+        mm_item.get<torch::Tensor>("tensor");
+
+    if (!mm_value.has_value()) {
+      CALLBACK_WITH_ERROR(
+          StatusCode::INVALID_ARGUMENT,
+          "Rec model requires embedding in mm data to be provided");
+      return false;
+    }
+
+    int64_t start = static_cast<int64_t>(token_pos.offset);
+    int64_t end = static_cast<int64_t>(token_pos.offset + token_pos.length);
+    torch::Tensor tensor = mm_value.value();
+
+    if (start < last_end || end >= local_prompt_tokens->size()) {
+      CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
+                          "Token pos in mm data is wrong");
+      return false;
+    }
+
+    last_end = end;
+
+    if (tensor.dim() != 2) {
+      CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
+                          "Embedding in mm data is invalid");
+      return false;
+    }
+
+    if (tensor.size(0) != token_pos.length) {
+      CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
+                          "Token length is not match to embedding");
+      return false;
+    }
+
+    if (tensor.size(1) != hidden_size) {
+      CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
+                          "Embedding size is not match to model hidden size");
+      return false;
+    }
+
+    torch::Tensor range_indices = torch::arange(start, end);
+    all_indices_list.push_back(range_indices);
+    all_values_list.push_back(tensor);
+  }
+
+  torch::Tensor total_indices = torch::cat(all_indices_list, 0);
+  torch::Tensor total_values = torch::cat(all_values_list, 0);
+
+  MMDict mm_dict;
+  mm_dict["MULTI_MODAL_INDICES"] = total_indices;
+  mm_dict["MULTI_MODAL_VALUES"] = total_values;
+  *processed_mm_data = MMData(MMType::EMBEDDING, mm_dict);
+
+  return true;
+}
+
+}  // namespace
+
+RecRequestFactory::RecRequestFactory(const ModelArgs* model_args,
+                                     Tokenizer* tokenizer,
+                                     const Options* options,
+                                     RateLimiter* rate_limiter,
+                                     RecType rec_type,
+                                     RecPipelineType pipeline_type)
+    : model_args_(model_args),
+      tokenizer_(tokenizer),
+      options_(options),
+      rate_limiter_(rate_limiter),
+      rec_type_(rec_type) {
+  CHECK(model_args_ != nullptr);
+  CHECK(options_ != nullptr);
+  CHECK(rate_limiter_ != nullptr);
+
+  request_builder_ = create_request_builder(pipeline_type, *this);
+
+  // For LlmRec, also create the mm_data request builder for the raw input
+  // interface.
+  if (rec_type_ == RecType::kLlmRec) {
+    mm_data_request_builder_ =
+        create_request_builder(RecPipelineType::kLlmRecWithMmData, *this);
+  }
+}
+
+std::shared_ptr<Request> RecRequestFactory::create(
+    std::string prompt,
+    std::optional<std::vector<int>> prompt_tokens,
+    std::optional<std::vector<proto::InferInputTensor>> input_tensors,
+    const RequestParams& sp,
+    OutputCallback callback) {
+  return request_builder_->generate_request(std::move(prompt),
+                                            std::move(prompt_tokens),
+                                            std::move(input_tensors),
+                                            sp,
+                                            std::move(callback));
+}
+
+std::shared_ptr<Request> RecRequestFactory::create(
+    const std::vector<int>& prompt_tokens,
+    std::optional<MMData> mm_data,
+    const RequestParams& sp,
+    OutputCallback callback) {
+  return mm_data_request_builder_->generate_request(
+      prompt_tokens, std::move(mm_data), sp, std::move(callback));
+}
+
+// ============================================================
+// RequestBuilder base class default implementations
+// ============================================================
+std::shared_ptr<Request> RecRequestFactory::RequestBuilder::generate_request(
+    std::string /*prompt*/,
+    std::optional<std::vector<int>> /*prompt_tokens*/,
+    std::optional<std::vector<proto::InferInputTensor>> /*input_tensors*/,
+    const RequestParams& /*sp*/,
+    OutputCallback callback) {
+  factory_.rate_limiter_->decrease_one_request();
+  CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
+                      "This request builder does not support prompt-based "
+                      "input");
+  return nullptr;
+}
+
+std::shared_ptr<Request> RecRequestFactory::RequestBuilder::generate_request(
+    const std::vector<int>& prompt_tokens,
+    std::optional<MMData> mm_data,
+    const RequestParams& sp,
+    OutputCallback callback) {
+  factory_.rate_limiter_->decrease_one_request();
+  CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
+                      "This request builder does not support raw input");
+  return nullptr;
+}
+
+std::shared_ptr<Request>
+RecRequestFactory::RequestBuilder::generate_onerec_request_common(
+    std::string prompt,
+    std::optional<std::vector<int>> prompt_tokens,
+    std::optional<std::vector<proto::InferInputTensor>> input_tensors,
+    const RequestParams& sp,
+    OutputCallback callback,
+    bool build_stop_checker) {
+  xllm::ScopeGuard rate_limit_guard(
+      [this] { factory_.rate_limiter_->decrease_one_request(); });
+
+  Timer timer;
+  std::vector<int32_t> local_prompt_tokens;
+  MMData processed_mm_data;
+
+  if (!process_onerec_inputs(prompt_tokens,
+                             input_tensors,
+                             *factory_.model_args_,
+                             &local_prompt_tokens,
+                             &processed_mm_data,
+                             callback)) {
+    return nullptr;
+  }
+
+  COUNTER_ADD(tokenization_latency_seconds, timer.elapsed_seconds());
+
+  rate_limit_guard.dismiss();
+  return factory_.build_request_common(std::move(prompt),
+                                       std::move(local_prompt_tokens),
+                                       std::move(processed_mm_data),
+                                       sp,
+                                       callback,
+                                       build_stop_checker);
+}
+
+// ============================================================
+// LlmRecRequestBuilder implementation (pure qwen3, no mm_data)
+// ============================================================
+std::shared_ptr<Request>
+RecRequestFactory::LlmRecRequestBuilder::generate_request(
+    std::string prompt,
+    std::optional<std::vector<int>> prompt_tokens,
+    std::optional<std::vector<proto::InferInputTensor>> /*input_tensors*/,
+    const RequestParams& sp,
+    OutputCallback callback) {
+  // Guard the rate-limit slot acquired at the service entry. Dismissed
+  // before we forward to build_request_common (which installs its own guard).
+  xllm::ScopeGuard rate_limit_guard(
+      [this] { factory_.rate_limiter_->decrease_one_request(); });
+
+  Timer timer;
+  std::vector<int32_t> local_prompt_tokens;
+  MMData processed_mm_data;
+
+  // LlmRec without mm_data: use prompt_tokens or tokenize prompt string
+  if (prompt_tokens.has_value()) {
+    local_prompt_tokens.assign(prompt_tokens.value().begin(),
+                               prompt_tokens.value().end());
+  } else if (!prompt.empty()) {
+    // Tokenize prompt string if prompt_tokens not provided
+    if (!factory_.tokenizer_) {
+      CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
+                          "Tokenizer is required for prompt-based input");
+      return nullptr;
+    }
+    std::vector<int> tmp_tokens;
+    if (!factory_.tokenizer_->encode(
+            prompt, &tmp_tokens, sp.add_special_tokens)) {
+      CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
+                          "Failed to tokenize prompt");
+      return nullptr;
+    }
+    local_prompt_tokens.assign(tmp_tokens.begin(), tmp_tokens.end());
+  }
+
+  if (local_prompt_tokens.empty()) {
+    CALLBACK_WITH_ERROR(
+        StatusCode::INVALID_ARGUMENT,
+        "LlmRec requires prompt or prompt_tokens to be provided");
+    return nullptr;
+  }
+
+  COUNTER_ADD(tokenization_latency_seconds, timer.elapsed_seconds());
+
+  rate_limit_guard.dismiss();
+  return factory_.build_request_common(std::move(prompt),
+                                       std::move(local_prompt_tokens),
+                                       std::move(processed_mm_data),
+                                       sp,
+                                       callback,
+                                       /*build_stop_checker=*/true);
+}
+
+// ============================================================
+// LlmRecWithMmDataRequestBuilder implementation (qwen3 with embedding)
+// ============================================================
+std::shared_ptr<Request>
+RecRequestFactory::LlmRecWithMmDataRequestBuilder::generate_request(
+    const std::vector<int>& prompt_tokens,
+    std::optional<MMData> mm_data,
+    const RequestParams& sp,
+    OutputCallback callback) {
+  xllm::ScopeGuard rate_limit_guard(
+      [this] { factory_.rate_limiter_->decrease_one_request(); });
+
+  std::vector<int32_t> local_prompt_tokens;
+  MMData processed_mm_data;
+
+  int32_t hidden_size = factory_.model_args_->hidden_size();
+  bool ret = process_llmrec_with_mm_data_inputs(prompt_tokens,
+                                                mm_data,
+                                                &local_prompt_tokens,
+                                                &processed_mm_data,
+                                                hidden_size,
+                                                callback);
+  if (!ret) {
+    return nullptr;
+  }
+
+  rate_limit_guard.dismiss();
+  return factory_.build_request_common(std::string(""),
+                                       std::move(local_prompt_tokens),
+                                       std::move(processed_mm_data),
+                                       sp,
+                                       callback,
+                                       /*build_stop_checker=*/true);
+}
+
+// ============================================================
+// OneRecPrefillOnlyRequestBuilder implementation (OneRec with input_tensors)
+// ============================================================
+std::shared_ptr<Request>
+RecRequestFactory::OneRecPrefillOnlyRequestBuilder::generate_request(
+    std::string prompt,
+    std::optional<std::vector<int>> prompt_tokens,
+    std::optional<std::vector<proto::InferInputTensor>> input_tensors,
+    const RequestParams& sp,
+    OutputCallback callback) {
+  return generate_onerec_request_common(std::move(prompt),
+                                        std::move(prompt_tokens),
+                                        std::move(input_tensors),
+                                        sp,
+                                        callback,
+                                        /*build_stop_checker=*/false);
+}
+
+std::shared_ptr<Request>
+RecRequestFactory::OneRecXAttentionRequestBuilder::generate_request(
+    std::string prompt,
+    std::optional<std::vector<int>> prompt_tokens,
+    std::optional<std::vector<proto::InferInputTensor>> input_tensors,
+    const RequestParams& sp,
+    OutputCallback callback) {
+  return generate_onerec_request_common(std::move(prompt),
+                                        std::move(prompt_tokens),
+                                        std::move(input_tensors),
+                                        sp,
+                                        callback,
+                                        /*build_stop_checker=*/true);
+}
+
+// ============================================================
+// Request builder factory (static method)
+// ============================================================
+std::unique_ptr<RecRequestFactory::RequestBuilder>
+RecRequestFactory::create_request_builder(RecPipelineType type,
+                                          RecRequestFactory& factory) {
+  switch (type) {
+    case RecPipelineType::kLlmRecDefault:
+    case RecPipelineType::kLlmRecMultiRoundPipeline:
+      return std::make_unique<LlmRecRequestBuilder>(factory);
+    case RecPipelineType::kLlmRecWithMmData:
+      return std::make_unique<LlmRecWithMmDataRequestBuilder>(factory);
+    case RecPipelineType::kOneRecDefault:
+      return std::make_unique<OneRecPrefillOnlyRequestBuilder>(factory);
+    case RecPipelineType::kOneRecXAttentionPipeline:
+      return std::make_unique<OneRecXAttentionRequestBuilder>(factory);
+    default:
+      LOG(FATAL) << "Unknown RecRequestFactory pipeline type: "
+                 << static_cast<int>(type);
+      return nullptr;
+  }
+}
+
+std::shared_ptr<Request> RecRequestFactory::build_request_common(
+    std::string prompt,
+    std::vector<int32_t> prompt_tokens,
+    MMData mm_data,
+    const RequestParams& sp,
+    OutputCallback callback,
+    bool build_stop_checker) {
+  // Guard the rate-limit slot acquired at the service entry. Dismissed
+  // right before Request takes ownership.
+  xllm::ScopeGuard rate_limit_guard(
+      [this] { rate_limiter_->decrease_one_request(); });
+
+  int32_t max_context_len = model_args_->max_position_embeddings();
+  if (!options_->enable_chunked_prefill()) {
+    int32_t max_tokens_per_req = options_->max_tokens_per_batch();
+    if (rec_type_ == RecType::kLlmRec && is_rec_multi_round_mode()) {
+      CHECK_GT(options_->max_seqs_per_batch(), 0)
+          << "max_seqs_per_batch must be greater than 0 in multi-round mode";
+      max_tokens_per_req /= options_->max_seqs_per_batch();
+    }
+    max_context_len = std::min(max_context_len, max_tokens_per_req);
+  }
+  if (prompt_tokens.size() >= max_context_len) {
+    LOG(ERROR) << "Prompt is too long: " << prompt_tokens.size();
+    CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT, "Prompt is too long");
+    return nullptr;
+  }
+
+  uint32_t max_tokens = sp.max_tokens;
+  if (max_tokens == 0) {
+    const uint32_t kDefaultMaxTokens = 5120;
+    max_tokens = kDefaultMaxTokens;
+  }
+
+  size_t capacity = prompt_tokens.size() + max_tokens +
+                    options_->num_speculative_tokens() + /*bonus_token*/ 1;
+  if (options_->enable_schedule_overlap()) {
+    capacity += options_->num_speculative_tokens() + 1;
+  }
+  const size_t best_of = sp.best_of.value_or(sp.n);
+
+  RequestSamplingParam sampling_param;
+  sampling_param.frequency_penalty = sp.frequency_penalty;
+  sampling_param.presence_penalty = sp.presence_penalty;
+  sampling_param.repetition_penalty = sp.repetition_penalty;
+  sampling_param.temperature = sp.temperature;
+  sampling_param.top_p = sp.top_p;
+  sampling_param.top_k = sp.top_k;
+  sampling_param.logprobs = sp.logprobs;
+  sampling_param.top_logprobs = sp.top_logprobs;
+  sampling_param.is_embeddings = sp.is_embeddings;
+  sampling_param.beam_width = sp.beam_width;
+  sampling_param.num_return_sequences = sp.num_return_sequences;
+  if (best_of > sp.n) {
+    sampling_param.logprobs = true;
+  }
+
+  bool stream = sp.streaming;
+  if (best_of != sp.n) {
+    stream = false;
+  }
+
+  StoppingChecker stopping_checker;
+  if (build_stop_checker) {
+    std::unordered_set<int32_t> stop_tokens;
+    if (sp.stop_token_ids.has_value()) {
+      const auto& stop_token_ids = sp.stop_token_ids.value();
+      stop_tokens.insert(stop_token_ids.begin(), stop_token_ids.end());
+    } else {
+      stop_tokens = model_args_->stop_token_ids();
+    }
+
+    std::vector<std::vector<int32_t>> stop_sequences;
+    if (sp.stop.has_value()) {
+      if (!tokenizer_) {
+        CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
+                            "Tokenizer is required for stop sequences");
+        return nullptr;
+      }
+      for (const auto& s : sp.stop.value()) {
+        std::vector<int> tmp_tokens;
+        if (!tokenizer_->encode(s, &tmp_tokens)) {
+          CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
+                              "Failed to encode stop sequence");
+          LOG(ERROR) << "Failed to encode stop sequence: " << s;
+          return nullptr;
+        }
+        stop_sequences.push_back(std::move(tmp_tokens));
+      }
+    }
+
+    stopping_checker =
+        StoppingChecker(max_tokens,
+                        max_context_len - options_->num_speculative_tokens(),
+                        model_args_->eos_token_id(),
+                        sp.ignore_eos,
+                        std::move(stop_tokens),
+                        std::move(stop_sequences));
+  }
+
+  RequestState req_state(std::move(prompt),
+                         std::move(prompt_tokens),
+                         std::move(mm_data),
+                         std::move(sampling_param),
+                         std::move(stopping_checker),
+                         capacity,
+                         sp.n,
+                         best_of,
+                         sp.logprobs,
+                         stream,
+                         sp.echo,
+                         sp.skip_special_tokens,
+                         options_->enable_schedule_overlap(),
+                         callback,
+                         nullptr,
+                         sp.decode_address);
+  req_state.include_stop_str_in_output = sp.include_stop_str_in_output;
+  req_state.rec_type = rec_type_;
+  req_state.bos_token_id = model_args_->bos_token_id();
+  rate_limit_guard.dismiss();
+  auto request = std::make_shared<Request>(sp.request_id,
+                                           sp.x_request_id,
+                                           sp.x_request_time,
+                                           std::move(req_state),
+                                           sp.service_request_id,
+                                           sp.source_xservice_addr,
+                                           rate_limiter_);
+  return request;
+}
+
+}  // namespace xllm

--- a/xllm/core/framework/request/rec_request_factory.h
+++ b/xllm/core/framework/request/rec_request_factory.h
@@ -1,0 +1,190 @@
+/* Copyright 2025-2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "common/options.h"
+#include "common/rate_limiter.h"
+#include "core/framework/multimodal/mm_data.h"
+#include "framework/model/model_args.h"
+#include "framework/request/rec_type.h"
+#include "framework/request/request.h"
+#include "framework/request/request_output.h"
+#include "framework/request/request_params.h"
+#include "rec.pb.h"
+#include "util/rec_model_utils.h"
+
+namespace xllm {
+
+class Tokenizer;
+
+// Factory that assembles a domain Request aggregate for the Rec path from raw
+// user input (a text prompt, pre-tokenized prompt, OneRec input tensors, or
+// LlmRec prompt tokens plus multimodal embedding data) and RequestParams.
+//
+// Request construction is delegated to a request-builder strategy selected
+// from the model kind at construction time: OneRec (prefill-only or
+// xattention) and LlmRec (with or without multimodal embedding) each build
+// requests differently. The factory owns the builder instances and the shared
+// build_request_common step that assembles sampling/stopping parameters and
+// the final Request aggregate.
+//
+// The factory holds non-owning references to model configuration owned by
+// RecMaster (model args, tokenizer, options, rate limiter); the owner must
+// outlive the factory. The tokenizer may be null for OneRec models.
+class RecRequestFactory final {
+ public:
+  RecRequestFactory(const ModelArgs* model_args,
+                    Tokenizer* tokenizer,
+                    const Options* options,
+                    RateLimiter* rate_limiter,
+                    RecType rec_type,
+                    RecPipelineType pipeline_type);
+
+  // prompt / prompt_tokens / input_tensors (OneRec and LlmRec without mm_data).
+  std::shared_ptr<Request> create(
+      std::string prompt,
+      std::optional<std::vector<int>> prompt_tokens,
+      std::optional<std::vector<proto::InferInputTensor>> input_tensors,
+      const RequestParams& sp,
+      OutputCallback callback);
+
+  // raw prompt_tokens plus multimodal embedding data (LlmRec).
+  std::shared_ptr<Request> create(const std::vector<int>& prompt_tokens,
+                                  std::optional<MMData> mm_data,
+                                  const RequestParams& sp,
+                                  OutputCallback callback);
+
+ private:
+  // ============================================================
+  // RequestBuilder: strategy base for request construction.
+  // ============================================================
+  class RequestBuilder {
+   public:
+    explicit RequestBuilder(RecRequestFactory& factory) : factory_(factory) {}
+    virtual ~RequestBuilder() = default;
+
+    // For prompt-based input (OneRec and LlmRec without mm_data).
+    virtual std::shared_ptr<Request> generate_request(
+        std::string prompt,
+        std::optional<std::vector<int>> prompt_tokens,
+        std::optional<std::vector<proto::InferInputTensor>> input_tensors,
+        const RequestParams& sp,
+        OutputCallback callback);
+
+    // For raw input (LlmRec with mm_data).
+    virtual std::shared_ptr<Request> generate_request(
+        const std::vector<int>& prompt_tokens,
+        std::optional<MMData> mm_data,
+        const RequestParams& sp,
+        OutputCallback callback);
+
+   protected:
+    std::shared_ptr<Request> generate_onerec_request_common(
+        std::string prompt,
+        std::optional<std::vector<int>> prompt_tokens,
+        std::optional<std::vector<proto::InferInputTensor>> input_tensors,
+        const RequestParams& sp,
+        OutputCallback callback,
+        bool build_stop_checker);
+
+    RecRequestFactory& factory_;
+  };
+
+  // LlmRecRequestBuilder - pure qwen3 (prompt-based, no mm_data).
+  class LlmRecRequestBuilder final : public RequestBuilder {
+   public:
+    explicit LlmRecRequestBuilder(RecRequestFactory& factory)
+        : RequestBuilder(factory) {}
+    std::shared_ptr<Request> generate_request(
+        std::string prompt,
+        std::optional<std::vector<int>> prompt_tokens,
+        std::optional<std::vector<proto::InferInputTensor>> input_tensors,
+        const RequestParams& sp,
+        OutputCallback callback) override;
+  };
+
+  // LlmRecWithMmDataRequestBuilder - qwen3 with embedding (raw input).
+  class LlmRecWithMmDataRequestBuilder final : public RequestBuilder {
+   public:
+    explicit LlmRecWithMmDataRequestBuilder(RecRequestFactory& factory)
+        : RequestBuilder(factory) {}
+    std::shared_ptr<Request> generate_request(
+        const std::vector<int>& prompt_tokens,
+        std::optional<MMData> mm_data,
+        const RequestParams& sp,
+        OutputCallback callback) override;
+  };
+
+  // OneRecPrefillOnlyRequestBuilder - legacy OneRec without stop checker.
+  class OneRecPrefillOnlyRequestBuilder final : public RequestBuilder {
+   public:
+    explicit OneRecPrefillOnlyRequestBuilder(RecRequestFactory& factory)
+        : RequestBuilder(factory) {}
+    std::shared_ptr<Request> generate_request(
+        std::string prompt,
+        std::optional<std::vector<int>> prompt_tokens,
+        std::optional<std::vector<proto::InferInputTensor>> input_tensors,
+        const RequestParams& sp,
+        OutputCallback callback) override;
+  };
+
+  // OneRecXAttentionRequestBuilder - OneRec xattention with stop checker for
+  // device-side multi-round decode.
+  class OneRecXAttentionRequestBuilder final : public RequestBuilder {
+   public:
+    explicit OneRecXAttentionRequestBuilder(RecRequestFactory& factory)
+        : RequestBuilder(factory) {}
+    std::shared_ptr<Request> generate_request(
+        std::string prompt,
+        std::optional<std::vector<int>> prompt_tokens,
+        std::optional<std::vector<proto::InferInputTensor>> input_tensors,
+        const RequestParams& sp,
+        OutputCallback callback) override;
+  };
+
+  // Factory method to create a request builder (can access the private
+  // builder classes).
+  static std::unique_ptr<RequestBuilder> create_request_builder(
+      RecPipelineType type,
+      RecRequestFactory& factory);
+
+  std::shared_ptr<Request> build_request_common(
+      std::string prompt,
+      std::vector<int32_t> prompt_tokens,
+      MMData mm_data,
+      const RequestParams& sp,
+      OutputCallback callback,
+      bool build_stop_checker);
+
+  const ModelArgs* model_args_ = nullptr;
+  Tokenizer* tokenizer_ = nullptr;
+  const Options* options_ = nullptr;
+  RateLimiter* rate_limiter_ = nullptr;
+  RecType rec_type_ = RecType::kNone;
+
+  // Request builder strategies (created from the model kind at construction
+  // time).
+  std::unique_ptr<RequestBuilder> request_builder_;
+  std::unique_ptr<RequestBuilder> mm_data_request_builder_;
+};
+
+}  // namespace xllm


### PR DESCRIPTION
Move Rec request-building logic out of RecMaster into a dedicated RecRequestFactory. The factory owns the pipeline strategy hierarchy (LlmRec, LlmRec-with-mm-data, OneRec prefill-only, OneRec xattention), the input-processing helpers, and build_request_common. RecMaster now owns the factory and delegates from its handle_request overloads while retaining request scheduling.

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
