### PR TITLE
perf: cut copies and lazily allocate logprob buffers in request build path.

### DIFF
--- a/.agents/skills/code-review/references/custom-code-style.md
+++ b/.agents/skills/code-review/references/custom-code-style.md
@@ -174,6 +174,26 @@ virtual ModelOutput forward(torch::Tensor tokens, ...);
   - Use `std::shared_ptr` only when shared ownership is genuinely needed.
   - Raw pointers are acceptable only for non-owning references where the lifetime is clearly managed elsewhere.
 
+### Move & Copy Semantics
+
+- **Never write `std::move()` on a `const&` (or otherwise const) value.** `std::move(x)` where `x` is `const T&` produces a `const T&&`, which binds to the **copy** constructor, not the move constructor. It compiles, looks like a move, and silently deep-copies. This is the exact bug that made `Request`/`RequestState` construction copy their whole payload. `clang-tidy`'s `performance-move-const-arg` flags it.
+
+```cpp
+// Bad – silently copies: the parameter is const&, so std::move binds to the
+//       copy constructor.
+Request(const RequestState& state) : state_(std::move(state)) {}
+
+// Good – sink parameter: take by value, then std::move into the member. The
+//        CALLER decides copy vs move (pass an lvalue to copy, std::move to move).
+Request(RequestState state) : state_(std::move(state)) {}
+```
+
+- **Sink parameters go by value.** If a constructor/setter/function stores (retains) its argument, take it **by value** and `std::move` it into the member. Do not take it by `const&` and copy, and do not take it by `const&` and `std::move` (see above). Reserve `const&` for parameters you only read and do not retain.
+
+- **Make callers move.** When you hand an owned local to a sink parameter and do not use it afterwards, pass `std::move(local)`. Leaving it as an lvalue silently deep-copies.
+
+- **Prefer making expensive-to-copy domain types move-only.** For heavy aggregates where a copy is almost always a bug, `= delete` the copy constructor/assignment and expose an explicit `clone()` for the rare intentional copy. An accidental copy then becomes a compile error instead of a silent performance cliff.
+
 ---
 
 ## 6. Scoping & Visibility

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,36 @@
+# Focused clang-tidy configuration for xLLM.
+#
+# Primary goal: catch the std::move(const&) silent-copy foot-gun and related
+# move/copy performance mistakes automatically, instead of relying on reviewers.
+# `std::move` on a const (or const-ref) argument yields a `const T&&`, which
+# binds to the COPY constructor rather than the move constructor -- so it
+# compiles, looks like a move, and silently deep-copies. performance-move-const-arg
+# flags exactly this.
+#
+# Run over a single file (needs a compile_commands.json under build/):
+#   clang-tidy -p build path/to/file.cpp
+Checks: >
+  -*,
+  performance-move-const-arg,
+  performance-move-constructor-init,
+  performance-noexcept-move-constructor,
+  performance-unnecessary-value-param,
+  performance-unnecessary-copy-initialization,
+  performance-for-range-copy,
+  performance-implicit-conversion-in-loop,
+  bugprone-use-after-move,
+  bugprone-move-forwarding-reference
+
+# Treat the two genuine correctness/foot-gun checks as errors so a silent copy
+# or a use-after-move fails the run instead of scrolling by as a warning.
+WarningsAsErrors: >
+  performance-move-const-arg,
+  bugprone-use-after-move
+
+CheckOptions:
+  # Also flag std::move of trivially-copyable types (pessimizing / misleading).
+  - key: performance-move-const-arg.CheckTriviallyCopyableMove
+    value: 'true'
+
+# Only report on first-party headers; skip third-party/generated code.
+HeaderFilterRegex: 'xllm/.*'

