### PR TITLE
perf: drop three redundant heap allocations per Sequence.

### DIFF
--- a/xllm/core/framework/request/sequence.cpp
+++ b/xllm/core/framework/request/sequence.cpp
@@ -165,7 +165,7 @@ void Sequence::init_onerec_sequence(
       is_beam_search;
   const bool enable_top_logprobs =
       sequence_params_.sampling_param->top_logprobs > 0 || is_beam_search;
-  logprob_state_ = std::make_unique<LogprobState>(
+  logprob_state_ = LogprobState(
       num_prompt_tokens_, capacity, enable_logprobs, enable_top_logprobs);
 }
 
@@ -188,9 +188,8 @@ void Sequence::generate_onerec_output(const Slice<int32_t>& ids,
     output.finish_reason = finish_reason_.to_string();
   }
   output.token_ids = ids.slice(num_prompt_tokens_, size);
-  if (::xllm::RecConfig::get_instance().enable_output_sku_logprobs() &&
-      logprob_state_ != nullptr) {
-    const auto& token_logprobs = logprob_state_->get_logprobs();
+  if (::xllm::RecConfig::get_instance().enable_output_sku_logprobs()) {
+    const auto& token_logprobs = logprob_state_.get_logprobs();
     output.token_ids_logprobs.reserve(output.token_ids.size());
     for (size_t i = num_prompt_tokens_; i < size; ++i) {
       if (i < token_logprobs.size()) {
@@ -248,9 +247,7 @@ Sequence::Sequence(size_t index,
       latest_generate_time_(absl::Now()),
       sequence_params_(seq_params),
       decoder_(std::move(decoder)),
-      stream_output_token_offset_(decoder_.output_offset()),
-      termination_flag_(std::make_shared<std::atomic<int32_t>>(INT32_MAX)),
-      request_id_(seq_params.request_id) {
+      stream_output_token_offset_(decoder_.output_offset()) {
   if (sequence_params_.request_failure_state == nullptr) {
     sequence_params_.request_failure_state =
         std::make_shared<RequestFailureState>();
@@ -295,7 +292,7 @@ Sequence::Sequence(size_t index,
       sequence_params_.sampling_param->logprobs || is_beam_search;
   const bool enable_top_logprobs =
       sequence_params_.sampling_param->top_logprobs > 0 || is_beam_search;
-  logprob_state_ = std::make_unique<LogprobState>(
+  logprob_state_ = LogprobState(
       num_prompt_tokens_, capacity, enable_logprobs, enable_top_logprobs);
 
   if (sequence_params_.sampling_param->frequency_penalty != 0 ||
@@ -349,7 +346,6 @@ Sequence::Sequence(const Sequence& other, size_t index)
       onerec_state_(other.onerec_state_),
       json_object_state_(other.json_object_state_),
       volatile_num_prompt_tokens_(other.volatile_num_prompt_tokens_),
-      request_id_(other.request_id_),
       finished_(other.finished_),
       finish_status_invalidated_(other.finish_status_invalidated_),
       finish_reason_(other.finish_reason_),
@@ -359,9 +355,10 @@ Sequence::Sequence(const Sequence& other, size_t index)
       cur_generated_token_idx_(other.cur_generated_token_idx_),
       first_token_(other.first_token_),
       is_pre_scheduled_step_prefill_(other.is_pre_scheduled_step_prefill_),
-      updated_since_last_beam_search_(other.updated_since_last_beam_search_),
-      termination_flag_(std::make_shared<std::atomic<int32_t>>(INT32_MAX)) {
-  logprob_state_ = std::make_unique<LogprobState>(*other.logprob_state_);
+      updated_since_last_beam_search_(other.updated_since_last_beam_search_) {
+  logprob_state_ = other.logprob_state_;
+  // termination_flag_ intentionally starts fresh (INT32_MAX) rather than
+  // copying: a forked sequence has its own kvcache-store copy lifecycle.
   // A forked sequence (beam / best_of) shares the prompt KV prefix by
   // ref-counting those blocks, but its linear-state / embedding resource block
   // is private: drop the copied Embedding and Linear blocks so this sequence
@@ -419,7 +416,7 @@ bool Sequence::try_commit_json_object_token(int32_t token_id,
     const JsonObjectGrammar* grammar = json_object_state_->grammar();
     LOG(ERROR)
         << "MTP JSON grammar mismatch: token_offset=" << token_offset
-        << ", request_id=" << request_id_ << ", sequence_index=" << index_
+        << ", request_id=" << request_id() << ", sequence_index=" << index_
         << ", output_row=-1"
         << ", token_id=" << token_id
         << ", committed_tokens=" << snapshot.token_ids.size()
@@ -429,7 +426,7 @@ bool Sequence::try_commit_json_object_token(int32_t token_id,
                 ? 0
                 : grammar->allowed_token_ids(*json_object_state_).size());
   } else {
-    LOG(ERROR) << "JSON grammar commit mismatch: request_id=" << request_id_
+    LOG(ERROR) << "JSON grammar commit mismatch: request_id=" << request_id()
                << ", sequence_index=" << index_
                << ", output_row=-1, token_offset=-1"
                << ", token_id=" << token_id
@@ -458,7 +455,7 @@ bool Sequence::restore_json_object_state(
   JsonObjectGrammarState restored_state = grammar->restore_state(snapshot);
   if (!restored_state.is_valid()) {
     LOG(ERROR) << "JSON grammar replay failed during beam state restoration: "
-               << "request_id=" << request_id_ << ", sequence_index=" << index_
+               << "request_id=" << request_id() << ", sequence_index=" << index_
                << ", committed_tokens=" << snapshot.token_ids.size();
     fail(Status(StatusCode::UNKNOWN,
                 "beam candidate violates json_object grammar"));
@@ -510,7 +507,7 @@ void Sequence::append_token(const Token& token) {
   }
   // update logprobs if needed
   if (sequence_params_.sampling_param->logprobs) {
-    logprob_state_->update_logprob(
+    logprob_state_.update_logprob(
         cur_idx, token, sequence_params_.sampling_param->top_logprobs);
   }
 
@@ -568,7 +565,7 @@ void Sequence::update_last_step_token(const Token& token, size_t token_offset) {
   }
   // update logprobs if needed
   if (sequence_params_.sampling_param->logprobs) {
-    logprob_state_->update_logprob(
+    logprob_state_.update_logprob(
         cur_generated_token_idx_,
         token,
         sequence_params_.sampling_param->top_logprobs);
@@ -595,7 +592,7 @@ void Sequence::update_token(size_t index, const Token& token) {
   }
   // update logprobs if needed
   if (sequence_params_.sampling_param->logprobs) {
-    logprob_state_->update_logprob(
+    logprob_state_.update_logprob(
         index, token, sequence_params_.sampling_param->top_logprobs);
   }
   // logprobs_[index] = token.logprob;
@@ -1076,11 +1073,11 @@ int64_t Sequence::tbt_microseconds(const absl::Time& now) {
 }
 
 float Sequence::get_acc_logprob() {
-  return logprob_state_->get_acc_logprob(num_tokens_);
+  return logprob_state_.get_acc_logprob(num_tokens_);
 }
 
 float Sequence::get_base_logprob() {
-  return logprob_state_->get_base_logprob(num_tokens_);
+  return logprob_state_.get_base_logprob(num_tokens_);
 }
 
 void Sequence::generate_output_tokens_logprobs(
@@ -1092,7 +1089,7 @@ void Sequence::generate_output_tokens_logprobs(
     return;
   }
 
-  logprob_state_->generate_output_tokens_logprobs(
+  logprob_state_.generate_output_tokens_logprobs(
       start_idx,
       end_idx,
       tokenizer,
@@ -1115,7 +1112,7 @@ bool Sequence::update_prefetch_result(uint32_t timeout, uint32_t& success_cnt) {
     return true;
   }
 
-  if (timeout != 0 && termination_flag_->load(std::memory_order_acquire) > 0) {
+  if (timeout != 0 && termination_flag_.load(std::memory_order_acquire) > 0) {
     if (!is_timeout_set_) {
       timer_.reset();
       is_timeout_set_ = true;
@@ -1127,7 +1124,7 @@ bool Sequence::update_prefetch_result(uint32_t timeout, uint32_t& success_cnt) {
     }
   }
 
-  termination_flag_->store(0, std::memory_order_release);
+  termination_flag_.store(0, std::memory_order_release);
   success_cnt = host_kv_state_.blocks(BlockType::KV).size();
   for (auto& cnt : prefetch_results_) {
     success_cnt = std::min(success_cnt, cnt->load());

--- a/xllm/core/framework/request/sequence.h
+++ b/xllm/core/framework/request/sequence.h
@@ -261,9 +261,11 @@ class Sequence final {
     return kv_state_.take_linear_restore_src_block();
   }
   Block copy_block(BlockType type) const { return kv_state_.copy_block(type); }
-  const std::string& request_id() const { return request_id_; }
+  // The request id already lives in sequence_params_; don't keep a second
+  // copy per sequence (a heap allocation each for UUID-length ids).
+  const std::string& request_id() const { return sequence_params_.request_id; }
   std::string sample_sequence_id() const {
-    return request_id_ + "#" + std::to_string(index_);
+    return sequence_params_.request_id + "#" + std::to_string(index_);
   }
 
   bool is_graph_warmup() const { return sequence_params_.is_graph_warmup; }
@@ -417,9 +419,6 @@ class Sequence final {
       const Tokenizer& tokenizer,
       std::optional<std::vector<LogProb>>& out_logprobs);
 
-  std::shared_ptr<std::atomic<int32_t>> get_termination_flag() {
-    return termination_flag_;
-  }
   std::vector<std::shared_ptr<std::atomic<uint32_t>>>* get_prefetch_results() {
     return &prefetch_results_;
   }
@@ -479,7 +478,7 @@ class Sequence final {
   int32_t beam_width_cached() const { return beam_width_cached_; }
   int32_t total_rounds_cached() const { return total_rounds_cached_; }
 
-  LogprobState* logprob_state() { return logprob_state_.get(); }
+  LogprobState* logprob_state() { return &logprob_state_; }
   void set_estimated_latency(double estimated_latency) {
     estimated_latency_ = estimated_latency;
   }
@@ -580,7 +579,10 @@ class Sequence final {
   std::optional<size_t> effective_restore_tokens_;
   size_t host_cache_copy_units_ = 0;
 
-  std::unique_ptr<LogprobState> logprob_state_;
+  // Held by value: it is always present after construction, so a unique_ptr
+  // only added a heap allocation per sequence and an indirection on the
+  // per-token update_logprob() path.
+  LogprobState logprob_state_;
 
   // latest token generate time
   absl::Time latest_generate_time_;
@@ -706,8 +708,10 @@ class Sequence final {
 
   std::atomic<bool> cancelled_{false};
 
-  // kvcache store copy async result
-  std::shared_ptr<std::atomic<int32_t>> termination_flag_;
+  // kvcache store copy async result. Only ever read/written by this sequence
+  // (nothing shares it), so it is a plain atomic rather than a heap-allocated
+  // shared_ptr<atomic>.
+  std::atomic<int32_t> termination_flag_{INT32_MAX};
   std::vector<std::shared_ptr<std::atomic<uint32_t>>> prefetch_results_;
 
   Timer timer_;
@@ -715,8 +719,6 @@ class Sequence final {
 
   // whether the last token is handled
   std::atomic<bool> last_token_handled_{false};
-
-  std::string request_id_;
 
   // Multi-round beam search result caching
   int32_t beam_width_cached_ = 0;

--- a/xllm/core/framework/request/sequence_logprob_state.h
+++ b/xllm/core/framework/request/sequence_logprob_state.h
@@ -39,7 +39,16 @@ class LogprobState {
                size_t capacity,
                bool enable_logprobs,
                bool enable_top_logprobs);
+  // Empty state (no buffers). Lets Sequence hold a LogprobState by value and
+  // assign the real one once capacity/flags are known, avoiding a heap
+  // allocation + pointer indirection per sequence.
+  LogprobState() = default;
   ~LogprobState() = default;
+
+  LogprobState(const LogprobState&) = default;
+  LogprobState& operator=(const LogprobState&) = default;
+  LogprobState(LogprobState&&) = default;
+  LogprobState& operator=(LogprobState&&) = default;
 
   // for generated tokens
   float get_acc_logprob(int64_t num_tokens);
@@ -75,7 +84,7 @@ class LogprobState {
   }
 
  private:
-  int64_t num_prompt_tokens_;
+  int64_t num_prompt_tokens_ = 0;
   std::vector<std::optional<float>> logprobs_;
   // accumulated log probability of the sequence
   float acc_logprob_ = 0.0;


### PR DESCRIPTION
After the logprob buffers went lazy and the token buffer became a single memcpy, the remaining fixed cost of Request construction is almost entirely malloc count (~10 per request). Three of those, one each per Sequence, were pure waste:

- termination_flag_ was a shared_ptr<atomic<int32_t>> whose accessor, get_termination_flag(), has no callers anywhere in the repo. It is only ever loaded/stored by its own Sequence, so it is now a plain inline atomic and the dead accessor is removed. The copy constructor keeps the old semantics of starting a forked sequence at INT32_MAX rather than copying.
- logprob_state_ was a unique_ptr that is always populated after construction. It is now held by value: LogprobState gains a default constructor and explicit defaulted copy/move, and logprob_state() returns &logprob_state_ so callers are unchanged. This also removes a pointer indirection on the per-token update_logprob() path.
- request_id_ duplicated sequence_params_.request_id. For UUID-length ids (beyond std::string SSO) that was a heap allocation per sequence that the benchmark's short "bench-req" id never showed. request_id() and sample_sequence_id() now read the copy already in sequence_params_.

All three scale with the number of sequences, so best_of / beam requests benefit proportionally.

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
