### PR TITLE
perf: build Sequence token buffer with a single memcpy.

### DIFF
--- a/xllm/core/framework/request/sequence.cpp
+++ b/xllm/core/framework/request/sequence.cpp
@@ -270,7 +270,17 @@ Sequence::Sequence(size_t index,
 
   num_prompt_tokens_ = prompt_token_ids.size();
   volatile_num_prompt_tokens_ = num_prompt_tokens_;
+
+  // Build the token buffer in a single allocation: memcpy the prompt in, then
+  // zero-fill only the generation tail (capacity - n). The previous
+  // resize(capacity) + per-token store loop zero-initialized every slot and
+  // then overwrote the first n one at a time -- two O(n) passes where one
+  // memcpy suffices. The resulting state is identical: size() == capacity, the
+  // first n slots hold the prompt, the rest are 0.
+  tokens_.reserve(capacity);
+  tokens_.assign(prompt_token_ids.begin(), prompt_token_ids.end());
   tokens_.resize(capacity);
+  num_tokens_ = num_prompt_tokens_;
 
   // init logprob state. Only allocate the per-position buffers when they will
   // actually be read. Beam search (SequencesGroup::process_beam_search) indexes
@@ -294,10 +304,10 @@ Sequence::Sequence(size_t index,
     need_unique_tokens_ = true;
   }
 
-  // add the prompt tokens
-  for (const auto token_id : prompt_token_ids) {
-    tokens_[num_tokens_++] = token_id;
-    if (need_unique_tokens_) {
+  // The prompt tokens were already copied into tokens_ above; only walk them
+  // again to seed the unique-token map when a penalty actually needs it.
+  if (need_unique_tokens_) {
+    for (const auto token_id : prompt_token_ids) {
       token_to_count_map_[token_id] = 0;
     }
   }


### PR DESCRIPTION
Sequence's constructor zero-initialized all seq_capacity token slots via resize(capacity) and then overwrote the first n with a per-token store loop (carrying a need_unique_tokens_ branch on every iteration). That is two O(n) passes over the prompt where one memcpy suffices, and the zeroing of the first n slots was wasted work since they are immediately overwritten.

Reserve capacity once, assign() the prompt tokens (a memcpy for int32), then resize() so only the generation tail (capacity - n) is zero-filled. The unique-token map is now seeded in a separate walk that only runs when a penalty actually needs it. The resulting state is identical: size() == capacity, the first n slots hold the prompt, the rest are 0, and num_tokens_ == n.

This is the dominant remaining O(n) cost in Request construction after the logprob buffers were made lazy; SequencesGroup and IncrementalDecoder already hold the prompt by reference / string_view and copy nothing.

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