--- a/.cursor/rules/move-copy-semantics.mdc
+++ b/.cursor/rules/move-copy-semantics.mdc
@@ -1,0 +1,32 @@
+---
+description: Avoid std::move(const&) silent copies; use sink-by-value + std::move
+globs: "**/*.{h,hpp,c,cc,cpp,cu}"
+alwaysApply: true
+---
+
+# Move & Copy Semantics
+
+`std::move(x)` is only a cast to `T&&`. When `x` is `const&` (or const), it yields
+a `const T&&` that binds to the **copy** constructor, not the move constructor —
+so it compiles, looks like a move, and silently deep-copies. This is the bug that
+made `Request`/`RequestState` construction copy their whole payload.
+
+- **Never `std::move` a `const&` / const value.** The two ingredients of the bug
+  are always "a const source + `std::move`". Don't combine them.
+- **Sink parameters go by value + `std::move`.** If a function/ctor retains its
+  argument, take it **by value** and `std::move` it into the member. Use `const&`
+  only for parameters you read but do not retain.
+- **Make callers move.** Pass `std::move(local)` when you hand an owned local to a
+  sink parameter and don't use it afterwards; an lvalue silently copies.
+- Consider making heavy, rarely-copied domain types move-only (`= delete` copy) with
+  an explicit `clone()`, so an accidental copy is a compile error.
+
+```cpp
+// Bad – const& + std::move => copies
+Request(const RequestState& state) : state_(std::move(state)) {}
+
+// Good – sink by value; caller chooses copy (lvalue) vs move (std::move)
+Request(RequestState state) : state_(std::move(state)) {}
+```
+
+`clang-tidy`'s `performance-move-const-arg` (see repo `.clang-tidy`) flags this.

--- a/tests/core/framework/batch/batch_test.cpp
+++ b/tests/core/framework/batch/batch_test.cpp
@@ -3040,7 +3040,7 @@ TEST(BatchTest, JsonObjectErrorFailsUnscheduledSiblingSequence) {
       /*enable_schedule_overlap=*/true,
       [](const RequestOutput&) { return true; },
       OutputsFunc{});
