### PR TITLE
chore: normalize existing Apache-2.0 license headers.

### DIFF
--- a/.agents/skills/code-review/references/custom-code-style.md
+++ b/.agents/skills/code-review/references/custom-code-style.md
@@ -41,7 +41,7 @@ Project-specific coding style for xllm. The reviewer **MUST** enforce these styl
 - **Copyright header required** on all new files. Use the correct year matching the file creation date.
 
 ```cpp
-/* Copyright 2025 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 ...

--- a/setup.py
+++ b/setup.py
@@ -238,7 +238,7 @@ def _stage_triton_jit_scripts(base_dir: str, extdir: str) -> None:
     shutil.copy2(source_script, os.path.join(dest_dir, "triton_compile.py"))
 
     pkg_init = (
-        "# Copyright 2026 The xLLM Authors. All Rights Reserved.\n"
+        "# Copyright 2026 The xLLM Authors.\n"
         '# Licensed under the Apache License, Version 2.0 (the "License").\n'
         "# See LICENSE for details.\n"
         '"""xllm internal package marker."""\n'

--- a/tests/api_service/completion_json_parser_test.cpp
+++ b/tests/api_service/completion_json_parser_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/api_service/models_service_impl_test.cpp
+++ b/tests/api_service/models_service_impl_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/api_service/request_id_test.cpp
+++ b/tests/api_service/request_id_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/common/flash_comm1_context_test.cpp
+++ b/tests/core/common/flash_comm1_context_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/common/options_test.cpp
+++ b/tests/core/common/options_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/distributed_runtime/spawn_worker_protocol_test.cpp
+++ b/tests/core/distributed_runtime/spawn_worker_protocol_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/distributed_runtime/worker_service_test.cpp
+++ b/tests/core/distributed_runtime/worker_service_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/framework/eplb/eplb_aggregator_test.cpp
+++ b/tests/core/framework/eplb/eplb_aggregator_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/framework/eplb/eplb_executor_test.cpp
+++ b/tests/core/framework/eplb/eplb_executor_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/framework/eplb/eplb_manager_test.cpp
+++ b/tests/core/framework/eplb/eplb_manager_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/framework/eplb/eplb_options_test.cpp
+++ b/tests/core/framework/eplb/eplb_options_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/framework/eplb/eplb_utils_test.cpp
+++ b/tests/core/framework/eplb/eplb_utils_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/framework/eplb/expert_weight_buffer_shm_test.cpp
+++ b/tests/core/framework/eplb/expert_weight_buffer_shm_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/framework/kv_cache/cache_layout_builder_test.cpp
+++ b/tests/core/framework/kv_cache/cache_layout_builder_test.cpp
@@ -1,10 +1,10 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/core/framework/kv_cache/linear_state_restore_test.cpp
+++ b/tests/core/framework/kv_cache/linear_state_restore_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/framework/kv_cache_transfer/hierarchy_kv_cache_transfer_test.cpp
+++ b/tests/core/framework/kv_cache_transfer/hierarchy_kv_cache_transfer_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/framework/kv_cache_transfer/kv_transfer_completion_test.cpp
+++ b/tests/core/framework/kv_cache_transfer/kv_transfer_completion_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/framework/kv_cache_transfer/reshard_planner_test.cpp
+++ b/tests/core/framework/kv_cache_transfer/reshard_planner_test.cpp
@@ -1,10 +1,10 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/core/framework/parallel_state/npu_cp_plan_test.cpp
+++ b/tests/core/framework/parallel_state/npu_cp_plan_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/framework/parallel_state/process_group_batch_test.cpp
+++ b/tests/core/framework/parallel_state/process_group_batch_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/framework/prefix_cache/linear_state_prefix_cache_test.cpp
+++ b/tests/core/framework/prefix_cache/linear_state_prefix_cache_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/framework/request/dit_request_params_test.cpp
+++ b/tests/core/framework/request/dit_request_params_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/framework/request/sequence_generated_tokens_test.cpp
+++ b/tests/core/framework/request/sequence_generated_tokens_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/framework/request/sequence_stop_output_test.cpp
+++ b/tests/core/framework/request/sequence_stop_output_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/framework/sampling/json_object_grammar_test.cpp
+++ b/tests/core/framework/sampling/json_object_grammar_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/framework/sampling/sampler_filter_mask_test.cpp
+++ b/tests/core/framework/sampling/sampler_filter_mask_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/framework/speculative/adaptive_speculative_controller_test.cpp
+++ b/tests/core/framework/speculative/adaptive_speculative_controller_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/framework/speculative/mtp_json_object_state_test.cpp
+++ b/tests/core/framework/speculative/mtp_json_object_state_test.cpp
@@ -1,10 +1,10 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://www.apache.org/licenses/LICENSE-2.0
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/core/framework/speculative/speculative_profile_registry_test.cpp
+++ b/tests/core/framework/speculative/speculative_profile_registry_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/framework/state_dict/state_dict_utils_test.cpp
+++ b/tests/core/framework/state_dict/state_dict_utils_test.cpp
@@ -1,10 +1,10 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://www.apache.org/licenses/LICENSE-2.0
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/core/kernels/cuda/moe/moe_topk_test.cu
+++ b/tests/core/kernels/cuda/moe/moe_topk_test.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/kernels/mlu/causal_conv1d_fn_test.cpp
+++ b/tests/core/kernels/mlu/causal_conv1d_fn_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/kernels/mlu/causal_conv1d_update_decode_test.cpp
+++ b/tests/core/kernels/mlu/causal_conv1d_update_decode_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/kernels/mlu/chunk_gated_delta_rule_regression_test.cpp
+++ b/tests/core/kernels/mlu/chunk_gated_delta_rule_regression_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/kernels/mlu/fused_gdn_gating_test.cpp
+++ b/tests/core/kernels/mlu/fused_gdn_gating_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/kernels/mlu/fused_recurrent_gated_delta_rule_beta_regression_test.cpp
+++ b/tests/core/kernels/mlu/fused_recurrent_gated_delta_rule_beta_regression_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/kernels/mlu/fused_recurrent_gated_delta_rule_packed_decode_test.cpp
+++ b/tests/core/kernels/mlu/fused_recurrent_gated_delta_rule_packed_decode_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/kernels/mlu/fused_recurrent_gated_delta_rule_test.cpp
+++ b/tests/core/kernels/mlu/fused_recurrent_gated_delta_rule_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/kernels/mlu/fused_sigmoid_update_regression_test.cpp
+++ b/tests/core/kernels/mlu/fused_sigmoid_update_regression_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/kernels/mlu/scaled_quantize_test.cpp
+++ b/tests/core/kernels/mlu/scaled_quantize_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/kernels/npu/tilelang/apply_token_bitmask_wrapper_test.cpp
+++ b/tests/core/kernels/npu/tilelang/apply_token_bitmask_wrapper_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/kernels/npu/tilelang/causal_conv1d_decode_wrapper_test.cpp
+++ b/tests/core/kernels/npu/tilelang/causal_conv1d_decode_wrapper_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/kernels/npu/tilelang/fused_sigmoid_gating_delta_rule_wrapper_test.cpp
+++ b/tests/core/kernels/npu/tilelang/fused_sigmoid_gating_delta_rule_wrapper_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/kernels/npu/tilelang/spec_verify_attention_tiling_update_wrapper_test.cpp
+++ b/tests/core/kernels/npu/tilelang/spec_verify_attention_tiling_update_wrapper_test.cpp
@@ -1,10 +1,10 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://www.apache.org/licenses/LICENSE-2.0
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/core/kernels/npu/tilelang/spec_verify_token_update_wrapper_test.cpp
+++ b/tests/core/kernels/npu/tilelang/spec_verify_token_update_wrapper_test.cpp
@@ -1,10 +1,10 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://www.apache.org/licenses/LICENSE-2.0
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/core/layers/dsa_topk_share_plan_test.cpp
+++ b/tests/core/layers/dsa_topk_share_plan_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/layers/mlu/dcp_attention_merge_test.cpp
+++ b/tests/core/layers/mlu/dcp_attention_merge_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/layers/mlu/dcp_decode_context_test.cpp
+++ b/tests/core/layers/mlu/dcp_decode_context_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/layers/mlu/deepseek_v4_sparse_moe_block_test.cpp
+++ b/tests/core/layers/mlu/deepseek_v4_sparse_moe_block_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/layers/mlu/dsa_topk_relay_test.cpp
+++ b/tests/core/layers/mlu/dsa_topk_relay_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/layers/mlu/qwen3_5_attention_test.cpp
+++ b/tests/core/layers/mlu/qwen3_5_attention_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/layers/mlu/qwen3_5_fused_moe_test.cpp
+++ b/tests/core/layers/mlu/qwen3_5_fused_moe_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/layers/mlu/qwen3_5_gated_delta_net_ops_test.cpp
+++ b/tests/core/layers/mlu/qwen3_5_gated_delta_net_ops_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/layers/mlu/qwen3_5_gated_delta_net_test.cpp
+++ b/tests/core/layers/mlu/qwen3_5_gated_delta_net_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/layers/mlu/qwen3_next_rms_norm_test.cpp
+++ b/tests/core/layers/mlu/qwen3_next_rms_norm_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/layers/npu_torch/deepseek_v4_eplb_load_utils_test.cpp
+++ b/tests/core/layers/npu_torch/deepseek_v4_eplb_load_utils_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/layers/npu_torch/deepseek_v4_eplb_test.cpp
+++ b/tests/core/layers/npu_torch/deepseek_v4_eplb_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/layers/rotary_embedding_util_test.cpp
+++ b/tests/core/layers/rotary_embedding_util_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/platform/mlu/host_page_aligned_region_test.cpp
+++ b/tests/core/platform/mlu/host_page_aligned_region_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/platform/mlu/mlu_batch_memcpy_test.cpp
+++ b/tests/core/platform/mlu/mlu_batch_memcpy_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/platform/mlu/mlu_layer_synchronizer_test.cpp
+++ b/tests/core/platform/mlu/mlu_layer_synchronizer_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/runtime/acl_graph_bucket_policy_test.cpp
+++ b/tests/core/runtime/acl_graph_bucket_policy_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/runtime/acl_graph_task_update_test.cpp
+++ b/tests/core/runtime/acl_graph_task_update_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/runtime/dspark_confidence_head_test.cpp
+++ b/tests/core/runtime/dspark_confidence_head_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/runtime/mlu_linear_state_restore_worker_test.cpp
+++ b/tests/core/runtime/mlu_linear_state_restore_worker_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/runtime/mtp_host_offload_test.cpp
+++ b/tests/core/runtime/mtp_host_offload_test.cpp
@@ -1,10 +1,10 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://www.apache.org/licenses/LICENSE-2.0
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/core/runtime/worker_json_object_overlap_test.cpp
+++ b/tests/core/runtime/worker_json_object_overlap_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/util/model_path_utils_test.cpp
+++ b/tests/core/util/model_path_utils_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/util/net_test.cpp
+++ b/tests/core/util/net_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/util/shared_memory_manager_test.cpp
+++ b/tests/core/util/shared_memory_manager_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/util/verbose_trace_logger_test.cpp
+++ b/tests/core/util/verbose_trace_logger_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/core/util/vocab_validation_test.cpp
+++ b/tests/core/util/vocab_validation_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/models/dit/utils/cola_utils_test.cpp
+++ b/tests/models/dit/utils/cola_utils_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/models/model_registry_test.cpp
+++ b/tests/models/model_registry_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/python/test_deepseek_v32_parallel.py
+++ b/tests/python/test_deepseek_v32_parallel.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/scripts/test_build_dependencies.py
+++ b/tests/scripts/test_build_dependencies.py
@@ -1,9 +1,9 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://github.com/xLLM-AI/xllm/blob/main/LICENSE
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/scripts/test_python_kernel_staging.py
+++ b/tests/scripts/test_python_kernel_staging.py
@@ -1,9 +1,9 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://github.com/xLLM-AI/xllm/blob/main/LICENSE
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tools/build_fast_tokenizer_json.py
+++ b/tools/build_fast_tokenizer_json.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/npu_timeline.py
+++ b/tools/npu_timeline.py
@@ -1,10 +1,10 @@
-# Copyright 2016 The xLLM Authors.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://github.com/xLLM-AI/xllm/blob/main/LICENSE
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/xllm/api_service/completion_json_parser.cpp
+++ b/xllm/api_service/completion_json_parser.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/api_service/completion_json_parser.h
+++ b/xllm/api_service/completion_json_parser.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/api_service/request_id.cpp
+++ b/xllm/api_service/request_id.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/api_service/request_id.h
+++ b/xllm/api_service/request_id.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/auto_config/__init__.py
+++ b/xllm/auto_config/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xllm/auto_config/qwen3.py
+++ b/xllm/auto_config/qwen3.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xllm/auto_config/utils.py
+++ b/xllm/auto_config/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xllm/compiler/tilelang/targets/ascend/aot/__init__.py
+++ b/xllm/compiler/tilelang/targets/ascend/aot/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xllm/compiler/tilelang/targets/ascend/aot/apply_token_bitmask.py
+++ b/xllm/compiler/tilelang/targets/ascend/aot/apply_token_bitmask.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xllm/compiler/tilelang/targets/ascend/aot/causal_conv1d.py
+++ b/xllm/compiler/tilelang/targets/ascend/aot/causal_conv1d.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xllm/compiler/tilelang/targets/ascend/aot/causal_conv1d_decode.py
+++ b/xllm/compiler/tilelang/targets/ascend/aot/causal_conv1d_decode.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xllm/compiler/tilelang/targets/ascend/aot/chunk_gated_delta_rule_fwd_h.py
+++ b/xllm/compiler/tilelang/targets/ascend/aot/chunk_gated_delta_rule_fwd_h.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xllm/compiler/tilelang/targets/ascend/aot/fused_gdn_gating.py
+++ b/xllm/compiler/tilelang/targets/ascend/aot/fused_gdn_gating.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xllm/compiler/tilelang/targets/ascend/aot/fused_sigmoid_gating_delta_rule.py
+++ b/xllm/compiler/tilelang/targets/ascend/aot/fused_sigmoid_gating_delta_rule.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xllm/compiler/tilelang/targets/ascend/aot/rope.py
+++ b/xllm/compiler/tilelang/targets/ascend/aot/rope.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xllm/compiler/tilelang/targets/ascend/aot/spec_verify_attention_tiling_update.py
+++ b/xllm/compiler/tilelang/targets/ascend/aot/spec_verify_attention_tiling_update.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xllm/compiler/tilelang/targets/ascend/aot/spec_verify_token_update.py
+++ b/xllm/compiler/tilelang/targets/ascend/aot/spec_verify_token_update.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xllm/compiler/tilelang/targets/ascend/aot/split_qkv_rmsnorm_mrope.py
+++ b/xllm/compiler/tilelang/targets/ascend/aot/split_qkv_rmsnorm_mrope.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xllm/compiler/tilelang/targets/ascend/aot/utils.py
+++ b/xllm/compiler/tilelang/targets/ascend/aot/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xllm/core/common/flash_comm1_context.cpp
+++ b/xllm/core/common/flash_comm1_context.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/common/flash_comm1_context.h
+++ b/xllm/core/common/flash_comm1_context.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/common/xllm_build_info.h.in
+++ b/xllm/core/common/xllm_build_info.h.in
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/distributed_runtime/spawn_worker_server/spawn_worker_protocol.h
+++ b/xllm/core/distributed_runtime/spawn_worker_server/spawn_worker_protocol.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/eplb/eplb_aggregator.cpp
+++ b/xllm/core/framework/eplb/eplb_aggregator.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/eplb/eplb_aggregator.h
+++ b/xllm/core/framework/eplb/eplb_aggregator.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/eplb/eplb_info.h
+++ b/xllm/core/framework/eplb/eplb_info.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/eplb/eplb_options.cpp
+++ b/xllm/core/framework/eplb/eplb_options.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/eplb/eplb_options.h
+++ b/xllm/core/framework/eplb/eplb_options.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/eplb/eplb_utils.h
+++ b/xllm/core/framework/eplb/eplb_utils.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/kv_cache/cache_layout_builder.cpp
+++ b/xllm/core/framework/kv_cache/cache_layout_builder.cpp
@@ -1,10 +1,10 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/xllm/core/framework/kv_cache/cache_layout_builder.h
+++ b/xllm/core/framework/kv_cache/cache_layout_builder.h
@@ -1,10 +1,10 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/xllm/core/framework/kv_cache/kv_cache_capacity.h
+++ b/xllm/core/framework/kv_cache/kv_cache_capacity.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/kv_cache/kv_cache_tensor_allocator.cpp
+++ b/xllm/core/framework/kv_cache/kv_cache_tensor_allocator.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/kv_cache/kv_cache_tensor_allocator.h
+++ b/xllm/core/framework/kv_cache/kv_cache_tensor_allocator.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/kv_cache/kv_shard_layout.cpp
+++ b/xllm/core/framework/kv_cache/kv_shard_layout.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/kv_cache/kv_shard_layout.h
+++ b/xllm/core/framework/kv_cache/kv_shard_layout.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/kv_cache/layerwise_split_layout.h
+++ b/xllm/core/framework/kv_cache/layerwise_split_layout.h
@@ -1,10 +1,10 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://www.apache.org/licenses/LICENSE-2.0
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
 
 Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/xllm/core/framework/kv_cache/logical_cache_layout.h
+++ b/xllm/core/framework/kv_cache/logical_cache_layout.h
@@ -1,10 +1,10 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/xllm/core/framework/kv_cache_transfer/cache_layout.cpp
+++ b/xllm/core/framework/kv_cache_transfer/cache_layout.cpp
@@ -1,10 +1,10 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/xllm/core/framework/kv_cache_transfer/cache_layout.h
+++ b/xllm/core/framework/kv_cache_transfer/cache_layout.h
@@ -1,10 +1,10 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/xllm/core/framework/kv_cache_transfer/kv_cache_store.cpp
+++ b/xllm/core/framework/kv_cache_transfer/kv_cache_store.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/kv_cache_transfer/kv_cache_store.h
+++ b/xllm/core/framework/kv_cache_transfer/kv_cache_store.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/kv_cache_transfer/kv_transfer_completion.cpp
+++ b/xllm/core/framework/kv_cache_transfer/kv_transfer_completion.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/kv_cache_transfer/kv_transfer_completion.h
+++ b/xllm/core/framework/kv_cache_transfer/kv_transfer_completion.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/kv_cache_transfer/prefetch_result.h
+++ b/xllm/core/framework/kv_cache_transfer/prefetch_result.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/kv_cache_transfer/reshard_planner.cpp
+++ b/xllm/core/framework/kv_cache_transfer/reshard_planner.cpp
@@ -1,10 +1,10 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/xllm/core/framework/kv_cache_transfer/reshard_planner.h
+++ b/xllm/core/framework/kv_cache_transfer/reshard_planner.h
@@ -1,10 +1,10 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/xllm/core/framework/model/aux_hidden_capture.h
+++ b/xllm/core/framework/model/aux_hidden_capture.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/model/mtp_topk_state.h
+++ b/xllm/core/framework/model/mtp_topk_state.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/model/mtp_utils.h
+++ b/xllm/core/framework/model/mtp_utils.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/parallel_state/npu_cp_plan.cpp
+++ b/xllm/core/framework/parallel_state/npu_cp_plan.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/parallel_state/npu_cp_plan.h
+++ b/xllm/core/framework/parallel_state/npu_cp_plan.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/parallel_state/rank_generator.h
+++ b/xllm/core/framework/parallel_state/rank_generator.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/sampling/json_object_grammar.cpp
+++ b/xllm/core/framework/sampling/json_object_grammar.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/sampling/json_object_grammar.h
+++ b/xllm/core/framework/sampling/json_object_grammar.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/speculative/adaptive_pruning_helpers.cpp
+++ b/xllm/core/framework/speculative/adaptive_pruning_helpers.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/speculative/adaptive_pruning_helpers.h
+++ b/xllm/core/framework/speculative/adaptive_pruning_helpers.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
+++ b/xllm/core/framework/speculative/adaptive_speculative_controller.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/speculative/adaptive_speculative_controller.h
+++ b/xllm/core/framework/speculative/adaptive_speculative_controller.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/speculative/mtp_json_object_state.h
+++ b/xllm/core/framework/speculative/mtp_json_object_state.h
@@ -1,10 +1,10 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://www.apache.org/licenses/LICENSE-2.0
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/xllm/core/framework/speculative/speculative_profile_registry.cpp
+++ b/xllm/core/framework/speculative/speculative_profile_registry.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/framework/speculative/speculative_profile_registry.h
+++ b/xllm/core/framework/speculative/speculative_profile_registry.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/activation.cu
+++ b/xllm/core/kernels/cuda/activation.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025 The vLLM Authors and The xLLM Authors.
+/* Copyright 2025 The vLLM Authors and The xLLM Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/activation.cu
+++ b/xllm/core/kernels/cuda/activation.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025 The vLLM Authors and The xLLM Authors. All Rights Reserved.
+/* Copyright 2025 The vLLM Authors and The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/air_log_softmax_last_dim.cu
+++ b/xllm/core/kernels/cuda/air_log_softmax_last_dim.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/block_copy.cu
+++ b/xllm/core/kernels/cuda/block_copy.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/core/math.hpp
+++ b/xllm/core/kernels/cuda/core/math.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/cutlass_extensions/common.hpp
+++ b/xllm/core/kernels/cuda/cutlass_extensions/common.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/cutlass_extensions/epilogue/scaled_mm_epilogues_c3x.hpp
+++ b/xllm/core/kernels/cuda/cutlass_extensions/epilogue/scaled_mm_epilogues_c3x.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/cutlass_w8a8/c3x/cutlass_gemm_caller.cuh
+++ b/xllm/core/kernels/cuda/cutlass_w8a8/c3x/cutlass_gemm_caller.cuh
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/cutlass_w8a8/c3x/scaled_mm.cuh
+++ b/xllm/core/kernels/cuda/cutlass_w8a8/c3x/scaled_mm.cuh
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/cutlass_w8a8/c3x/scaled_mm_helper.hpp
+++ b/xllm/core/kernels/cuda/cutlass_w8a8/c3x/scaled_mm_helper.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/cutlass_w8a8/c3x/scaled_mm_kernels.hpp
+++ b/xllm/core/kernels/cuda/cutlass_w8a8/c3x/scaled_mm_kernels.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/cutlass_w8a8/c3x/scaled_mm_sm100_fp8.cu
+++ b/xllm/core/kernels/cuda/cutlass_w8a8/c3x/scaled_mm_sm100_fp8.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/cutlass_w8a8/c3x/scaled_mm_sm100_fp8_dispatch.cuh
+++ b/xllm/core/kernels/cuda/cutlass_w8a8/c3x/scaled_mm_sm100_fp8_dispatch.cuh
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/cutlass_w8a8/c3x/scaled_mm_sm120_fp8.cu
+++ b/xllm/core/kernels/cuda/cutlass_w8a8/c3x/scaled_mm_sm120_fp8.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/cutlass_w8a8/c3x/scaled_mm_sm120_fp8_dispatch.cuh
+++ b/xllm/core/kernels/cuda/cutlass_w8a8/c3x/scaled_mm_sm120_fp8_dispatch.cuh
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/cutlass_w8a8/c3x/scaled_mm_sm90_fp8.cu
+++ b/xllm/core/kernels/cuda/cutlass_w8a8/c3x/scaled_mm_sm90_fp8.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/cutlass_w8a8/c3x/scaled_mm_sm90_fp8_dispatch.cuh
+++ b/xllm/core/kernels/cuda/cutlass_w8a8/c3x/scaled_mm_sm90_fp8_dispatch.cuh
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/cutlass_w8a8/c3x/sm120_fp8_dispatch_policy.hpp
+++ b/xllm/core/kernels/cuda/cutlass_w8a8/c3x/sm120_fp8_dispatch_policy.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/cutlass_w8a8/c3x/sm120_fp8_kernel_configs.cuh
+++ b/xllm/core/kernels/cuda/cutlass_w8a8/c3x/sm120_fp8_kernel_configs.cuh
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/cutlass_w8a8/scaled_mm_c3x_sm100.cu
+++ b/xllm/core/kernels/cuda/cutlass_w8a8/scaled_mm_c3x_sm100.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/cutlass_w8a8/scaled_mm_c3x_sm120.cu
+++ b/xllm/core/kernels/cuda/cutlass_w8a8/scaled_mm_c3x_sm120.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/cutlass_w8a8/scaled_mm_c3x_sm90.cu
+++ b/xllm/core/kernels/cuda/cutlass_w8a8/scaled_mm_c3x_sm90.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/cutlass_w8a8/scaled_mm_entry.cu
+++ b/xllm/core/kernels/cuda/cutlass_w8a8/scaled_mm_entry.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/device_utils.cuh
+++ b/xllm/core/kernels/cuda/device_utils.cuh
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/fp8_quant.cu
+++ b/xllm/core/kernels/cuda/fp8_quant.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/fp8_quant_utils.cuh
+++ b/xllm/core/kernels/cuda/fp8_quant_utils.cuh
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/fused_qknorm_rope.cu
+++ b/xllm/core/kernels/cuda/fused_qknorm_rope.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/llm_decode_metadata_update.cu
+++ b/xllm/core/kernels/cuda/llm_decode_metadata_update.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/moe/moe_combine.cu
+++ b/xllm/core/kernels/cuda/moe/moe_combine.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/moe/moe_compute_index.cu
+++ b/xllm/core/kernels/cuda/moe/moe_compute_index.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/moe/moe_fused_topk.cu
+++ b/xllm/core/kernels/cuda/moe/moe_fused_topk.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/norm.cu
+++ b/xllm/core/kernels/cuda/norm.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025 The vLLM Authors and The xLLM Authors.
+/* Copyright 2025 The vLLM Authors and The xLLM Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/norm.cu
+++ b/xllm/core/kernels/cuda/norm.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025 The vLLM Authors and The xLLM Authors. All Rights Reserved.
+/* Copyright 2025 The vLLM Authors and The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/rec_beam_search.cu
+++ b/xllm/core/kernels/cuda/rec_beam_search.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/reshape_paged_cache.cu
+++ b/xllm/core/kernels/cuda/reshape_paged_cache.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/rope.cu
+++ b/xllm/core/kernels/cuda/rope.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025 The vLLM Authors and The xLLM Authors.
+/* Copyright 2025 The vLLM Authors and The xLLM Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/rope.cu
+++ b/xllm/core/kernels/cuda/rope.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025 The vLLM Authors and The xLLM Authors. All Rights Reserved.
+/* Copyright 2025 The vLLM Authors and The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/type_convert.cuh
+++ b/xllm/core/kernels/cuda/type_convert.cuh
@@ -1,4 +1,4 @@
-/* Copyright 2025 The vLLM Authors and The xLLM Authors.
+/* Copyright 2025 The vLLM Authors and The xLLM Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/type_convert.cuh
+++ b/xllm/core/kernels/cuda/type_convert.cuh
@@ -1,4 +1,4 @@
-/* Copyright 2025 The vLLM Authors and The xLLM Authors. All Rights Reserved.
+/* Copyright 2025 The vLLM Authors and The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/xattention/cache_select.cu
+++ b/xllm/core/kernels/cuda/xattention/cache_select.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/xattention/decoder_reshape_and_cache.cu
+++ b/xllm/core/kernels/cuda/xattention/decoder_reshape_and_cache.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/xattention/lse_combine.cu
+++ b/xllm/core/kernels/cuda/xattention/lse_combine.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/cuda/xattention/prefill_reshape_and_cache.cu
+++ b/xllm/core/kernels/cuda/xattention/prefill_reshape_and_cache.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/dcu/aiter_moe_adapter.cpp
+++ b/xllm/core/kernels/dcu/aiter_moe_adapter.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/dcu/aiter_moe_adapter.h
+++ b/xllm/core/kernels/dcu/aiter_moe_adapter.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/dcu/aiter_quant_adapter.cpp
+++ b/xllm/core/kernels/dcu/aiter_quant_adapter.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/dcu/aiter_quant_adapter.h
+++ b/xllm/core/kernels/dcu/aiter_quant_adapter.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/dcu/build_block_table_from_paged_kv.hip
+++ b/xllm/core/kernels/dcu/build_block_table_from_paged_kv.hip
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/dcu/causal_conv1d_adapter.cpp
+++ b/xllm/core/kernels/dcu/causal_conv1d_adapter.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/xllm/core/kernels/dcu/causal_conv1d_adapter.h
+++ b/xllm/core/kernels/dcu/causal_conv1d_adapter.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/xllm/core/kernels/dcu/flash_mla_adapter.cpp
+++ b/xllm/core/kernels/dcu/flash_mla_adapter.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/dcu/flash_mla_adapter.h
+++ b/xllm/core/kernels/dcu/flash_mla_adapter.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/dcu/gather_mla_latent_cache.hip
+++ b/xllm/core/kernels/dcu/gather_mla_latent_cache.hip
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/dcu/hipblaslt_fp8_adapter.cpp
+++ b/xllm/core/kernels/dcu/hipblaslt_fp8_adapter.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/dcu/hipblaslt_fp8_adapter.h
+++ b/xllm/core/kernels/dcu/hipblaslt_fp8_adapter.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/dcu/random_sample.hip
+++ b/xllm/core/kernels/dcu/random_sample.hip
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/dcu/rejection_sample.hip
+++ b/xllm/core/kernels/dcu/rejection_sample.hip
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/dcu/scaled_quantize.hip
+++ b/xllm/core/kernels/dcu/scaled_quantize.hip
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/dcu/topk_gate.cpp
+++ b/xllm/core/kernels/dcu/topk_gate.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/mlu/causal_conv1d_fn.cpp
+++ b/xllm/core/kernels/mlu/causal_conv1d_fn.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/mlu/causal_conv1d_update_decode.cpp
+++ b/xllm/core/kernels/mlu/causal_conv1d_update_decode.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/mlu/chunk_gated_delta_rule.cpp
+++ b/xllm/core/kernels/mlu/chunk_gated_delta_rule.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/mlu/chunk_gated_delta_rule.h
+++ b/xllm/core/kernels/mlu/chunk_gated_delta_rule.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/mlu/fused_gdn_gating.cpp
+++ b/xllm/core/kernels/mlu/fused_gdn_gating.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/mlu/fused_post_conv_prep.cpp
+++ b/xllm/core/kernels/mlu/fused_post_conv_prep.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/mlu/fused_recurrent_gated_delta_rule.cpp
+++ b/xllm/core/kernels/mlu/fused_recurrent_gated_delta_rule.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/mlu/fused_recurrent_gated_delta_rule_packed_decode.cpp
+++ b/xllm/core/kernels/mlu/fused_recurrent_gated_delta_rule_packed_decode.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/mlu/fused_sigmoid_gating_delta_rule_update.cpp
+++ b/xllm/core/kernels/mlu/fused_sigmoid_gating_delta_rule_update.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/mlu/triton_kernel/__init__.py
+++ b/xllm/core/kernels/mlu/triton_kernel/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/mlu/triton_kernel/causal_conv1d_update_decode.py
+++ b/xllm/core/kernels/mlu/triton_kernel/causal_conv1d_update_decode.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/mlu/triton_kernel/fused_gdn_gating.py
+++ b/xllm/core/kernels/mlu/triton_kernel/fused_gdn_gating.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/mlu/triton_kernel/fused_post_conv_prep.py
+++ b/xllm/core/kernels/mlu/triton_kernel/fused_post_conv_prep.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/mlu/triton_kernel/fused_recurrent_gated_delta_rule_packed_decode.py
+++ b/xllm/core/kernels/mlu/triton_kernel/fused_recurrent_gated_delta_rule_packed_decode.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/mlu/triton_kernel/fused_sigmoid_gating_delta_rule_update.py
+++ b/xllm/core/kernels/mlu/triton_kernel/fused_sigmoid_gating_delta_rule_update.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/musa/activation.cu
+++ b/xllm/core/kernels/musa/activation.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025 The vLLM Authors and The xLLM Authors.
+/* Copyright 2025 The vLLM Authors and The xLLM Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/musa/activation.cu
+++ b/xllm/core/kernels/musa/activation.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025 The vLLM Authors and The xLLM Authors. All Rights Reserved.
+/* Copyright 2025 The vLLM Authors and The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/musa/causal_conv1d.cu
+++ b/xllm/core/kernels/musa/causal_conv1d.cu
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/musa/fused_qknorm_rope.cu
+++ b/xllm/core/kernels/musa/fused_qknorm_rope.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/musa/gdn_decode.cu
+++ b/xllm/core/kernels/musa/gdn_decode.cu
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/musa/gdn_ops.h
+++ b/xllm/core/kernels/musa/gdn_ops.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/musa/gdn_prefill.cpp
+++ b/xllm/core/kernels/musa/gdn_prefill.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/musa/gdn_state_commit.cu
+++ b/xllm/core/kernels/musa/gdn_state_commit.cu
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/musa/gemma_norm.cu
+++ b/xllm/core/kernels/musa/gemma_norm.cu
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/musa/llm_decode_metadata_update.cu
+++ b/xllm/core/kernels/musa/llm_decode_metadata_update.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/musa/moe_combine_indexed.cu
+++ b/xllm/core/kernels/musa/moe_combine_indexed.cu
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/musa/musa_ops_api.h
+++ b/xllm/core/kernels/musa/musa_ops_api.h
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/musa/musa_tvmffi_stream.cpp
+++ b/xllm/core/kernels/musa/musa_tvmffi_stream.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/musa/musa_tvmffi_stream.h
+++ b/xllm/core/kernels/musa/musa_tvmffi_stream.h
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/musa/rejection_sample.cu
+++ b/xllm/core/kernels/musa/rejection_sample.cu
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/musa/rope.cu
+++ b/xllm/core/kernels/musa/rope.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025 The vLLM Authors and The xLLM Authors.
+/* Copyright 2025 The vLLM Authors and The xLLM Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/musa/rope.cu
+++ b/xllm/core/kernels/musa/rope.cu
@@ -1,4 +1,4 @@
-/* Copyright 2025 The vLLM Authors and The xLLM Authors. All Rights Reserved.
+/* Copyright 2025 The vLLM Authors and The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/npu/aclnn/pytorch_npu_helper.hpp
+++ b/xllm/core/kernels/npu/aclnn/pytorch_npu_helper.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/npu/npu_block_sparse_attention.cpp
+++ b/xllm/core/kernels/npu/npu_block_sparse_attention.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/npu/npu_rain_fusion_attention.cpp
+++ b/xllm/core/kernels/npu/npu_rain_fusion_attention.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/npu/tilelang/apply_token_bitmask_wrapper.cpp
+++ b/xllm/core/kernels/npu/tilelang/apply_token_bitmask_wrapper.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/npu/tilelang/causal_conv1d_decode_wrapper.cpp
+++ b/xllm/core/kernels/npu/tilelang/causal_conv1d_decode_wrapper.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/npu/tilelang/causal_conv1d_wrapper.cpp
+++ b/xllm/core/kernels/npu/tilelang/causal_conv1d_wrapper.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/npu/tilelang/fused_sigmoid_gating_delta_rule_wrapper.cpp
+++ b/xllm/core/kernels/npu/tilelang/fused_sigmoid_gating_delta_rule_wrapper.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/npu/tilelang/spec_verify_attention_tiling_update_wrapper.cpp
+++ b/xllm/core/kernels/npu/tilelang/spec_verify_attention_tiling_update_wrapper.cpp
@@ -1,10 +1,10 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://www.apache.org/licenses/LICENSE-2.0
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/xllm/core/kernels/npu/tilelang/spec_verify_token_update_wrapper.cpp
+++ b/xllm/core/kernels/npu/tilelang/spec_verify_token_update_wrapper.cpp
@@ -4,7 +4,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://www.apache.org/licenses/LICENSE-2.0
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/xllm/core/kernels/npu/xllm_ops/gamma_add_rms_norm.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/gamma_add_rms_norm.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/npu/xllm_ops/layer_norm_fwd.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/layer_norm_fwd.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/npu/xllm_ops/mtp_prepare_next_draft.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/mtp_prepare_next_draft.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved. */
+/* Copyright 2026 The xLLM Authors. */
 
 #include <glog/logging.h>
 #include <torch/torch.h>

--- a/xllm/core/kernels/npu/xllm_ops/npu_mega_chunk_gdn.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/npu_mega_chunk_gdn.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/kernels/npu/xllm_ops/reshape_and_cache_a5.cpp
+++ b/xllm/core/kernels/npu/xllm_ops/reshape_and_cache_a5.cpp
@@ -1,10 +1,10 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://www.apache.org/licenses/LICENSE-2.0
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/xllm/core/layers/common/kv_shard_batch_metadata.cpp
+++ b/xllm/core/layers/common/kv_shard_batch_metadata.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/common/kv_shard_batch_metadata.h
+++ b/xllm/core/layers/common/kv_shard_batch_metadata.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/common/quant_utils.h
+++ b/xllm/core/layers/common/quant_utils.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/dcu/deepseek_v2_attention.cpp
+++ b/xllm/core/layers/dcu/deepseek_v2_attention.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/dcu/deepseek_v2_attention.h
+++ b/xllm/core/layers/dcu/deepseek_v2_attention.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/dcu/deepseek_v2_decoder_layer_impl.cpp
+++ b/xllm/core/layers/dcu/deepseek_v2_decoder_layer_impl.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/dcu/deepseek_v2_decoder_layer_impl.h
+++ b/xllm/core/layers/dcu/deepseek_v2_decoder_layer_impl.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/dcu/qwen3_5_decoder_layer.cpp
+++ b/xllm/core/layers/dcu/qwen3_5_decoder_layer.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/dcu/qwen3_5_decoder_layer.h
+++ b/xllm/core/layers/dcu/qwen3_5_decoder_layer.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/dcu/qwen3_5_gated_delta_net.cpp
+++ b/xllm/core/layers/dcu/qwen3_5_gated_delta_net.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/xllm/core/layers/dcu/qwen3_5_gated_delta_net.h
+++ b/xllm/core/layers/dcu/qwen3_5_gated_delta_net.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/dcu/qwen3_gated_delta_net_base.cpp
+++ b/xllm/core/layers/dcu/qwen3_gated_delta_net_base.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/xllm/core/layers/dcu/qwen3_gated_delta_net_base.h
+++ b/xllm/core/layers/dcu/qwen3_gated_delta_net_base.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/dcu/qwen3_gated_delta_net_helpers.h
+++ b/xllm/core/layers/dcu/qwen3_gated_delta_net_helpers.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/xllm/core/layers/dcu/qwen3_gated_delta_net_impls.h
+++ b/xllm/core/layers/dcu/qwen3_gated_delta_net_impls.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/xllm/core/layers/dcu/qwen3_gated_delta_net_kernel_impl.cpp
+++ b/xllm/core/layers/dcu/qwen3_gated_delta_net_kernel_impl.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/xllm/core/layers/dcu/qwen3_gated_delta_net_torch_impl.cpp
+++ b/xllm/core/layers/dcu/qwen3_gated_delta_net_torch_impl.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/xllm/core/layers/mlu/dcp_attention_merge.cpp
+++ b/xllm/core/layers/mlu/dcp_attention_merge.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/mlu/dcp_attention_merge.h
+++ b/xllm/core/layers/mlu/dcp_attention_merge.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/mlu/dcp_decode_context.cpp
+++ b/xllm/core/layers/mlu/dcp_decode_context.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/mlu/dcp_decode_context.h
+++ b/xllm/core/layers/mlu/dcp_decode_context.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/mlu/deepseek_v2_attention_dcp.cpp
+++ b/xllm/core/layers/mlu/deepseek_v2_attention_dcp.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/mlu/deepseek_v4/deepseek_v4_sparse_moe_block.cpp
+++ b/xllm/core/layers/mlu/deepseek_v4/deepseek_v4_sparse_moe_block.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/mlu/deepseek_v4/deepseek_v4_sparse_moe_block.h
+++ b/xllm/core/layers/mlu/deepseek_v4/deepseek_v4_sparse_moe_block.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/mlu/deepseek_v4/dsa_empty_dp_input.cpp
+++ b/xllm/core/layers/mlu/deepseek_v4/dsa_empty_dp_input.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/mlu/deepseek_v4/dsa_empty_dp_input.h
+++ b/xllm/core/layers/mlu/deepseek_v4/dsa_empty_dp_input.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/mlu/dsa_topk_relay.h
+++ b/xllm/core/layers/mlu/dsa_topk_relay.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/mlu/dsa_topk_state.h
+++ b/xllm/core/layers/mlu/dsa_topk_state.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/mlu/qwen3_5/qwen3_5_gated_delta_net.cpp
+++ b/xllm/core/layers/mlu/qwen3_5/qwen3_5_gated_delta_net.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/xllm/core/layers/mlu/qwen3_5/qwen3_5_gated_delta_net.h
+++ b/xllm/core/layers/mlu/qwen3_5/qwen3_5_gated_delta_net.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/mlu/qwen3_5/qwen3_next_rms_norm.cpp
+++ b/xllm/core/layers/mlu/qwen3_5/qwen3_next_rms_norm.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/mlu/qwen3_5/qwen3_next_rms_norm.h
+++ b/xllm/core/layers/mlu/qwen3_5/qwen3_next_rms_norm.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/musa/linear_block_fp8.cpp
+++ b/xllm/core/layers/musa/linear_block_fp8.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/musa/linear_block_fp8.h
+++ b/xllm/core/layers/musa/linear_block_fp8.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/musa/rms_norm_gated.cpp
+++ b/xllm/core/layers/musa/rms_norm_gated.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/musa/rms_norm_gated.h
+++ b/xllm/core/layers/musa/rms_norm_gated.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/npu/loader/mistral3_vision_encoder_loader.cpp
+++ b/xllm/core/layers/npu/loader/mistral3_vision_encoder_loader.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/npu/loader/mistral3_vision_encoder_loader.h
+++ b/xllm/core/layers/npu/loader/mistral3_vision_encoder_loader.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/npu/loader/mistral_decoder_loader.cpp
+++ b/xllm/core/layers/npu/loader/mistral_decoder_loader.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/npu/loader/mistral_decoder_loader.h
+++ b/xllm/core/layers/npu/loader/mistral_decoder_loader.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/npu/npu_mistral3_vision_encoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_mistral3_vision_encoder_layer_impl.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/npu/npu_mistral3_vision_encoder_layer_impl.h
+++ b/xllm/core/layers/npu/npu_mistral3_vision_encoder_layer_impl.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/npu/npu_mistral_decoder_layer_impl.cpp
+++ b/xllm/core/layers/npu/npu_mistral_decoder_layer_impl.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/npu/npu_mistral_decoder_layer_impl.h
+++ b/xllm/core/layers/npu/npu_mistral_decoder_layer_impl.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/npu_torch/deepseek_v4_eplb_load_utils.h
+++ b/xllm/core/layers/npu_torch/deepseek_v4_eplb_load_utils.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/layers/npu_torch/deepseek_v4_eplb_utils.h
+++ b/xllm/core/layers/npu_torch/deepseek_v4_eplb_utils.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/platform/mlu/mlu_batch_memcpy.cpp
+++ b/xllm/core/platform/mlu/mlu_batch_memcpy.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/platform/mlu/mlu_batch_memcpy.h
+++ b/xllm/core/platform/mlu/mlu_batch_memcpy.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/platform/mlu/mlu_host_memory.cpp
+++ b/xllm/core/platform/mlu/mlu_host_memory.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/platform/mlu/mlu_host_memory.h
+++ b/xllm/core/platform/mlu/mlu_host_memory.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/platform/musa/musa_utils.h
+++ b/xllm/core/platform/musa/musa_utils.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/platform/npu/acl_graph_task_update_context.h
+++ b/xllm/core/platform/npu/acl_graph_task_update_context.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/platform/sleepable_allocator.cpp
+++ b/xllm/core/platform/sleepable_allocator.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/platform/sleepable_allocator.h
+++ b/xllm/core/platform/sleepable_allocator.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/runtime/acl_graph_bucket_policy.h
+++ b/xllm/core/runtime/acl_graph_bucket_policy.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/runtime/acl_graph_executor_impl.cpp
+++ b/xllm/core/runtime/acl_graph_executor_impl.cpp
@@ -1,4 +1,4 @@
-﻿/* Copyright 2025-2026 The xLLM Authors.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/runtime/decode_graph_bucket.cpp
+++ b/xllm/core/runtime/decode_graph_bucket.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/runtime/decode_graph_bucket.h
+++ b/xllm/core/runtime/decode_graph_bucket.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/runtime/dflash_worker_impl.cpp
+++ b/xllm/core/runtime/dflash_worker_impl.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/runtime/dflash_worker_impl.h
+++ b/xllm/core/runtime/dflash_worker_impl.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/runtime/dspark_worker_impl.cpp
+++ b/xllm/core/runtime/dspark_worker_impl.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/runtime/dspark_worker_impl.h
+++ b/xllm/core/runtime/dspark_worker_impl.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/runtime/json_object_output_rows.h
+++ b/xllm/core/runtime/json_object_output_rows.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/runtime/musa_graph_executor_impl.cpp
+++ b/xllm/core/runtime/musa_graph_executor_impl.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/runtime/musa_graph_executor_impl.h
+++ b/xllm/core/runtime/musa_graph_executor_impl.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/scheduler/profile/decode_graph_warmup_plan.cpp
+++ b/xllm/core/scheduler/profile/decode_graph_warmup_plan.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/scheduler/profile/decode_graph_warmup_plan.h
+++ b/xllm/core/scheduler/profile/decode_graph_warmup_plan.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/triton_jit/include/arg.h
+++ b/xllm/core/triton_jit/include/arg.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/triton_jit/include/arg_pack.h
+++ b/xllm/core/triton_jit/include/arg_pack.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/triton_jit/include/backend.h
+++ b/xllm/core/triton_jit/include/backend.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/triton_jit/include/backends/mlu_backend.h
+++ b/xllm/core/triton_jit/include/backends/mlu_backend.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/triton_jit/include/dtype.h
+++ b/xllm/core/triton_jit/include/dtype.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/triton_jit/include/jit_kernel.h
+++ b/xllm/core/triton_jit/include/jit_kernel.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/triton_jit/include/spec.h
+++ b/xllm/core/triton_jit/include/spec.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/triton_jit/include/types.h
+++ b/xllm/core/triton_jit/include/types.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/triton_jit/scripts/triton_compile.py
+++ b/xllm/core/triton_jit/scripts/triton_compile.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xllm/core/triton_jit/src/backend.cpp
+++ b/xllm/core/triton_jit/src/backend.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/triton_jit/src/jit_kernel.cpp
+++ b/xllm/core/triton_jit/src/jit_kernel.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/triton_jit/src/mlu_backend.cpp
+++ b/xllm/core/triton_jit/src/mlu_backend.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/triton_jit/src/spec.cpp
+++ b/xllm/core/triton_jit/src/spec.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/util/dit_model_discovery.cpp
+++ b/xllm/core/util/dit_model_discovery.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/core/util/dit_model_discovery.h
+++ b/xllm/core/util/dit_model_discovery.h
@@ -1,4 +1,4 @@
-/* Copyright 2025-2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2025-2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/models/dit/autoencoders/autoencoder_kl_flux2.h
+++ b/xllm/models/dit/autoencoders/autoencoder_kl_flux2.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/models/dit/pipelines/pipeline_flux2.h
+++ b/xllm/models/dit/pipelines/pipeline_flux2.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/models/dit/pipelines/pipeline_flux2_base.h
+++ b/xllm/models/dit/pipelines/pipeline_flux2_base.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/models/dit/processors/flux2_image_processor.h
+++ b/xllm/models/dit/processors/flux2_image_processor.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/models/dit/transformers/transformer_flux2.h
+++ b/xllm/models/dit/transformers/transformer_flux2.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/models/dit/utils/dit_block_weight_manager.cpp
+++ b/xllm/models/dit/utils/dit_block_weight_manager.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/models/dit/utils/dit_block_weight_manager.h
+++ b/xllm/models/dit/utils/dit_block_weight_manager.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/models/dit/utils/dit_parallel_mixin.h
+++ b/xllm/models/dit/utils/dit_parallel_mixin.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/models/dit/utils/sparse_attention.h
+++ b/xllm/models/dit/utils/sparse_attention.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/models/llm/deepseek_v4_dspark.h
+++ b/xllm/models/llm/deepseek_v4_dspark.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/models/llm/dspark_confidence_head.h
+++ b/xllm/models/llm/dspark_confidence_head.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/models/llm/dspark_markov_head.h
+++ b/xllm/models/llm/dspark_markov_head.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/models/llm/dspark_weight_source.h
+++ b/xllm/models/llm/dspark_weight_source.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/models/llm/mlu/deepseek_v4_base.h
+++ b/xllm/models/llm/mlu/deepseek_v4_base.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/models/llm/mlu/deepseek_v4_mtp.h
+++ b/xllm/models/llm/mlu/deepseek_v4_mtp.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -9,7 +9,7 @@ You may obtain a copy of the License at
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the language governing permissions and
+See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 

--- a/xllm/models/llm/mlu/mtp_model_base.h
+++ b/xllm/models/llm/mlu/mtp_model_base.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/models/llm/mlu/mtp_topk_state.h
+++ b/xllm/models/llm/mlu/mtp_topk_state.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/models/llm/mlu/qwen3_5_mtp.h
+++ b/xllm/models/llm/mlu/qwen3_5_mtp.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/models/llm/npu/glm_shared_expert_stream.h
+++ b/xllm/models/llm/npu/glm_shared_expert_stream.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/models/llm/npu/mistral.h
+++ b/xllm/models/llm/npu/mistral.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/models/llm/npu/mtp_topk_state.h
+++ b/xllm/models/llm/npu/mtp_topk_state.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/models/llm/npu/qwen3_dflash.h
+++ b/xllm/models/llm/npu/qwen3_dflash.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/models/llm/npu/qwen3_dspark.h
+++ b/xllm/models/llm/npu/qwen3_dspark.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/models/llm/qwen3_5_mtp_base.h
+++ b/xllm/models/llm/qwen3_5_mtp_base.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/models/vlm/npu/mistral3.h
+++ b/xllm/models/vlm/npu/mistral3.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/processors/mistral3_image_processor.cpp
+++ b/xllm/processors/mistral3_image_processor.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/processors/mistral3_image_processor.h
+++ b/xllm/processors/mistral3_image_processor.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/processors/mistral3_prompt_processor.cpp
+++ b/xllm/processors/mistral3_prompt_processor.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/processors/mistral3_prompt_processor.h
+++ b/xllm/processors/mistral3_prompt_processor.h
@@ -1,4 +1,4 @@
-/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+/* Copyright 2026 The xLLM Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xllm/python/kernels_npu/tilelang/__init__.py
+++ b/xllm/python/kernels_npu/tilelang/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xllm/python/kernels_npu/tilelang/apply_token_bitmask.py
+++ b/xllm/python/kernels_npu/tilelang/apply_token_bitmask.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xllm/python/kernels_npu/tilelang/spec_verify_attention_tiling_update.py
+++ b/xllm/python/kernels_npu/tilelang/spec_verify_attention_tiling_update.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#     https://github.com/xLLM-AI/xllm/blob/main/LICENSE
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/xllm/python/kernels_npu/tilelang/spec_verify_token_update.py
+++ b/xllm/python/kernels_npu/tilelang/spec_verify_token_update.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#     https://github.com/xLLM-AI/xllm/blob/main/LICENSE
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/xllm/python/models/deepseek_v32.py
+++ b/xllm/python/models/deepseek_v32.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xllm/python/models/deepseek_v32_mtp.py
+++ b/xllm/python/models/deepseek_v32_mtp.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xllm/python/models/glm5_2.py
+++ b/xllm/python/models/glm5_2.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The xLLM Authors. All Rights Reserved.
+# Copyright 2026 The xLLM Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## What

Normalize existing Apache-2.0 license headers across the source tree. This
is a metadata-only cleanup: no headers are added or removed, no code
changes, and documentation files are left untouched.

Two commits, kept separate for review:

1. **Fix incorrect header metadata** (27 files)
   - Replace the generic `apache.org/licenses/LICENSE-2.0` URL and the stale
     `jd-opensource` organization URL with the repository `LICENSE` URL,
     matching the convention already used by the vast majority of the tree.
   - Fix an impossible copyright year and strip a stray UTF-8 BOM.
   - Drop the contradictory "All Rights Reserved" phrase from the headers
     touched here.
   - `custom-code-style.md`: drop "All Rights Reserved" from the header
     example so it matches the corrected headers.

2. **Drop "All Rights Reserved" from Apache-2.0 headers** (333 files)
   - Strip the phrase from the first copyright line of every xLLM-authored
     source file that still carries it (C/C++/CUDA/HIP, Python, Protobuf,
     and generated-header templates).

## Why

The Apache-2.0 boilerplate (see the appendix in `LICENSE`, "How to apply the
Apache License to your work") is `Copyright [yyyy] [owner]` followed by the
standard notice — it does not include "All Rights Reserved". The license
grants the rights, so reserving them is contradictory, and the standard
template omits the phrase.

## Scope

- Only the xLLM copyright line is touched. Upstream third-party attributions
  (NVIDIA, vLLM, ScaleLLM, SGLang) keep their own notices verbatim.
- Existing headers only; files without a header are not modified.
- Documentation files (README, CONTRIBUTING, design docs) are not modified.
