### PR TITLE
bugfix: exclude resampled tokens from DFlash and DSpark acceptance counts.

### DIFF
--- a/tests/core/distributed_runtime/worker_service_test.cpp
+++ b/tests/core/distributed_runtime/worker_service_test.cpp
@@ -21,9 +21,11 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include "core/common/metrics.h"
+#include "core/framework/sampling/rejection_sampler.h"
 #include "core/framework/sampling/sampling_params.h"
 #include "core/runtime/options.h"
 #include "core/runtime/speculative_worker_impl.h"
@@ -80,12 +82,110 @@ TEST(SpeculativeTokenStatsTest, CountsAdaptiveTokensPerSequence) {
   const std::vector<SpeculativeTokenStats> block_stats =
       calculate_block_speculative_token_stats(tokens, proposed_tokens);
   ASSERT_EQ(block_stats.size(), 3);
-  EXPECT_EQ(block_stats[0].accepted_tokens, 3);
+  EXPECT_EQ(block_stats[0].accepted_tokens, 2);
   EXPECT_EQ(block_stats[0].proposed_tokens, 4);
   EXPECT_EQ(block_stats[1].accepted_tokens, 2);
   EXPECT_EQ(block_stats[1].proposed_tokens, 2);
   EXPECT_EQ(block_stats[2].accepted_tokens, 0);
   EXPECT_EQ(block_stats[2].proposed_tokens, 0);
+}
+
+TEST(SpeculativeTokenStatsTest, BlockGreedyExcludesTargetTokens) {
+  const torch::Tensor draft_tokens = torch::tensor(
+      {{1, 2, 3}, {1, 2, 3}, {1, 2, 3}, {1, 2, 3}}, torch::kInt64);
+  // Reject at each possible position, then accept the entire final row.
+  const torch::Tensor target_tokens = torch::tensor(
+      {{9, 2, 3}, {1, 9, 3}, {1, 2, 9}, {1, 2, 3}}, torch::kInt64);
+  const torch::Tensor bonus_tokens = torch::full({4, 1}, 8, torch::kInt64);
+  const auto sampled = RejectionSampler::greedy_sample_from_token_ids(
+      draft_tokens,
+      target_tokens,
+      bonus_tokens,
+      /*mask_out_rejected_tokens=*/true);
+  const torch::Tensor& masked_tokens = std::get<1>(sampled);
+  ASSERT_TRUE(torch::equal(
+      masked_tokens,
+      torch::tensor(
+          {{9, -1, -1, -1}, {1, 9, -1, -1}, {1, 2, 9, -1}, {1, 2, 3, 8}},
+          torch::kInt64)));
+
+  const auto stats =
+      calculate_block_speculative_token_stats(masked_tokens, {3, 3, 3, 3});
+  ASSERT_EQ(stats.size(), 4);
+  for (size_t row = 0; row < stats.size(); ++row) {
+    EXPECT_EQ(stats[row].accepted_tokens, static_cast<int64_t>(row));
+    EXPECT_EQ(stats[row].proposed_tokens, 3);
+  }
+}
+
+TEST(SpeculativeTokenStatsTest, BlockRandomExcludesTargetTokens) {
+  const torch::Tensor draft_tokens = torch::zeros({4, 3}, torch::kInt64);
+  const torch::Tensor draft_probs =
+      torch::tensor({0.9f, 0.1f}).view({1, 1, 2}).repeat({4, 3, 1});
+  const torch::Tensor target_probs =
+      torch::tensor({0.8f, 0.2f}).view({1, 1, 2}).repeat({4, 3, 1});
+  // The fixed draws reject at positions 0, 1, 2, then accept all drafts.
+  // Residual probability exists only for token 1, so recovery is deterministic.
+  const torch::Tensor uniform_rand = torch::tensor({{0.95f, 0.1f, 0.1f},
+                                                    {0.1f, 0.95f, 0.1f},
+                                                    {0.1f, 0.1f, 0.95f},
+                                                    {0.1f, 0.1f, 0.1f}});
+  const torch::Tensor bonus_tokens = torch::ones({4, 1}, torch::kInt64);
+  const DraftProposal proposal(draft_tokens, draft_probs);
+  const auto sampled =
+      RejectionSampler::random_sample(proposal,
+                                      target_probs,
+                                      uniform_rand,
+                                      bonus_tokens,
+                                      /*mask_out_rejected_tokens=*/true);
+  const torch::Tensor& masked_tokens = std::get<1>(sampled);
+  ASSERT_TRUE(torch::equal(
+      masked_tokens,
+      torch::tensor(
+          {{1, -1, -1, -1}, {0, 1, -1, -1}, {0, 0, 1, -1}, {0, 0, 0, 1}},
+          torch::kInt64)));
+
+  const auto stats =
+      calculate_block_speculative_token_stats(masked_tokens, {3, 3, 3, 3});
+  ASSERT_EQ(stats.size(), 4);
+  for (size_t row = 0; row < stats.size(); ++row) {
+    EXPECT_EQ(stats[row].accepted_tokens, static_cast<int64_t>(row));
+    EXPECT_EQ(stats[row].proposed_tokens, 3);
+  }
+}
+
+TEST(SpeculativeTokenStatsTest, BlockHandlesSingleAndZeroDrafts) {
+  const torch::Tensor draft_tokens = torch::tensor({{1}, {1}}, torch::kInt64);
+  const torch::Tensor target_tokens = torch::tensor({{9}, {1}}, torch::kInt64);
+  const torch::Tensor bonus_tokens = torch::full({2, 1}, 8, torch::kInt64);
+  const auto sampled = RejectionSampler::greedy_sample_from_token_ids(
+      draft_tokens,
+      target_tokens,
+      bonus_tokens,
+      /*mask_out_rejected_tokens=*/true);
+  const auto stats =
+      calculate_block_speculative_token_stats(std::get<1>(sampled), {1, 1});
+  ASSERT_EQ(stats.size(), 2);
+  EXPECT_EQ(stats[0].accepted_tokens, 0);
+  EXPECT_EQ(stats[0].proposed_tokens, 1);
+  EXPECT_EQ(stats[1].accepted_tokens, 1);
+  EXPECT_EQ(stats[1].proposed_tokens, 1);
+
+  // A fully pruned row emits only the target bonus and proposes no drafts.
+  const torch::Tensor empty_drafts = torch::empty({2, 0}, torch::kInt64);
+  const auto bonus_only = RejectionSampler::greedy_sample_from_token_ids(
+      empty_drafts,
+      empty_drafts,
+      bonus_tokens,
+      /*mask_out_rejected_tokens=*/true);
+  ASSERT_TRUE(torch::equal(std::get<1>(bonus_only), bonus_tokens));
+  const auto zero_stats =
+      calculate_block_speculative_token_stats(std::get<1>(bonus_only), {0, 0});
+  ASSERT_EQ(zero_stats.size(), 2);
+  for (const SpeculativeTokenStats& row_stats : zero_stats) {
+    EXPECT_EQ(row_stats.accepted_tokens, 0);
+    EXPECT_EQ(row_stats.proposed_tokens, 0);
+  }
 }
 
 TEST(WorkerServiceMetricsTest, AdaptiveMtpUpdatesMetricsOnce) {
@@ -179,7 +279,8 @@ TEST(WorkerServiceMetricsTest, StaticMtpRecordsTokenTotals) {
 
 TEST(WorkerServiceMetricsTest, BlockDiffusionPreservesInlineMetrics) {
   const torch::Tensor tokens = torch::tensor({{10, 11, -1, -1}}, torch::kInt32);
-  const std::vector<SpeculativeTokenStats> output_stats = {{2, 3}};
+  const std::vector<SpeculativeTokenStats> output_stats =
+      calculate_block_speculative_token_stats(tokens, {3});
   const double drafts_before = COUNTER_VALUE(speculative_num_drafts_total);
   const double proposed_before =
       COUNTER_VALUE(speculative_num_draft_tokens_total);
@@ -198,7 +299,7 @@ TEST(WorkerServiceMetricsTest, BlockDiffusionPreservesInlineMetrics) {
     const auto result = WorkerServiceTestPeer::record_speculative_metrics(
         service, tokens, output_stats);
     ASSERT_EQ(result.size(), 1);
-    EXPECT_EQ(result[0].accepted_tokens, 2);
+    EXPECT_EQ(result[0].accepted_tokens, 1);
     EXPECT_EQ(result[0].proposed_tokens, 3);
   }
   EXPECT_DOUBLE_EQ(COUNTER_VALUE(speculative_num_drafts_total), drafts_before);

--- a/xllm/core/runtime/speculative_worker_impl.cpp
+++ b/xllm/core/runtime/speculative_worker_impl.cpp
@@ -185,8 +185,11 @@ std::vector<SpeculativeTokenStats> calculate_mtp_speculative_token_stats(
 std::vector<SpeculativeTokenStats> calculate_block_speculative_token_stats(
     const torch::Tensor& tokens,
     const std::vector<int32_t>& proposed_tokens) {
+  // The contiguous output includes one target-model token: the replacement
+  // at the first rejection, or the bonus after all drafts are accepted.
+  // Count one fewer valid token, capped by each row's actual proposal width.
   return calculate_contiguous_speculative_token_stats(
-      tokens, proposed_tokens, /*accepted_token_offset=*/0);
+      tokens, proposed_tokens, /*accepted_token_offset=*/1);
 }
 
 SpeculativeOutputStats calculate_speculative_output_stats(


### PR DESCRIPTION
## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [x] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [x] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [x] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [x] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [x] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
