### PR TITLE
bugfix: enforce beam-search logprob requirements in RecRequestFactory.

### DIFF
--- a/tests/core/framework/request/llm_request_factory_test.cpp
+++ b/tests/core/framework/request/llm_request_factory_test.cpp
@@ -264,6 +264,33 @@ TEST_F(LLMRequestFactoryTest,
   EXPECT_EQ(rate_limiter_.get_num_concurrent_requests(), 1);
 }
 
+// verify_params only knows the model-agnostic 2000 cap; the factory knows the
+// vocabulary. A top-k above it would throw inside the sampler and, since the
+// batch uses max(top_logprobs), take every request in the batch down with it.
+TEST_F(LLMRequestFactoryTest, RejectsTopLogprobsAboveVocabulary) {
+  auto factory = make_factory(/*vocab_size=*/1000);
+  CallbackCapture capture;
+  RequestParams sp;
+  sp.max_tokens = 16;
+  sp.beam_width = 4;
+  sp.logprobs = false;
+  // Under the 2000 cap, so it passes verify_params, but above the vocabulary.
+  sp.top_logprobs = 1500;
+
+  auto request = factory->create(/*prompt=*/"hello world",
+                                 /*prompt_tokens=*/std::nullopt,
+                                 sp,
+                                 /*call=*/std::nullopt,
+                                 make_capture_callback(&capture));
+
+  EXPECT_EQ(request, nullptr);
+  ASSERT_TRUE(capture.status.has_value());
+  EXPECT_EQ(capture.status->code(), StatusCode::INVALID_ARGUMENT);
+  EXPECT_NE(capture.status->message().find("top_logprobs (1500)"),
+            std::string::npos);
+  EXPECT_EQ(rate_limiter_.get_num_concurrent_requests(), 0);
+}
+
 TEST_F(LLMRequestFactoryTest, MessageOverloadFailsWhenTemplateRejects) {
   auto factory = make_factory();
   chat_template_->set_succeed(false);

--- a/tests/core/framework/request/rec_request_factory_test.cpp
+++ b/tests/core/framework/request/rec_request_factory_test.cpp
@@ -231,6 +231,178 @@ TEST_F(RecRequestFactoryTest, LlmRecCreatesRequestForValidPromptTokens) {
   EXPECT_EQ(rate_limiter_.get_num_concurrent_requests(), 1);
 }
 
+// Beam search selects beams from the sampler's top-k, so a beam request must
+// end up with logprobs on and top_logprobs > 0 even when the client explicitly
+// disabled them (the RequestParams-level default only applies when they are
+// left unset). Previously REC copied beam_width raw and the beams silently
+// collapsed to identical sequences.
+TEST_F(RecRequestFactoryTest, LlmRecBeamSearchForcesLogprobRequirements) {
+  auto factory = make_llmrec_factory();
+  CallbackCapture capture;
+  RequestParams sp;
+  sp.request_id = "req-beam";
+  sp.max_tokens = 16;
+  sp.beam_width = 4;
+  // Explicitly disabled by the client.
+  sp.logprobs = false;
+  sp.top_logprobs = 0;
+
+  auto request = factory->create(/*prompt=*/"",
+                                 /*prompt_tokens=*/std::vector<int>{1, 2, 3},
+                                 /*input_tensors=*/std::nullopt,
+                                 sp,
+                                 make_capture_callback(&capture));
+
+  ASSERT_NE(request, nullptr);
+  const auto& sampling_param = request->state().sampling_param;
+  EXPECT_EQ(sampling_param.beam_width, 4);
+  EXPECT_TRUE(sampling_param.logprobs);
+  EXPECT_EQ(sampling_param.top_logprobs, 4);
+}
+
+// The search fans out from a single sequence, so fewer than beam_width
+// candidates per step would permanently drop the lower-ranked initial
+// candidates and narrow the search. A smaller explicit value is raised.
+TEST_F(RecRequestFactoryTest, LlmRecBeamSearchRaisesTopLogprobsToBeamWidth) {
+  auto factory = make_llmrec_factory();
+  CallbackCapture capture;
+  RequestParams sp;
+  sp.request_id = "req-beam-top";
+  sp.max_tokens = 16;
+  sp.beam_width = 4;
+  sp.logprobs = false;
+  sp.top_logprobs = 2;
+
+  auto request = factory->create(/*prompt=*/"",
+                                 /*prompt_tokens=*/std::vector<int>{1, 2, 3},
+                                 /*input_tensors=*/std::nullopt,
+                                 sp,
+                                 make_capture_callback(&capture));
+
+  ASSERT_NE(request, nullptr);
+  const auto& sampling_param = request->state().sampling_param;
+  EXPECT_TRUE(sampling_param.logprobs);
+  EXPECT_EQ(sampling_param.top_logprobs, 4);
+}
+
+TEST_F(RecRequestFactoryTest,
+       LlmRecBeamSearchKeepsTopLogprobsAtOrAboveBeamWidth) {
+  auto factory = make_llmrec_factory();
+  CallbackCapture capture;
+  RequestParams sp;
+  sp.request_id = "req-beam-top-wide";
+  sp.max_tokens = 16;
+  sp.beam_width = 4;
+  sp.logprobs = true;
+  // Already wide enough for the beam; the client's value is respected.
+  sp.top_logprobs = 8;
+
+  auto request = factory->create(/*prompt=*/"",
+                                 /*prompt_tokens=*/std::vector<int>{1, 2, 3},
+                                 /*input_tensors=*/std::nullopt,
+                                 sp,
+                                 make_capture_callback(&capture));
+
+  ASSERT_NE(request, nullptr);
+  const auto& sampling_param = request->state().sampling_param;
+  EXPECT_TRUE(sampling_param.logprobs);
+  EXPECT_EQ(sampling_param.top_logprobs, 8);
+}
+
+// verify_params only knows the model-agnostic 2000 cap; the factory knows the
+// vocabulary. A top-k above it would throw inside the sampler and, since the
+// batch uses max(top_logprobs), take every request in the batch down with it.
+TEST_F(RecRequestFactoryTest, LlmRecRejectsTopLogprobsAboveVocabulary) {
+  auto factory = make_llmrec_factory(/*vocab_size=*/1000);
+  CallbackCapture capture;
+  RequestParams sp;
+  sp.max_tokens = 16;
+  sp.beam_width = 4;
+  sp.logprobs = false;
+  // Under the 2000 cap, so it passes verify_params, but above the vocabulary.
+  sp.top_logprobs = 1500;
+
+  auto request = factory->create(/*prompt=*/"",
+                                 /*prompt_tokens=*/std::vector<int>{1, 2, 3},
+                                 /*input_tensors=*/std::nullopt,
+                                 sp,
+                                 make_capture_callback(&capture));
+
+  EXPECT_EQ(request, nullptr);
+  ASSERT_TRUE(capture.status.has_value());
+  EXPECT_EQ(capture.status->code(), StatusCode::INVALID_ARGUMENT);
+  EXPECT_NE(capture.status->message().find("top_logprobs (1500)"),
+            std::string::npos);
+  EXPECT_NE(capture.status->message().find("1000"), std::string::npos);
+  EXPECT_EQ(rate_limiter_.get_num_concurrent_requests(), 0);
+}
+
+// When the oversized top-k was derived from beam_width, the error names the
+// field the client actually set.
+TEST_F(RecRequestFactoryTest, LlmRecRejectsBeamWidthAboveVocabulary) {
+  auto factory = make_llmrec_factory(/*vocab_size=*/100);
+  CallbackCapture capture;
+  RequestParams sp;
+  sp.max_tokens = 16;
+  sp.beam_width = 128;
+  sp.logprobs = false;
+  sp.top_logprobs = 0;
+
+  auto request = factory->create(/*prompt=*/"",
+                                 /*prompt_tokens=*/std::vector<int>{1, 2, 3},
+                                 /*input_tensors=*/std::nullopt,
+                                 sp,
+                                 make_capture_callback(&capture));
+
+  EXPECT_EQ(request, nullptr);
+  ASSERT_TRUE(capture.status.has_value());
+  EXPECT_EQ(capture.status->code(), StatusCode::INVALID_ARGUMENT);
+  EXPECT_NE(capture.status->message().find("beam_width (128)"),
+            std::string::npos);
+  EXPECT_EQ(rate_limiter_.get_num_concurrent_requests(), 0);
+}
+
+TEST_F(RecRequestFactoryTest, LlmRecAcceptsTopLogprobsEqualToVocabulary) {
+  auto factory = make_llmrec_factory(/*vocab_size=*/1000);
+  CallbackCapture capture;
+  RequestParams sp;
+  sp.max_tokens = 16;
+  sp.logprobs = true;
+  sp.top_logprobs = 1000;
+
+  auto request = factory->create(/*prompt=*/"",
+                                 /*prompt_tokens=*/std::vector<int>{1, 2, 3},
+                                 /*input_tensors=*/std::nullopt,
+                                 sp,
+                                 make_capture_callback(&capture));
+
+  ASSERT_NE(request, nullptr);
+  EXPECT_FALSE(capture.called);
+}
+
+TEST_F(RecRequestFactoryTest, LlmRecNoBeamSearchLeavesLogprobsAlone) {
+  auto factory = make_llmrec_factory();
+  CallbackCapture capture;
+  RequestParams sp;
+  sp.request_id = "req-no-beam";
+  sp.max_tokens = 16;
+  sp.beam_width = 1;
+  sp.logprobs = false;
+  sp.top_logprobs = 0;
+
+  auto request = factory->create(/*prompt=*/"",
+                                 /*prompt_tokens=*/std::vector<int>{1, 2, 3},
+                                 /*input_tensors=*/std::nullopt,
+                                 sp,
+                                 make_capture_callback(&capture));
+
+  ASSERT_NE(request, nullptr);
+  const auto& sampling_param = request->state().sampling_param;
+  EXPECT_EQ(sampling_param.beam_width, 1);
+  EXPECT_FALSE(sampling_param.logprobs);
+  EXPECT_EQ(sampling_param.top_logprobs, 0);
+}
+
 TEST_F(RecRequestFactoryTest, LlmRecCreatesRequestForValidPromptString) {
   auto factory = make_llmrec_factory();
   CallbackCapture capture;

--- a/tests/core/framework/request/request_params_test.cpp
+++ b/tests/core/framework/request/request_params_test.cpp
@@ -200,6 +200,104 @@ TEST(RequestParamsTest, ChatBeamSearchKeepsExplicitZeroTopLogprobs) {
   EXPECT_EQ(params.top_logprobs, 0);
 }
 
+namespace {
+
+// Runs verify_params and returns the rejection status, if any.
+std::optional<Status> verify(const RequestParams& params) {
+  std::optional<Status> received_status;
+  const bool valid =
+      params.verify_params([&received_status](RequestOutput output) {
+        received_status = output.status;
+        return false;
+      });
+  EXPECT_EQ(valid, !received_status.has_value());
+  return received_status;
+}
+
+}  // namespace
+
+// Beam search forces logprobs on downstream, so top_logprobs must be validated
+// even when the client explicitly disabled logprobs; otherwise an invalid count
+// would only surface inside the sampler at execution time.
+TEST(RequestParamsTest,
+     VerifyRejectsNegativeTopLogprobsForBeamWithLogprobsOff) {
+  proto::ChatRequest request;
+  request.set_beam_width(4);
+  request.set_logprobs(false);
+  request.set_top_logprobs(-1);
+  RequestParams params(request, "", "");
+
+  const auto status = verify(params);
+
+  ASSERT_TRUE(status.has_value());
+  EXPECT_EQ(status->code(), StatusCode::INVALID_ARGUMENT);
+  EXPECT_NE(status->message().find("2000"), std::string::npos);
+}
+
+TEST(RequestParamsTest,
+     VerifyRejectsOversizedTopLogprobsForBeamWithLogprobsOff) {
+  proto::ChatRequest request;
+  request.set_beam_width(4);
+  request.set_logprobs(false);
+  request.set_top_logprobs(5000);
+  RequestParams params(request, "", "");
+
+  const auto status = verify(params);
+
+  ASSERT_TRUE(status.has_value());
+  EXPECT_EQ(status->code(), StatusCode::INVALID_ARGUMENT);
+}
+
+// When top_logprobs is unset, beam search derives it from beam_width, so an
+// oversized beam_width is rejected on the value that would actually be used.
+TEST(RequestParamsTest, VerifyRejectsBeamWidthThatDerivesOversizedTopLogprobs) {
+  proto::ChatRequest request;
+  request.set_beam_width(3000);
+  request.set_logprobs(false);
+  request.set_top_logprobs(0);
+  RequestParams params(request, "", "");
+
+  const auto status = verify(params);
+
+  ASSERT_TRUE(status.has_value());
+  EXPECT_EQ(status->code(), StatusCode::INVALID_ARGUMENT);
+}
+
+// A positive top_logprobs below beam_width is valid input: the factory raises
+// it to the width (RequestSamplingParam::enable_beam_search), it is not an
+// error.
+TEST(RequestParamsTest, VerifyAcceptsTopLogprobsBelowBeamWidth) {
+  proto::ChatRequest request;
+  request.set_beam_width(4);
+  request.set_logprobs(false);
+  request.set_top_logprobs(2);
+  RequestParams params(request, "", "");
+
+  EXPECT_FALSE(verify(params).has_value());
+}
+
+TEST(RequestParamsTest, VerifyAcceptsBeamWithLogprobsOffAndInRangeDerivedTopK) {
+  proto::ChatRequest request;
+  request.set_beam_width(4);
+  request.set_logprobs(false);
+  request.set_top_logprobs(0);
+  RequestParams params(request, "", "");
+
+  EXPECT_FALSE(verify(params).has_value());
+}
+
+// Non-beam requests with logprobs off never consume top_logprobs, so the value
+// is not validated (unchanged behavior).
+TEST(RequestParamsTest, VerifyIgnoresTopLogprobsWhenLogprobsOffAndNoBeam) {
+  proto::ChatRequest request;
+  request.set_beam_width(1);
+  request.set_logprobs(false);
+  request.set_top_logprobs(5000);
+  RequestParams params(request, "", "");
+
+  EXPECT_FALSE(verify(params).has_value());
+}
+
 TEST(RequestParamsTest, AnthropicPreservesIgnoreEos) {
   proto::AnthropicMessagesRequest request;
   request.set_model("claude-3");

--- a/xllm/core/framework/request/llm_request_factory.cpp
+++ b/xllm/core/framework/request/llm_request_factory.cpp
@@ -172,16 +172,9 @@ RequestSamplingParam LLMRequestFactory::build_sampling_param(
   sampling_param.json_object =
       ServiceConfig::get_instance().enable_json_object_output() &&
       sp.response_format == ResponseFormatType::JSON_OBJECT;
-  sampling_param.beam_width = sp.beam_width;
-  if (sampling_param.beam_width > 1) {
-    // beam search requires logprobs, and needs at least one top_logprob
-    // candidate for beam expansion.
-    sampling_param.logprobs = true;
-    if (sampling_param.top_logprobs == 0) {
-      sampling_param.top_logprobs =
-          static_cast<int64_t>(sampling_param.beam_width);
-    }
-  }
+  // Enforces the beam-search logprob requirements; see
+  // RequestSamplingParam::enable_beam_search.
+  sampling_param.enable_beam_search(sp.beam_width);
   // sampling_param.do_sample = sp.do_sample;
   return sampling_param;
 }
@@ -327,6 +320,13 @@ std::shared_ptr<Request> LLMRequestFactory::create(
 
   const size_t best_of = sp.best_of.value_or(sp.n);
   RequestSamplingParam sampling_param = build_sampling_param(sp, best_of);
+  // Model-aware complement to verify_params' 2000 cap: an oversized top-k
+  // would throw inside the sampler and take the whole batch down with it.
+  if (const auto error =
+          sampling_param.top_logprobs_vocab_error(model_args_->vocab_size())) {
+    CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT, *error);
+    return nullptr;
+  }
   const bool json_object = sampling_param.json_object;
   SchedulerParam scheduler_param = sp.to_scheduler_param();
 

--- a/xllm/core/framework/request/rec_request_factory.cpp
+++ b/xllm/core/framework/request/rec_request_factory.cpp
@@ -593,8 +593,21 @@ std::shared_ptr<Request> RecRequestFactory::build_request_common(
   const size_t best_of = sp.best_of.value_or(sp.n);
 
   RequestSamplingParam sampling_param = sp.to_sampling_param(best_of);
-  sampling_param.beam_width = sp.beam_width;
+  // REC drives the same BeamSearcher kernel as LLM, which selects beams from
+  // the sampler's top-k, so it needs the same logprob requirements. Previously
+  // beam_width was copied raw: a client that explicitly sent logprobs=false or
+  // top_logprobs=0 with beam_width > 1 got no candidates and the beams silently
+  // collapsed to identical sequences. (The RequestParams-level default only
+  // kicks in when the client leaves those fields unset.)
+  sampling_param.enable_beam_search(sp.beam_width);
   sampling_param.num_return_sequences = sp.num_return_sequences;
+  // Model-aware complement to verify_params' 2000 cap: an oversized top-k
+  // would throw inside the sampler and take the whole batch down with it.
+  if (const auto error =
+          sampling_param.top_logprobs_vocab_error(model_args_->vocab_size())) {
+    CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT, *error);
+    return nullptr;
+  }
 
   bool stream = sp.streaming;
   if (best_of != sp.n) {

--- a/xllm/core/framework/request/request_params.cpp
+++ b/xllm/core/framework/request/request_params.cpp
@@ -663,17 +663,40 @@ bool RequestParams::verify_params(OutputCallback callback) const {
     }
   }
 
-  if (logprobs) {
-    if (echo) {
+  if (logprobs && echo) {
+    CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
+                        "logprobs is not supported with echo",
+                        service_request_id,
+                        source_xservice_addr);
+    return false;
+  }
+
+  // top_logprobs becomes the k of torch::topk() whenever logprobs are in
+  // effect. Beam search forces logprobs on downstream
+  // (RequestSamplingParam::enable_beam_search), so a beam request with
+  // logprobs=false must be validated too; otherwise an oversized count would
+  // only surface as a throw inside the sampler at execution time. The raw field
+  // is checked first so that a negative count is reported as a client error
+  // rather than silently repaired by the beam normalization.
+  if (logprobs || beam_width > 1) {
+    if (top_logprobs < 0 || top_logprobs > 2000) {
       CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                          "logprobs is not supported with echo",
+                          "logprobs must be between 0 and 2000",
                           service_request_id,
                           source_xservice_addr);
       return false;
     }
-    if (top_logprobs < 0 || top_logprobs > 2000) {
+    // Beam search raises top_logprobs to at least beam_width, so also validate
+    // the value that will actually be used. Derive it through the same helper
+    // so the rule is not duplicated here.
+    RequestSamplingParam effective;
+    effective.logprobs = logprobs;
+    effective.top_logprobs = top_logprobs;
+    effective.enable_beam_search(beam_width);
+    if (effective.top_logprobs > 2000) {
       CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT,
-                          "logprobs must be between 0 and 2000",
+                          "beam_width must be at most 2000 (it sets the "
+                          "top_logprobs used for beam expansion)",
                           service_request_id,
                           source_xservice_addr);
       return false;

--- a/xllm/core/framework/request/sequence.cpp
+++ b/xllm/core/framework/request/sequence.cpp
@@ -155,9 +155,9 @@ void Sequence::init_onerec_sequence(
   cur_generated_token_idx_ = num_prompt_tokens_;
   // OneRec can also emit per-token logprobs via enable_output_sku_logprobs
   // (see generate_onerec_streaming_output), independent of the sampling flag,
-  // so allocate the logprob buffer when either path needs it. Beam search reads
-  // both buffers unconditionally (see the main constructor), so force them on
-  // for beam requests too.
+  // so allocate the logprob buffer when either path needs it. The beam readers
+  // index both buffers by token position (see the main constructor), so keep
+  // them allocated for beam requests too.
   const bool is_beam_search = sequence_params_.sampling_param->beam_width > 1;
   const bool enable_logprobs =
       sequence_params_.sampling_param->logprobs ||
@@ -280,13 +280,14 @@ Sequence::Sequence(size_t index,
   num_tokens_ = num_prompt_tokens_;
 
   // init logprob state. Only allocate the per-position buffers when they will
-  // actually be read. Beam search (SequencesGroup::process_beam_search) indexes
-  // both the logprob and top-k buffers on every expansion regardless of the
-  // request's logprobs flags, so beam requests must allocate them even when
-  // logprobs are disabled -- otherwise the reader would be out of bounds. The
-  // LLM factory normalizes these flags for beam, but the REC factory copies
-  // beam_width without doing so, so gate on beam_width here to stay safe for
-  // both. best_of>n forces logprobs on upstream, so it is already covered.
+  // actually be read. The beam readers (SequencesGroup::process_beam_search and
+  // Batch::process_beam_search_output) index both the logprob and top-k buffers
+  // by token position, so a beam request must have them allocated. The request
+  // factories already force logprobs/top_logprobs on for beam
+  // (RequestSamplingParam::enable_beam_search); tying the allocation to
+  // beam_width itself as well keeps the readers' requirement enforced where the
+  // buffers are created, independent of any upstream normalization. best_of>n
+  // forces logprobs on upstream, so it is already covered.
   const bool is_beam_search = sequence_params_.sampling_param->beam_width > 1;
   const bool enable_logprobs =
       sequence_params_.sampling_param->logprobs || is_beam_search;

--- a/xllm/core/framework/request/vlm_request_factory.cpp
+++ b/xllm/core/framework/request/vlm_request_factory.cpp
@@ -119,6 +119,13 @@ std::shared_ptr<Request> VLMRequestFactory::build_request(
   const size_t best_of = sp.best_of.value_or(sp.n);
 
   RequestSamplingParam sampling_param = sp.to_sampling_param(best_of);
+  // Model-aware complement to verify_params' 2000 cap: an oversized top-k
+  // would throw inside the sampler and take the whole batch down with it.
+  if (const auto error =
+          sampling_param.top_logprobs_vocab_error(model_args_->vocab_size())) {
+    CALLBACK_WITH_ERROR(StatusCode::INVALID_ARGUMENT, *error);
+    return nullptr;
+  }
 
   std::optional<StoppingChecker> stopping_checker =
       build_stopping_checker(sp, max_tokens, max_context_len, callback);

--- a/xllm/core/framework/sampling/sampler.cpp
+++ b/xllm/core/framework/sampling/sampler.cpp
@@ -19,6 +19,8 @@ limitations under the License.
 #include <glog/logging.h>
 #include <torch/torch.h>
 
+#include <algorithm>
+
 #include "common/global_flags.h"
 #include "core/framework/config/model_config.h"
 #include "core/framework/sampling/json_object_grammar.h"
@@ -164,8 +166,16 @@ SampleOutput Sampler::forward(torch::Tensor& logits,
     output.logprobs = selected_logprobs.view({-1});
 
     if (params.max_top_logprobs > 0) {
-      auto [values, indices] =
-          logprobs.topk(params.max_top_logprobs, /*dim=*/-1);
+      // max_top_logprobs is the batch-wide max, so one request asking for more
+      // than the vocabulary would make topk throw and fail every request in the
+      // batch. The factories reject such requests up front
+      // (RequestSamplingParam::top_logprobs_vocab_error); clamp here as the
+      // last line of defense so the sampler can never be the failure point.
+      // Every consumer sizes by the returned row width, so a shorter row is
+      // safe.
+      const int64_t k =
+          std::min<int64_t>(params.max_top_logprobs, logprobs.size(-1));
+      auto [values, indices] = logprobs.topk(k, /*dim=*/-1);
       output.top_logprobs = values;
       output.top_tokens = indices;
     }

--- a/xllm/core/framework/sampling/sampling_params.h
+++ b/xllm/core/framework/sampling/sampling_params.h
@@ -17,7 +17,10 @@ limitations under the License.
 #pragma once
 #include <torch/torch.h>
 
+#include <algorithm>
 #include <cstdint>
+#include <optional>
+#include <string>
 #include <vector>
 
 namespace xllm {
@@ -36,6 +39,55 @@ struct RequestSamplingParam {
   bool json_object = false;
   int32_t beam_width = 0;
   int32_t num_return_sequences = 0;
+
+  // Turns on beam search with the given width and enforces what the beam
+  // machinery needs. Both the on-device BeamSearcher kernel and the host-side
+  // SequencesGroup::process_beam_search() pick the next beams from the
+  // sampler's top-k candidates, and the sampler produces exactly top_logprobs
+  // of them per sequence (the batch takes max(top_logprobs) as its top-k). So
+  // logprobs must be on, and top_logprobs must be at least beam_width: the
+  // search starts from a single sequence, so with fewer candidates the first
+  // step can only fan out to top_logprobs beams and the lower-ranked initial
+  // candidates are discarded for good, yielding a narrower search than asked
+  // for. A smaller explicit value is therefore raised to the width (the client
+  // still receives at least the logprob count it requested); an unset one is
+  // derived from it, matching the RequestParams-level default. Every factory
+  // that enables beam search goes through here so the invariant lives in one
+  // place. Out-of-range counts are rejected up front by
+  // RequestParams::verify_params. A width <= 1 just records the value (no beam
+  // search).
+  void enable_beam_search(int32_t width) {
+    beam_width = width;
+    if (beam_width > 1) {
+      logprobs = true;
+      top_logprobs =
+          std::max<int64_t>(top_logprobs, static_cast<int64_t>(beam_width));
+    }
+  }
+
+  // Whenever logprobs are on, the sampler runs topk(top_logprobs) over the
+  // vocabulary, and torch::topk throws for k > vocab. The batch uses
+  // max(top_logprobs) across its requests, so a single oversized request would
+  // take down every request in the batch. RequestParams::verify_params only
+  // knows the model-agnostic 2000 cap; this is the model-aware check for the
+  // factories, which know the vocabulary. Returns an error message when the
+  // effective top-k exceeds it, std::nullopt when it fits or the vocabulary is
+  // unknown (vocab_size <= 0). Call after enable_beam_search so the beam-raised
+  // value is what gets checked.
+  std::optional<std::string> top_logprobs_vocab_error(
+      int64_t vocab_size) const {
+    if (!logprobs || vocab_size <= 0 || top_logprobs <= vocab_size) {
+      return std::nullopt;
+    }
+    std::string error = "top_logprobs (" + std::to_string(top_logprobs) + ")";
+    if (beam_width > 1 && top_logprobs == static_cast<int64_t>(beam_width)) {
+      // The value came from beam_width (unset or smaller top_logprobs was
+      // raised to the width), so point the client at the field it actually set.
+      error = "beam_width (" + std::to_string(beam_width) + ")";
+    }
+    return error + " must not exceed the model vocabulary size (" +
+           std::to_string(vocab_size) + ")";
+  }
 };
 
 struct SamplingParameters {


### PR DESCRIPTION
Both the LLM and REC workers select beams with the same BeamSearcher kernel, which takes its candidates from the sampler's top-k. The sampler only produces those when a request has logprobs on and top_logprobs > 0 (the batch uses max(top_logprobs) as its top-k). LLMRequestFactory re-forced these for beam requests; RecRequestFactory copied beam_width raw, so a client that explicitly sent logprobs=false or top_logprobs=0 with beam_width > 1 got no candidates and the beams silently collapsed to identical sequences. The RequestParams-level default only applies when the client leaves those fields unset, so it did not cover this.

Move the invariant into RequestSamplingParam::enable_beam_search() and route both factories through it, so the rule lives in one place instead of being duplicated per model. LLM behavior is unchanged; REC now matches it. Keep the beam_width-gated LogprobState allocation in Sequence as defense in depth (the beam readers index those buffers by position) and reword its comments, which no longer need to blame REC for skipping normalization.

Add RecRequestFactory tests covering the forced flags, an explicit non-zero top_logprobs being preserved, and beam_width <= 1 leaving the flags alone.

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