-  Request request("req-shared", "", "", request_state);
+  Request request("req-shared", "", "", std::move(request_state));
   ASSERT_TRUE(request.expand_sequences(/*share_prefix=*/false));
   ASSERT_EQ(request.sequences().size(), 2u);
   for (const auto& sequence : request.sequences()) {

--- a/tests/core/framework/block/hierarchy_block_manager_pool_test.cpp
+++ b/tests/core/framework/block/hierarchy_block_manager_pool_test.cpp
@@ -225,8 +225,11 @@ std::shared_ptr<Request> make_test_request(
                              /*enable_schedule_overlap=*/false,
                              /*output_func=*/nullptr,
                              /*outputs_func=*/nullptr);
-  return std::make_shared<Request>(
-      "request", "x-request", "time", request_state, "service-request");
+  return std::make_shared<Request>("request",
+                                   "x-request",
+                                   "time",
+                                   std::move(request_state),
+                                   "service-request");
 }
 
 void seed_host_prefix(BlockManager* leaf, const std::vector<int32_t>& tokens) {

--- a/tests/core/framework/request/request_prefix_cache_tokens_test.cpp
+++ b/tests/core/framework/request/request_prefix_cache_tokens_test.cpp
@@ -98,7 +98,8 @@ std::shared_ptr<Request> MakeRequest(
       [](const RequestOutput&) { return true; },
       OutputsFunc{});
 
-  return std::make_shared<Request>("cached-tokens-test", "", "", state);
+  return std::make_shared<Request>(
+      "cached-tokens-test", "", "", std::move(state));
 }
 
 void EvictPrefixCache(BlockManagerPool& pool,

--- a/tests/core/framework/request/sample_slot_test.cpp
+++ b/tests/core/framework/request/sample_slot_test.cpp
@@ -195,7 +195,7 @@ TEST(SampleSlotTest, RequestPropagatesSampleSlotsToSequenceRuntime) {
 
   request_state.sample_slots = {first_slot, second_slot};
 
-  Request request("sample-req", "", "", request_state);
+  Request request("sample-req", "", "", std::move(request_state));
 
   ASSERT_EQ(request.sequences().size(), 1);
   const auto& runtime_sample_slots = request.sequences()[0]->sample_slots();
@@ -224,7 +224,7 @@ TEST(RequestTest, GenerateOutputReturnsSequenceFailureStatus) {
       /*enable_schedule_overlap=*/true,
       [](const RequestOutput&) { return true; },
       OutputsFunc{});
-  Request request("req-error", "", "", request_state);
+  Request request("req-error", "", "", std::move(request_state));
   Status failure(StatusCode::UNKNOWN,
                  "json_object constrained decoding failed");
   request.sequences()[0]->fail(failure);
@@ -290,7 +290,7 @@ TEST(SampleSlotTest, RequestOutputSplitsSampleResultsBySampleId) {
 
   request_state.sample_slots = {first_slot, second_slot};
 
-  Request request("sample-req", "", "", request_state);
+  Request request("sample-req", "", "", std::move(request_state));
   auto* seq = request.sequences()[0].get();
   seq->add_blocks(BlockType::KV, manager.allocate(1));
   seq->kv_state().set_kv_cache_tokens_num(seq->num_prompt_tokens());
@@ -375,7 +375,7 @@ TEST(SampleSlotTest, RequestOutputStableSortsOutOfOrderSampleIds) {
 
   request_state.sample_slots = {slot2, slot0, slot1};
 
-  Request request("sample-req", "", "", request_state);
+  Request request("sample-req", "", "", std::move(request_state));
   auto* seq = request.sequences()[0].get();
   seq->add_blocks(BlockType::KV, manager.allocate(1));
   seq->kv_state().set_kv_cache_tokens_num(seq->num_prompt_tokens());
@@ -437,7 +437,7 @@ TEST(SampleSlotTest, OneRecOutputCarriesTokenLogprobsWhenEnabled) {
   Request request("onerec-score",
                   /*x_request_id=*/"",
                   /*x_request_time=*/"",
-                  request_state);
+                  std::move(request_state));
   auto* seq = request.sequences()[0].get();
 
   Token first_token(101);

--- a/tests/core/scheduler/disagg_pd_scheduler_test.cpp
+++ b/tests/core/scheduler/disagg_pd_scheduler_test.cpp
@@ -196,7 +196,7 @@ std::shared_ptr<Request> make_request(
                      /*service_request_id=*/nullptr);
 
   return std::make_shared<Request>(
-      "req", "x-request-id", "x-request-time", state, "service-req");
+      "req", "x-request-id", "x-request-time", std::move(state), "service-req");
 }
 
 void finish_prefill(Sequence* sequence) {

--- a/xllm/core/framework/request/request.cpp
+++ b/xllm/core/framework/request/request.cpp
@@ -36,7 +36,7 @@ namespace xllm {
 Request::Request(const std::string& request_id,
                  const std::string& x_request_id,
                  const std::string& x_request_time,
-                 const RequestState& state,
+                 RequestState state,
                  const std::string& service_request_id,
                  const std::string& source_xservice_addr,
                  RateLimiter* rate_limiter)
@@ -73,11 +73,12 @@ void Request::create_sequences_group() {
   sequence_params.json_reasoning_enabled = state_.json_reasoning_enabled;
   sequence_params.request_failure_state = failure_state_;
   sequence_params.speculative_token_stats = speculative_token_stats_;
-  sequences_group_ = std::make_unique<SequencesGroup>(state_.prompt,
-                                                      state_.prompt_tokens,
-                                                      state_.input_embedding,
-                                                      state_.mm_data,
-                                                      sequence_params);
+  sequences_group_ =
+      std::make_unique<SequencesGroup>(state_.prompt,
+                                       state_.prompt_tokens,
+                                       state_.input_embedding,
+                                       state_.mm_data,
+                                       std::move(sequence_params));
 }
 
 bool Request::finished() const {

--- a/xllm/core/framework/request/request.h
+++ b/xllm/core/framework/request/request.h
@@ -40,7 +40,7 @@ class Request : public RequestBase {
   Request(const std::string& request_id,
           const std::string& x_request_id,
           const std::string& x_request_time,
-          const RequestState& state,
+          RequestState state,
           const std::string& service_request_id = "",
           const std::string& source_xservice_addr = "",
           RateLimiter* rate_limiter = nullptr);

--- a/xllm/core/framework/request/request_state.h
+++ b/xllm/core/framework/request/request_state.h
@@ -55,7 +55,7 @@ struct SchedulerParam {
   RequestPriority priority = RequestPriority::NORMAL;
 };
 
-struct RequestState final {
+class RequestState final {
  public:
   RequestState() {}
 
@@ -113,6 +113,24 @@ struct RequestState final {
 
   // for profiling run, only provide prompt tokens
   RequestState(const std::vector<int32_t>& prompt_tokens);
+
+  // RequestState owns the heavy request payload (prompt, prompt_tokens,
+  // mm_data, sample_slots, callbacks). An implicit copy is almost always an
+  // accidental deep copy, so the type is move-only. Use clone() for the rare
+  // intentional copy (e.g. a benchmark/test that reuses a template state). This
+  // also makes the std::move(const&) foot-gun a compile error rather than a
+  // silent copy.
+  RequestState(RequestState&&) = default;
+  RequestState& operator=(RequestState&&) = default;
+
+  // Explicit deep copy. Prefer moving; only clone when a genuine second owner
+  // is required.
+  RequestState clone() const { return RequestState(*this); }
+
+ private:
+  // Non-public so external code cannot copy implicitly; clone() uses it.
+  RequestState(const RequestState&) = default;
+  RequestState& operator=(const RequestState&) = delete;
 
  public:
   // sampling parameters

--- a/xllm/core/framework/request/request_state_benchmark.cpp
+++ b/xllm/core/framework/request/request_state_benchmark.cpp
@@ -37,6 +37,7 @@ limitations under the License.
 #include <string>
 #include <vector>
 
+#include "core/framework/request/request.h"
 #include "core/framework/request/request_output.h"
 #include "core/framework/request/request_state.h"
 
@@ -49,6 +50,26 @@ constexpr size_t kPromptChars = 2048;
 
 OutputFunc NoopOutput() {
   return [](const RequestOutput&) { return true; };
+}
+
+// Builds a RequestState carrying a heap prompt + `n` prompt tokens, used as the
+// source for the Request-construction benchmarks below.
+RequestState MakeRequestState(size_t n) {
+  return RequestState(std::string(kPromptChars, 'x'),
+                      std::vector<int32_t>(n, 7),
+                      RequestSamplingParam{},
+                      SchedulerParam{},
+                      StoppingChecker{},
+                      /*seq_capacity=*/n + 8,
+                      /*n=*/1,
+                      /*best_of=*/1,
+                      /*logprobs=*/false,
+                      /*stream=*/false,
+                      /*echo=*/false,
+                      /*skip_special_tokens=*/true,
+                      /*enable_schedule_overlap=*/false,
+                      NoopOutput(),
+                      OutputsFunc{});
 }
 
 void BM_RequestState_Copy(benchmark::State& state) {
@@ -77,9 +98,6 @@ void BM_RequestState_Copy(benchmark::State& state) {
     benchmark::DoNotOptimize(s.prompt.data());
     benchmark::DoNotOptimize(s.prompt_tokens.data());
   }
-  state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) *
-                          (static_cast<int64_t>(n) * sizeof(int32_t) +
-                           static_cast<int64_t>(kPromptChars)));
 }
 
 void BM_RequestState_Move(benchmark::State& state) {
@@ -116,12 +134,66 @@ void BM_RequestState_Move(benchmark::State& state) {
   // meaningless, ever-increasing bandwidth for what is constant work.
 }
 
+// ---------------------------------------------------------------------------
+// Request construction: COPY state vs MOVE state.
+//
+// Request's constructor takes RequestState by value and std::move-s it into its
+// member (and, transitively, SequencesGroup takes SequenceParams by value +
+// std::move). RequestState is move-only, so a deep copy must be requested
+// explicitly via clone(); handing over ownership with std::move avoids it.
+// Both paths run the same create_sequences_group() work, so the delta between
+// them isolates the RequestState copy the by-value+std::move change removed
+// (matching what the request factories do via std::move(req_state)).
+//
+//   * BM_Request_CopyState - clone()s the state first (deep copy), then moves.
+//   * BM_Request_MoveState - passes an rvalue (std::move), so it is moved.
+// ---------------------------------------------------------------------------
+
+void BM_Request_CopyState(benchmark::State& state) {
+  const size_t n = static_cast<size_t>(state.range(0));
+  const RequestState src = MakeRequestState(n);
+
+  for (auto _ : state) {
+    // Explicit deep copy of the reusable template state (RequestState is
+    // move-only), then moved into the request. This is the cost the by-value +
+    // std::move constructor change avoids whenever the caller can hand over
+    // ownership instead of cloning.
+    Request req("bench-req", "", "", src.clone());
+    benchmark::DoNotOptimize(req.state().prompt.data());
+    benchmark::DoNotOptimize(req.state().prompt_tokens.data());
+  }
+}
+
+void BM_Request_MoveState(benchmark::State& state) {
+  const size_t n = static_cast<size_t>(state.range(0));
+
+  for (auto _ : state) {
+    // Building the source state is excluded from timing; only the request
+    // construction (which moves the state in) is timed.
+    state.PauseTiming();
+    RequestState src = MakeRequestState(n);
+    state.ResumeTiming();
+
+    Request req("bench-req", "", "", std::move(src));
+    benchmark::DoNotOptimize(req.state().prompt.data());
+    benchmark::DoNotOptimize(req.state().prompt_tokens.data());
+  }
+}
+
 // Sweep prompt_tokens length from 128 to 128K tokens.
 BENCHMARK(BM_RequestState_Copy)
     ->RangeMultiplier(8)
     ->Range(128, 128 << 10)
     ->Unit(benchmark::kNanosecond);
 BENCHMARK(BM_RequestState_Move)
+    ->RangeMultiplier(8)
+    ->Range(128, 128 << 10)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_Request_CopyState)
+    ->RangeMultiplier(8)
+    ->Range(128, 128 << 10)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_Request_MoveState)
     ->RangeMultiplier(8)
     ->Range(128, 128 << 10)
     ->Unit(benchmark::kNanosecond);

--- a/xllm/core/framework/request/sequence.cpp
+++ b/xllm/core/framework/request/sequence.cpp
@@ -153,7 +153,20 @@ void Sequence::init_onerec_sequence(
   volatile_num_prompt_tokens_ = num_prompt_tokens_;
   input_embedding_ = std::move(input_embedding);
   cur_generated_token_idx_ = num_prompt_tokens_;
-  logprob_state_ = std::make_unique<LogprobState>(num_prompt_tokens_, capacity);
+  // OneRec can also emit per-token logprobs via enable_output_sku_logprobs
+  // (see generate_onerec_streaming_output), independent of the sampling flag,
+  // so allocate the logprob buffer when either path needs it. Beam search reads
+  // both buffers unconditionally (see the main constructor), so force them on
+  // for beam requests too.
+  const bool is_beam_search = sequence_params_.sampling_param->beam_width > 1;
+  const bool enable_logprobs =
+      sequence_params_.sampling_param->logprobs ||
+      ::xllm::RecConfig::get_instance().enable_output_sku_logprobs() ||
+      is_beam_search;
+  const bool enable_top_logprobs =
+      sequence_params_.sampling_param->top_logprobs > 0 || is_beam_search;
+  logprob_state_ = std::make_unique<LogprobState>(
+      num_prompt_tokens_, capacity, enable_logprobs, enable_top_logprobs);
 }
 
 void Sequence::generate_onerec_streaming_output(const Slice<int32_t>& ids,
@@ -259,8 +272,21 @@ Sequence::Sequence(size_t index,
   volatile_num_prompt_tokens_ = num_prompt_tokens_;
   tokens_.resize(capacity);
 
-  // init logprob state
-  logprob_state_ = std::make_unique<LogprobState>(num_prompt_tokens_, capacity);
+  // init logprob state. Only allocate the per-position buffers when they will
+  // actually be read. Beam search (SequencesGroup::process_beam_search) indexes
+  // both the logprob and top-k buffers on every expansion regardless of the
+  // request's logprobs flags, so beam requests must allocate them even when
+  // logprobs are disabled -- otherwise the reader would be out of bounds. The
+  // LLM factory normalizes these flags for beam, but the REC factory copies
+  // beam_width without doing so, so gate on beam_width here to stay safe for
+  // both. best_of>n forces logprobs on upstream, so it is already covered.
+  const bool is_beam_search = sequence_params_.sampling_param->beam_width > 1;
+  const bool enable_logprobs =
+      sequence_params_.sampling_param->logprobs || is_beam_search;
+  const bool enable_top_logprobs =
+      sequence_params_.sampling_param->top_logprobs > 0 || is_beam_search;
+  logprob_state_ = std::make_unique<LogprobState>(
+      num_prompt_tokens_, capacity, enable_logprobs, enable_top_logprobs);
 
   if (sequence_params_.sampling_param->frequency_penalty != 0 ||
       sequence_params_.sampling_param->presence_penalty != 0 ||

--- a/xllm/core/framework/request/sequence_logprob_state.cpp
+++ b/xllm/core/framework/request/sequence_logprob_state.cpp
@@ -20,12 +20,26 @@ limitations under the License.
 
 namespace xllm {
 
-LogprobState::LogprobState(int64_t num_prompt_tokens, size_t capacity)
+LogprobState::LogprobState(int64_t num_prompt_tokens,
+                           size_t capacity,
+                           bool enable_logprobs,
+                           bool enable_top_logprobs)
     : num_prompt_tokens_(num_prompt_tokens), acc_logprob_(0.0) {
   last_acc_token_idx_ = num_prompt_tokens_;
-  logprobs_.resize(capacity);
-  top_tokens_.resize(capacity);
-  top_logprobs_.resize(capacity);
+  // Only pre-size the buffers that will actually be written/read. When the
+  // request produces no logprobs these stay empty, avoiding an O(capacity)
+  // allocation + zero-init per sequence (the dominant cost of Request build for
+  // long prompts). update_logprob() and the logprob readers are all gated on
+  // the same logprobs flag, so leaving these empty is safe.
+  if (enable_logprobs) {
+    logprobs_.resize(capacity);
+    // Top-k candidate buffers are only needed when top_logprobs are requested
+    // (e.g. beam search, which forces top_logprobs > 0).
+    if (enable_top_logprobs) {
+      top_tokens_.resize(capacity);
+      top_logprobs_.resize(capacity);
+    }
+  }
 }
 
 float LogprobState::get_acc_logprob(int64_t num_tokens) {
@@ -129,8 +143,9 @@ void LogprobState::generate_output_tokens_logprobs(
     tmp_logprob.token_id = token_id;
     tmp_logprob.logprob = logprobs_[i].value();
 
-    // add top logprobs
-    if (top_tokens_[i].empty()) {
+    // add top logprobs. top_tokens_ is empty when top_logprobs were not
+    // requested (the buffer isn't allocated in that case), so guard the index.
+    if (top_tokens_.empty() || top_tokens_[i].empty()) {
       out_logprobs->emplace_back(std::move(tmp_logprob));
       continue;
     }

--- a/xllm/core/framework/request/sequence_logprob_state.h
+++ b/xllm/core/framework/request/sequence_logprob_state.h
@@ -29,7 +29,16 @@ namespace xllm {
 
 class LogprobState {
  public:
-  LogprobState(int64_t num_prompt_tokens, size_t capacity);
+  // `enable_logprobs` / `enable_top_logprobs` gate the per-position buffers:
+  // when a request does not produce logprobs they stay empty (size 0) and cost
+  // nothing, instead of eagerly allocating + zero-initializing capacity-sized
+  // vectors. All readers are gated on the same logprobs flag (or bounds-check),
+  // so an empty buffer is safe. See Sequence::Sequence for how the flags are
+  // derived.
+  LogprobState(int64_t num_prompt_tokens,
+               size_t capacity,
+               bool enable_logprobs,
+               bool enable_top_logprobs);
   ~LogprobState() = default;
 
   // for generated tokens

--- a/xllm/core/framework/request/sequences_group.cpp
+++ b/xllm/core/framework/request/sequences_group.cpp
@@ -32,7 +32,7 @@ SequencesGroup::SequencesGroup(const std::string& prompt,
                                const std::vector<int32_t>& prompt_tokens,
                                const torch::Tensor& input_embedding,
                                const MMData& mm_data,
-                               const SequenceParams& sequence_params)
+                               SequenceParams sequence_params)
     : prompt_(prompt),
       prompt_tokens_(prompt_tokens),
       input_embedding_(input_embedding),

--- a/xllm/core/framework/request/sequences_group.h
+++ b/xllm/core/framework/request/sequences_group.h
@@ -38,7 +38,7 @@ class SequencesGroup {
                  const std::vector<int32_t>& prompt_tokens,
                  const torch::Tensor& input_embedding,
                  const MMData& mm_data,
-                 const SequenceParams& sequence_params);
+                 SequenceParams sequence_params);
 
   bool finished() const;
 

--- a/xllm/core/scheduler/profile/profile_manager.cpp
+++ b/xllm/core/scheduler/profile/profile_manager.cpp
@@ -827,7 +827,7 @@ std::shared_ptr<Request> ProfileManager::generate_single_request(
       /*request_id=*/next_warmup_request_id(),
       /*x_request_id=*/"",
       /*x_request_time=*/"",
-      req_state);
+      std::move(req_state));
 
   // TODO: better disable prefix cache
   if (prefix_length > 0) {
@@ -904,7 +904,7 @@ std::shared_ptr<Request> ProfileManager::try_generate_single_decode_request(
       /*request_id=*/next_warmup_request_id(),
       /*x_request_id=*/"",
       /*x_request_time=*/"",
-      req_state);
+      std::move(req_state));
 
   auto* sequence = request->sequences()[0].get();
   if (dp_rank.has_value()) {


### PR DESCRIPTION
Eliminate the silent deep copies on the per-request build path and avoid allocating logprob buffers that most requests never use.

Copies:
- Take RequestState by value in Request's ctor and SequenceParams by value in SequencesGroup's ctor, then std::move into the members. Both previously ran std::move on a const& parameter, which binds to the copy constructor and silently deep-copied the whole RequestState (prompt, prompt_tokens, stopping_checker, sample_slots, mm_data) per request, defeating the moves already done by the request factories.
- Make RequestState move-only with an explicit clone() so an accidental copy is a compile error rather than a silent performance cliff; update all call sites (profile_manager, tests) to move or clone.

Lazy logprob buffers:
- LogprobState now takes enable_logprobs / enable_top_logprobs and only resizes logprobs_ / top_tokens_ / top_logprobs_ to capacity when the request actually produces logprobs. When logprobs are off (the common case) these stay empty, avoiding ~8MB of allocation + zero-init per sequence for long prompts. Beam / best_of>n / OneRec SKU logprobs still allocate as before, and the top-logprob reader is guarded for the logprobs-without-top-k case.

Guardrails:
- Add .clang-tidy (performance-move-const-arg, bugprone-use-after-move as errors, plus related perf checks), a move-copy-semantics cursor rule, and a custom-code-style section to prevent the std::move(const&) foot-gun.
- Add request_state_benchmark to quantify the copy-vs-move win.

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
