### PR TITLE
refactor: split REC sequences out of Sequence into a class hierarchy.

### DIFF
--- a/tests/core/framework/request/CMakeLists.txt
+++ b/tests/core/framework/request/CMakeLists.txt
@@ -65,6 +65,18 @@ cc_test(
 
 cc_test(
   NAME
+    rec_sequence_test
+  SRCS
+    rec_sequence_test.cpp
+  DEPS
+    :config
+    :request
+    GTest::gtest
+    GTest::gtest_main
+)
+
+cc_test(
+  NAME
     request_params_test
   SRCS
     request_params_test.cpp

--- a/tests/core/framework/request/rec_sequence_test.cpp
+++ b/tests/core/framework/request/rec_sequence_test.cpp
@@ -1,0 +1,451 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "core/framework/request/rec_sequence.h"
+
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "core/framework/config/rec_config.h"
+#include "core/framework/multimodal/mm_data.h"
+#include "core/framework/multimodal/mm_type.h"
+#include "core/framework/request/incremental_decoder.h"
+#include "core/framework/request/onerec_sequence.h"
+#include "core/framework/request/rec_type.h"
+#include "core/framework/request/sequence.h"
+#include "core/framework/request/sequence_factory.h"
+#include "core/framework/tokenizer/tokenizer.h"
+
+namespace xllm {
+namespace {
+
+constexpr int32_t kBosTokenId = 7;
+
+// Restores the process-wide RecConfig flags this test touches.
+class ScopedRecConfig {
+ public:
+  ScopedRecConfig()
+      : sku_logprobs_(RecConfig::get_instance().enable_output_sku_logprobs()),
+        convert_items_(
+            RecConfig::get_instance().enable_convert_tokens_to_item()),
+        extended_info_(RecConfig::get_instance().enable_extended_item_info()),
+        threshold_(RecConfig::get_instance().each_conversion_threshold()) {}
+
+  ~ScopedRecConfig() {
+    RecConfig::get_instance()
+        .enable_output_sku_logprobs(sku_logprobs_)
+        .enable_convert_tokens_to_item(convert_items_)
+        .enable_extended_item_info(extended_info_)
+        .each_conversion_threshold(threshold_);
+  }
+
+ private:
+  bool sku_logprobs_;
+  bool convert_items_;
+  bool extended_info_;
+  int32_t threshold_;
+};
+
+// Decodes any REC token triple to two fixed item ids.
+class FakeItemTokenizer final : public Tokenizer {
+ public:
+  using Tokenizer::decode;
+
+  bool decode(const Slice<int32_t>& /*token_ids*/,
+              bool /*skip_special_tokens*/,
+              std::vector<int64_t>* item_ids) const override {
+    *item_ids = {1001, 1002, 1001};
+    return true;
+  }
+};
+
+class SequenceFixture {
+ public:
+  SequenceFixture() {
+    params_.seq_capacity = 16;
+    params_.echo = false;
+    params_.skip_special_tokens = true;
+    params_.streaming = false;
+    params_.enable_schedule_overlap = false;
+    params_.bos_token_id = kBosTokenId;
+    params_.request_id = "rec_sequence_test";
+    params_.sampling_param = &sampling_param_;
+    params_.stopping_checker = &stopping_checker_;
+  }
+
+  SequenceParams& params() { return params_; }
+  RequestSamplingParam& sampling_param() { return sampling_param_; }
+
+  std::unique_ptr<Sequence> create(RecType rec_type,
+                                   const std::vector<int32_t>& prompt,
+                                   const MMData& mm_data = MMData()) {
+    params_.rec_type = rec_type;
+    IncrementalDecoder decoder(/*prompt=*/"prompt",
+                               prompt.size(),
+                               params_.echo,
+                               params_.skip_special_tokens);
+    return create_sequence(/*index=*/0,
+                           prompt,
+                           /*input_embedding=*/torch::Tensor(),
+                           mm_data,
+                           decoder,
+                           params_);
+  }
+
+ private:
+  RequestSamplingParam sampling_param_;
+  StoppingChecker stopping_checker_;
+  SequenceParams params_;
+};
+
+MMData embedding_mm_data(const std::string& key, int64_t rows) {
+  MMData mm_data;
+  mm_data.add(MMType::EMBEDDING, key, torch::zeros({rows, 4}));
+  return mm_data;
+}
+
+void append_generated(Sequence& sequence,
+                      const std::vector<int32_t>& ids,
+                      float logprob = -0.5f) {
+  for (const int32_t id : ids) {
+    Token token(id);
+    token.logprob = logprob;
+    sequence.append_token(token);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory selection
+// ---------------------------------------------------------------------------
+
+TEST(SequenceFactoryTest, LlmRequestGetsPlainSequence) {
+  SequenceFixture fixture;
+  auto sequence = fixture.create(RecType::kNone, {1, 2, 3});
+  EXPECT_EQ(dynamic_cast<RecSequence*>(sequence.get()), nullptr);
+  EXPECT_EQ(sequence->num_prompt_tokens(), 3u);
+}
+
+TEST(SequenceFactoryTest, LlmRecRequestGetsLlmRecSequence) {
+  SequenceFixture fixture;
+  auto sequence = fixture.create(RecType::kLlmRec, {1, 2, 3});
+  EXPECT_NE(dynamic_cast<LlmRecSequence*>(sequence.get()), nullptr);
+  EXPECT_EQ(dynamic_cast<OneRecSequence*>(sequence.get()), nullptr);
+  // LlmRec drives the decoder like an LLM: the prompt seeds the token buffer.
+  EXPECT_EQ(sequence->num_prompt_tokens(), 3u);
+  EXPECT_EQ(sequence->tokens()[0], 1);
+}
+
+TEST(SequenceFactoryTest, OneRecRequestGetsOneRecSequence) {
+  SequenceFixture fixture;
+  auto sequence = fixture.create(RecType::kOneRec, {1, 2, 3});
+  EXPECT_NE(dynamic_cast<OneRecSequence*>(sequence.get()), nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// Typed access
+// ---------------------------------------------------------------------------
+
+TEST(RecSequenceTest, FromAcceptsRecSequences) {
+  SequenceFixture fixture;
+  auto llm_rec = fixture.create(RecType::kLlmRec, {1, 2, 3});
+  auto onerec = fixture.create(RecType::kOneRec, {1, 2, 3});
+  EXPECT_EQ(&RecSequence::from(*llm_rec), llm_rec.get());
+  EXPECT_EQ(&RecSequence::from(*onerec), onerec.get());
+  EXPECT_EQ(&OneRecSequence::from(*onerec), onerec.get());
+}
+
+TEST(RecSequenceDeathTest, FromRejectsPlainSequence) {
+  SequenceFixture fixture;
+  auto sequence = fixture.create(RecType::kNone, {1, 2, 3});
+  EXPECT_DEATH(RecSequence::from(*sequence), "not a REC sequence");
+}
+
+TEST(RecSequenceDeathTest, OneRecFromRejectsLlmRecSequence) {
+  SequenceFixture fixture;
+  auto sequence = fixture.create(RecType::kLlmRec, {1, 2, 3});
+  EXPECT_DEATH(OneRecSequence::from(*sequence), "not a OneRec sequence");
+}
+
+// ---------------------------------------------------------------------------
+// Beam result
+// ---------------------------------------------------------------------------
+
+TEST(RecBeamSearchResultTest, DefaultIsNotReady) {
+  const RecBeamSearchResult result;
+  EXPECT_FALSE(result.ready());
+  EXPECT_EQ(result.beam_width(), 0);
+  EXPECT_EQ(result.total_rounds(), 0);
+  EXPECT_TRUE(result.beams().empty());
+  EXPECT_TRUE(result.last_logprobs().empty());
+}
+
+TEST(RecBeamSearchResultTest, ReadyRequiresWidthRoundsAndBeams) {
+  EXPECT_FALSE(RecBeamSearchResult(/*beam_width=*/2,
+                                   /*total_rounds=*/3,
+                                   /*beams=*/{},
+                                   /*last_logprobs=*/{})
+                   .ready());
+  EXPECT_FALSE(RecBeamSearchResult(/*beam_width=*/0,
+                                   /*total_rounds=*/3,
+                                   /*beams=*/{{1, 2, 3}},
+                                   /*last_logprobs=*/{})
+                   .ready());
+  EXPECT_FALSE(RecBeamSearchResult(/*beam_width=*/1,
+                                   /*total_rounds=*/0,
+                                   /*beams=*/{{1, 2, 3}},
+                                   /*last_logprobs=*/{})
+                   .ready());
+
+  const RecBeamSearchResult result(/*beam_width=*/2,
+                                   /*total_rounds=*/1,
+                                   /*beams=*/{{1, 2, 3}, {4, 5, 6}},
+                                   /*last_logprobs=*/{-0.1f, -0.2f});
+  EXPECT_TRUE(result.ready());
+  EXPECT_EQ(result.beam_width(), 2);
+  EXPECT_EQ(result.total_rounds(), 1);
+  EXPECT_EQ(result.beams().size(), 2u);
+  EXPECT_EQ(result.last_logprobs(), (std::vector<float>{-0.1f, -0.2f}));
+}
+
+TEST(RecSequenceTest, ForkStartsWithEmptyBeamResult) {
+  SequenceFixture fixture;
+  auto sequence = fixture.create(RecType::kLlmRec, {1, 2, 3});
+  RecSequence& rec_sequence = RecSequence::from(*sequence);
+  rec_sequence.set_beam_search_result(
+      RecBeamSearchResult(/*beam_width=*/2,
+                          /*total_rounds=*/1,
+                          /*beams=*/{{1, 2, 3}, {4, 5, 6}},
+                          /*last_logprobs=*/{-0.1f, -0.2f}));
+  ASSERT_TRUE(rec_sequence.beam_search_result().ready());
+
+  std::unique_ptr<Sequence> fork = sequence->fork(/*index=*/1);
+  EXPECT_NE(dynamic_cast<LlmRecSequence*>(fork.get()), nullptr);
+  EXPECT_EQ(fork->index(), 1u);
+  EXPECT_FALSE(RecSequence::from(*fork).beam_search_result().ready());
+  // The source keeps its result.
+  EXPECT_TRUE(rec_sequence.beam_search_result().ready());
+}
+
+TEST(SequenceTest, PlainForkStaysPlain) {
+  SequenceFixture fixture;
+  auto sequence = fixture.create(RecType::kNone, {1, 2, 3});
+  std::unique_ptr<Sequence> fork = sequence->fork(/*index=*/2);
+  EXPECT_EQ(dynamic_cast<RecSequence*>(fork.get()), nullptr);
+  EXPECT_EQ(fork->index(), 2u);
+  EXPECT_EQ(fork->num_prompt_tokens(), 3u);
+}
+
+// ---------------------------------------------------------------------------
+// OneRec layout
+// ---------------------------------------------------------------------------
+
+TEST(OneRecSequenceTest, PromptTokensFeedEncoderAndBosSeedsDecoder) {
+  SequenceFixture fixture;
+  auto sequence = fixture.create(RecType::kOneRec, {11, 12, 13, 14});
+  const OneRecSequence& onerec = OneRecSequence::from(*sequence);
+
+  EXPECT_EQ(onerec.encoder_tokens(), (std::vector<int32_t>{11, 12, 13, 14}));
+  EXPECT_EQ(onerec.encoder_seq_len(), 4u);
+  EXPECT_EQ(onerec.num_decoder_embeddings(), 0u);
+
+  // The decoder holds a single BOS token, not the prompt.
+  EXPECT_EQ(sequence->num_prompt_tokens(), 1u);
+  EXPECT_EQ(sequence->num_tokens(), 1u);
+  EXPECT_EQ(sequence->tokens()[0], kBosTokenId);
+  EXPECT_EQ(sequence->tokens().size(), 1u);
+}
+
+TEST(OneRecSequenceTest, SparseEmbeddingFeedsEncoder) {
+  SequenceFixture fixture;
+  auto sequence = fixture.create(
+      RecType::kOneRec,
+      /*prompt=*/{},
+      embedding_mm_data(OneRecSequence::kEncoderSparseEmbeddingName, 6));
+  const OneRecSequence& onerec = OneRecSequence::from(*sequence);
+
+  EXPECT_TRUE(onerec.encoder_tokens().empty());
+  EXPECT_EQ(onerec.encoder_seq_len(), 6u);
+  EXPECT_EQ(sequence->num_prompt_tokens(), 1u);
+  EXPECT_EQ(sequence->tokens()[0], kBosTokenId);
+}
+
+TEST(OneRecSequenceTest, DecoderContextEmbeddingReplacesBos) {
+  SequenceFixture fixture;
+  MMData mm_data =
+      embedding_mm_data(OneRecSequence::kEncoderSparseEmbeddingName, 6);
+  mm_data.add(MMType::EMBEDDING,
+              OneRecSequence::kDecoderContextEmbeddingName,
+              torch::zeros({5, 4}));
+  auto sequence = fixture.create(RecType::kOneRec, /*prompt=*/{}, mm_data);
+  const OneRecSequence& onerec = OneRecSequence::from(*sequence);
+
+  EXPECT_EQ(onerec.num_decoder_embeddings(), 5u);
+  EXPECT_EQ(sequence->num_prompt_tokens(), 0u);
+  EXPECT_EQ(sequence->num_tokens(), 0u);
+}
+
+TEST(OneRecSequenceDeathTest, EmptyPromptRequiresSparseEmbedding) {
+  SequenceFixture fixture;
+  EXPECT_DEATH(fixture.create(RecType::kOneRec, /*prompt=*/{}),
+               "encoder sparse embedding not found");
+}
+
+TEST(OneRecSequenceTest, ForkKeepsLayoutAndType) {
+  SequenceFixture fixture;
+  auto sequence = fixture.create(RecType::kOneRec, {11, 12, 13});
+  RecSequence::from(*sequence).set_beam_search_result(
+      RecBeamSearchResult(/*beam_width=*/1,
+                          /*total_rounds=*/1,
+                          /*beams=*/{{1, 2, 3}},
+                          /*last_logprobs=*/{}));
+
+  std::unique_ptr<Sequence> fork = sequence->fork(/*index=*/1);
+  const auto* onerec_fork = dynamic_cast<const OneRecSequence*>(fork.get());
+  ASSERT_NE(onerec_fork, nullptr);
+  EXPECT_EQ(onerec_fork->encoder_tokens(), (std::vector<int32_t>{11, 12, 13}));
+  EXPECT_EQ(onerec_fork->encoder_seq_len(), 3u);
+  EXPECT_FALSE(onerec_fork->beam_search_result().ready());
+}
+
+// ---------------------------------------------------------------------------
+// OneRec behavior hooks
+// ---------------------------------------------------------------------------
+
+TEST(OneRecSequenceTest, AppendsBeforePrefillAndNeedsTokenToFinish) {
+  SequenceFixture fixture;
+  auto sequence = fixture.create(RecType::kOneRec, {11, 12, 13});
+
+  // No KV cache filled yet and no generated token: not finished, and appending
+  // is allowed (an LLM sequence would CHECK-fail here).
+  EXPECT_FALSE(sequence->finished());
+  append_generated(*sequence, {21});
+  EXPECT_EQ(sequence->num_generated_tokens(), 1u);
+}
+
+TEST(OneRecSequenceTest, StreamingOutputCarriesGeneratedIdsOnly) {
+  SequenceFixture fixture;
+  auto sequence = fixture.create(RecType::kOneRec, {11, 12, 13});
+  append_generated(*sequence, {21, 22});
+
+  FakeItemTokenizer tokenizer;
+  auto output =
+      sequence->generate_streaming_output(sequence->num_tokens(), tokenizer);
+  ASSERT_TRUE(output.has_value());
+  EXPECT_EQ(output->index, 0u);
+  EXPECT_EQ(output->token_ids, (std::vector<int32_t>{21, 22}));
+  EXPECT_TRUE(output->text.empty());
+}
+
+TEST(OneRecSequenceTest, OutputSkipsTrailingPlaceholderTokens) {
+  SequenceFixture fixture;
+  fixture.params().enable_schedule_overlap = true;
+  auto sequence = fixture.create(RecType::kOneRec, {11, 12, 13});
+  append_generated(*sequence, {21, 22});
+  sequence->append_token(Token(-1));
+
+  FakeItemTokenizer tokenizer;
+  SequenceOutput output = sequence->generate_output(tokenizer);
+  EXPECT_EQ(output.token_ids, (std::vector<int32_t>{21, 22}));
+}
+
+TEST(OneRecSequenceTest, SkuLogprobsAreEmittedWhenEnabled) {
+  ScopedRecConfig scoped;
+  RecConfig::get_instance().enable_output_sku_logprobs(true);
+
+  SequenceFixture fixture;
+  fixture.sampling_param().logprobs = true;
+  auto sequence = fixture.create(RecType::kOneRec, {11, 12, 13});
+  append_generated(*sequence, {21, 22, 23}, /*logprob=*/-0.25f);
+
+  FakeItemTokenizer tokenizer;
+  SequenceOutput output = sequence->generate_output(tokenizer);
+  ASSERT_EQ(output.token_ids_logprobs.size(), 3u);
+  for (const auto& logprob : output.token_ids_logprobs) {
+    ASSERT_TRUE(logprob.has_value());
+    EXPECT_FLOAT_EQ(logprob.value(), -0.25f);
+  }
+}
+
+TEST(OneRecSequenceTest, NoSkuLogprobsWhenDisabled) {
+  ScopedRecConfig scoped;
+  RecConfig::get_instance().enable_output_sku_logprobs(false);
+
+  SequenceFixture fixture;
+  auto sequence = fixture.create(RecType::kOneRec, {11, 12, 13});
+  append_generated(*sequence, {21, 22, 23});
+
+  FakeItemTokenizer tokenizer;
+  SequenceOutput output = sequence->generate_output(tokenizer);
+  EXPECT_TRUE(output.token_ids_logprobs.empty());
+}
+
+TEST(OneRecSequenceTest, ConvertsCompleteTripleToDedupedItems) {
+  ScopedRecConfig scoped;
+  RecConfig::get_instance()
+      .enable_convert_tokens_to_item(true)
+      .enable_extended_item_info(false)
+      .each_conversion_threshold(50);
+
+  SequenceFixture fixture;
+  auto sequence = fixture.create(RecType::kOneRec, {11, 12, 13});
+  append_generated(*sequence, {21, 22, 23});
+
+  FakeItemTokenizer tokenizer;
+  SequenceOutput output = sequence->generate_output(tokenizer);
+  EXPECT_EQ(output.item_ids_list, (std::vector<int64_t>{1001, 1002}));
+  ASSERT_TRUE(output.item_ids.has_value());
+  EXPECT_EQ(output.item_ids.value(), 1001);
+}
+
+TEST(OneRecSequenceTest, DoesNotConvertIncompleteTriple) {
+  ScopedRecConfig scoped;
+  RecConfig::get_instance().enable_convert_tokens_to_item(true);
+
+  SequenceFixture fixture;
+  auto sequence = fixture.create(RecType::kOneRec, {11, 12, 13});
+  append_generated(*sequence, {21, 22});
+
+  FakeItemTokenizer tokenizer;
+  SequenceOutput output = sequence->generate_output(tokenizer);
+  EXPECT_TRUE(output.item_ids_list.empty());
+  EXPECT_FALSE(output.item_ids.has_value());
+}
+
+TEST(OneRecSequenceTest, CapsConvertedItemsAtThreshold) {
+  ScopedRecConfig scoped;
+  RecConfig::get_instance()
+      .enable_convert_tokens_to_item(true)
+      .enable_extended_item_info(false)
+      .each_conversion_threshold(1);
+
+  SequenceFixture fixture;
+  auto sequence = fixture.create(RecType::kOneRec, {11, 12, 13});
+  append_generated(*sequence, {21, 22, 23});
+
+  FakeItemTokenizer tokenizer;
+  SequenceOutput output = sequence->generate_output(tokenizer);
+  EXPECT_EQ(output.item_ids_list.size(), 1u);
+  ASSERT_TRUE(output.item_ids.has_value());
+  EXPECT_EQ(output.item_ids.value(), output.item_ids_list.front());
+}
+
+}  // namespace
+}  // namespace xllm

--- a/xllm/core/framework/batch/batch.cpp
+++ b/xllm/core/framework/batch/batch.cpp
@@ -23,6 +23,7 @@ limitations under the License.
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "batch_input_builder.h"
@@ -32,6 +33,8 @@ limitations under the License.
 #include "core/framework/config/model_config.h"
 #include "core/framework/config/parallel_config.h"
 #include "core/framework/config/scheduler_config.h"
+#include "core/framework/request/onerec_sequence.h"
+#include "core/framework/request/rec_sequence.h"
 #include "core/util/rec_model_utils.h"
 #include "framework/model/model_args.h"
 #include "framework/model/model_input_params.h"
@@ -502,9 +505,12 @@ void Batch::refresh_onerec_prefill_output_targets() {
     const uint32_t n_tokens = token_ids.size();
     const uint32_t n_kv_cache_tokens =
         sequence->kv_state().kv_cache_tokens_num();
-    const bool needs_context_target = sequence->is_onerec_model() &&
-                                      n_tokens == 0 && n_kv_cache_tokens == 0 &&
-                                      sequence->num_decoder_embeddings() > 0;
+    // The prefill-only contract is not restricted to OneRec deployments; only
+    // OneRec sequences carry decoder context embeddings.
+    const auto* onerec_sequence = dynamic_cast<const OneRecSequence*>(sequence);
+    const bool needs_context_target =
+        onerec_sequence != nullptr && n_tokens == 0 && n_kv_cache_tokens == 0 &&
+        onerec_sequence->num_decoder_embeddings() > 0;
     if (needs_context_target) {
       output_targets_.push_back({sequence, /*sample_id=*/0, false});
       continue;
@@ -654,14 +660,11 @@ void Batch::process_beam_sequence_group(const ForwardOutput& output) {
   bool has_logprobs = output.beam_search_output.out_logprobs.defined() &&
                       output.beam_search_output.out_logprobs.numel() > 0;
 
-  std::vector<std::vector<int32_t>> group_flat2d;
-  std::vector<float> last_logprobs;
-  group_flat2d.reserve(static_cast<size_t>(result_width));
-  last_logprobs.reserve(static_cast<size_t>(result_width));
-
   for (size_t g = 0; g < num_groups; ++g) {
-    group_flat2d.clear();
-    last_logprobs.clear();
+    std::vector<std::vector<int32_t>> group_flat2d;
+    std::vector<float> last_logprobs;
+    group_flat2d.reserve(static_cast<size_t>(result_width));
+    last_logprobs.reserve(static_cast<size_t>(result_width));
 
     for (int b = 0; b < result_width; ++b) {
       std::vector<int32_t> row_tokens;
@@ -683,8 +686,11 @@ void Batch::process_beam_sequence_group(const ForwardOutput& output) {
     Sequence* seq = sequence_groups_.empty()
                         ? sequences[g]
                         : sequence_groups_[g]->sequences()[0].get();
-    seq->set_beam_result(
-        result_width, total_rounds, group_flat2d, last_logprobs);
+    RecSequence::from(*seq).set_beam_search_result(
+        RecBeamSearchResult(result_width,
+                            total_rounds,
+                            std::move(group_flat2d),
+                            std::move(last_logprobs)));
   }
 }
 

--- a/xllm/core/framework/batch/onerec_batch_input_builder.cpp
+++ b/xllm/core/framework/batch/onerec_batch_input_builder.cpp
@@ -26,8 +26,8 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
+#include "core/framework/request/onerec_sequence.h"
 #include "framework/model/model_input_params.h"
-#include "framework/request/sequence.h"
 #include "framework/sampling/sampling_params.h"
 #include "util/tensor_helper.h"
 #include "util/threadpool.h"
@@ -139,7 +139,7 @@ ForwardInput OneRecBatchInputBuilder::build_rec_forward_input(
 
   const uint32_t seq_len = first_sequence->num_tokens();
   const uint32_t num_decoder_embeddings =
-      first_sequence->num_decoder_embeddings();
+      OneRecSequence::from(*first_sequence).num_decoder_embeddings();
   const uint32_t n_prompt_tokens = first_sequence->num_prompt_tokens();
   const bool is_first_prefill = (first_sequence->num_generated_tokens() == 0);
   // const uint64_t model_version = first_sequence->get_model_version();
@@ -167,7 +167,9 @@ ForwardInput OneRecBatchInputBuilder::build_rec_forward_input(
         // Sequences within group have same length, only need to get first
         // sequence's length
         const int32_t group_encoder_seq_len =
-            group_ptr->sequences()[0]->encoder_tokens().size();
+            OneRecSequence::from(*group_ptr->sequences()[0])
+                .encoder_tokens()
+                .size();
         total_tokens += group_encoder_seq_len * group_ptr->sequences().size();
       }
     }
@@ -188,7 +190,7 @@ ForwardInput OneRecBatchInputBuilder::build_rec_forward_input(
       if (group_size == 0) continue;
 
       const int32_t group_encoder_seq_len =
-          group.sequences()[0]->encoder_seq_len();
+          OneRecSequence::from(*group.sequences()[0]).encoder_seq_len();
 
       // Batch set same values
       std::fill_n(&cache_data.encoder_seq_lens[global_seq_idx],
@@ -196,8 +198,9 @@ ForwardInput OneRecBatchInputBuilder::build_rec_forward_input(
                   group_encoder_seq_len);
 
       // Batch copy tokens by sequence and collect sparse_embedding
-      for (const auto& sequence : group.sequences()) {
-        const auto& encoder_tokens = sequence->encoder_tokens();
+      for (const auto& sequence_ptr : group.sequences()) {
+        const OneRecSequence& sequence = OneRecSequence::from(*sequence_ptr);
+        const auto& encoder_tokens = sequence.encoder_tokens();
         const int32_t* src_ptr = encoder_tokens.data();
         const int32_t group_encoder_seq_len = encoder_tokens.size();
 
@@ -208,16 +211,16 @@ ForwardInput OneRecBatchInputBuilder::build_rec_forward_input(
                                            src_ptr + group_encoder_seq_len);
         }
         // Collect sparse_embedding
-        auto mm_data = sequence->mm_data();
-        auto sparse_embedding_optional =
-            mm_data.get<torch::Tensor>(Sequence::ENCODER_SPARSE_EMBEDDING_NAME);
+        const MMData& mm_data = sequence.mm_data();
+        auto sparse_embedding_optional = mm_data.get<torch::Tensor>(
+            OneRecSequence::kEncoderSparseEmbeddingName);
         if (sparse_embedding_optional.has_value()) {
           cache_data.encoder_sparse_embeddings.push_back(
               sparse_embedding_optional.value());
         }
 
         auto decoder_context_embedding_optional = mm_data.get<torch::Tensor>(
-            Sequence::DECODER_CONTEXT_EMBEDDING_NAME);
+            OneRecSequence::kDecoderContextEmbeddingName);
         if (decoder_context_embedding_optional.has_value()) {
           cache_data.decoder_context_embeddings.push_back(
               decoder_context_embedding_optional.value());

--- a/xllm/core/framework/batch/onerec_xattention_batch_input_builder.cpp
+++ b/xllm/core/framework/batch/onerec_xattention_batch_input_builder.cpp
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include "common/global_flags.h"
 #include "core/framework/config/scheduler_config.h"
+#include "core/framework/request/onerec_sequence.h"
 #include "core/util/rec_model_utils.h"
 #include "core/util/utils.h"
 #include "util/tensor_helper.h"
@@ -29,8 +30,9 @@ namespace xllm {
 namespace {
 
 int32_t get_onerec_xattention_decode_position(const Sequence& sequence) {
-  return static_cast<int32_t>(sequence.num_prompt_tokens() +
-                              sequence.num_decoder_embeddings());
+  return static_cast<int32_t>(
+      sequence.num_prompt_tokens() +
+      OneRecSequence::from(sequence).num_decoder_embeddings());
 }
 
 }  // namespace
@@ -77,7 +79,8 @@ ForwardInput OneRecXAttentionBatchInputBuilder::build_rec_forward_input(
       }
       ++batch_size;
       const int32_t total_seq_len = static_cast<int32_t>(
-          sequence_ptr->num_tokens() + sequence_ptr->num_decoder_embeddings());
+          sequence_ptr->num_tokens() +
+          OneRecSequence::from(*sequence_ptr).num_decoder_embeddings());
       const int32_t n_kv_cache_tokens =
           static_cast<int32_t>(sequence_ptr->kv_state().kv_cache_tokens_num());
       const auto blocks = sequence_ptr->kv_state().blocks(BlockType::KV);

--- a/xllm/core/framework/request/CMakeLists.txt
+++ b/xllm/core/framework/request/CMakeLists.txt
@@ -22,6 +22,9 @@ cc_library(
     request_params.h
     sample_slot.h
     sequence.h
+    rec_sequence.h
+    onerec_sequence.h
+    sequence_factory.h
     sequence_logprob_state.h
     sequence_kv_state.h
     sequences_group.h
@@ -45,6 +48,9 @@ cc_library(
     sample_slot.cpp
     dit_request_params.cpp
     sequence.cpp
+    rec_sequence.cpp
+    onerec_sequence.cpp
+    sequence_factory.cpp
     sequence_logprob_state.cpp
     sequence_kv_state.cpp
     sequences_group.cpp

--- a/xllm/core/framework/request/onerec_sequence.cpp
+++ b/xllm/core/framework/request/onerec_sequence.cpp
@@ -1,0 +1,274 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "core/framework/request/onerec_sequence.h"
+
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <memory>
+#include <random>
+#include <unordered_set>
+#include <utility>
+
+#include "core/common/metrics.h"
+#include "core/common/types.h"
+#include "core/framework/config/execution_config.h"
+#include "core/framework/config/rec_config.h"
+#include "core/framework/request/rec_type.h"
+#include "core/framework/tokenizer/rec_tokenizer.h"
+
+namespace xllm {
+
+namespace {
+constexpr size_t kDecoderBosTokenCount = 1;
+constexpr size_t kDecoderMaxTokenCount = kRecTotalSteps + kDecoderBosTokenCount;
+
+// Shuffle seed for capping the converted item list: deterministic per sequence
+// when a random seed is configured, otherwise random.
+uint32_t item_shuffle_seed(size_t sequence_index) {
+  const int32_t random_seed = ExecutionConfig::get_instance().random_seed();
+  if (random_seed >= 0) {
+    return static_cast<uint32_t>(random_seed) +
+           static_cast<uint32_t>(sequence_index);
+  }
+  return std::random_device{}();
+}
+
+std::vector<int64_t> normalize_rec_item_ids(const std::vector<int64_t>& raw_ids,
+                                            size_t sequence_index) {
+  std::vector<int64_t> item_ids;
+  item_ids.reserve(raw_ids.size());
+  std::unordered_set<int64_t> seen_item_ids;
+  for (const int64_t item_id : raw_ids) {
+    if (seen_item_ids.insert(item_id).second) {
+      item_ids.emplace_back(item_id);
+    }
+  }
+
+  const int32_t each_threshold =
+      RecConfig::get_instance().each_conversion_threshold();
+  if (each_threshold > 0 &&
+      static_cast<int32_t>(item_ids.size()) > each_threshold) {
+    std::mt19937 generator(item_shuffle_seed(sequence_index));
+    std::shuffle(item_ids.begin(), item_ids.end(), generator);
+    item_ids.resize(each_threshold);
+  }
+
+  return item_ids;
+}
+
+std::vector<RecItemInfo> normalize_rec_item_infos(
+    const std::vector<RecItemInfo>& raw_item_infos,
+    size_t sequence_index) {
+  std::vector<RecItemInfo> item_infos;
+  item_infos.reserve(raw_item_infos.size());
+  std::unordered_set<int64_t> seen_item_ids;
+  for (const RecItemInfo& item_info : raw_item_infos) {
+    if (seen_item_ids.insert(item_info.item_id).second) {
+      item_infos.emplace_back(item_info);
+    }
+  }
+
+  const int32_t each_threshold =
+      RecConfig::get_instance().each_conversion_threshold();
+  if (each_threshold > 0 &&
+      static_cast<int32_t>(item_infos.size()) > each_threshold) {
+    std::mt19937 generator(item_shuffle_seed(sequence_index));
+    std::shuffle(item_infos.begin(), item_infos.end(), generator);
+    item_infos.resize(each_threshold);
+  }
+
+  return item_infos;
+}
+}  // namespace
+
+const std::string OneRecSequence::kEncoderSparseEmbeddingName =
+    "sparse_embedding";
+const std::string OneRecSequence::kDecoderContextEmbeddingName =
+    "decoder_context_embedding";
+
+OneRecSequence::Layout OneRecSequence::derive_layout(
+    const std::vector<int32_t>& prompt_token_ids,
+    const MMData& mm_data) {
+  Layout layout;
+  if (!prompt_token_ids.empty()) {
+    layout.encoder_tokens = prompt_token_ids;
+    layout.num_encoder_tokens = prompt_token_ids.size();
+  } else {
+    const auto encoder_sparse_embedding =
+        mm_data.get<torch::Tensor>(kEncoderSparseEmbeddingName);
+    CHECK(encoder_sparse_embedding.has_value())
+        << "encoder sparse embedding not found in mm_data";
+    layout.num_encoder_tokens = encoder_sparse_embedding.value().size(0);
+  }
+
+  const auto decoder_context_embedding =
+      mm_data.get<torch::Tensor>(kDecoderContextEmbeddingName);
+  if (decoder_context_embedding.has_value()) {
+    // The context embeddings play the role of the decoder prompt; the token
+    // buffer only needs room for the generated triples.
+    layout.num_decoder_embeddings = decoder_context_embedding.value().size(0);
+    layout.decoder_seed.num_bos_tokens = 0;
+    layout.decoder_seed.capacity = layout.num_decoder_embeddings +
+                                   kDecoderMaxTokenCount -
+                                   kDecoderBosTokenCount;
+  } else {
+    layout.decoder_seed.num_bos_tokens = kDecoderBosTokenCount;
+    layout.decoder_seed.capacity = kDecoderMaxTokenCount;
+  }
+  return layout;
+}
+
+OneRecSequence::OneRecSequence(size_t index,
+                               const std::vector<int32_t>& prompt_token_ids,
+                               torch::Tensor input_embedding,
+                               const MMData& mm_data,
+                               const IncrementalDecoder& incremental_decoder,
+                               const SequenceParams& seq_params)
+    : OneRecSequence(index,
+                     derive_layout(prompt_token_ids, mm_data),
+                     std::move(input_embedding),
+                     mm_data,
+                     incremental_decoder,
+                     seq_params) {}
+
+// OneRec emits per-token logprobs in its output when SKU logprobs are enabled,
+// independent of the request's sampling flags, so the buffer is forced on.
+OneRecSequence::OneRecSequence(size_t index,
+                               Layout layout,
+                               torch::Tensor input_embedding,
+                               const MMData& mm_data,
+                               const IncrementalDecoder& incremental_decoder,
+                               const SequenceParams& seq_params)
+    : RecSequence(index,
+                  layout.decoder_seed,
+                  std::move(input_embedding),
+                  mm_data,
+                  incremental_decoder,
+                  seq_params,
+                  RecConfig::get_instance().enable_output_sku_logprobs()),
+      num_encoder_tokens_(layout.num_encoder_tokens),
+      num_decoder_embeddings_(layout.num_decoder_embeddings),
+      encoder_tokens_(std::move(layout.encoder_tokens)) {}
+
+OneRecSequence::OneRecSequence(const OneRecSequence& other, size_t index)
+    : RecSequence(other, index),
+      num_encoder_tokens_(other.num_encoder_tokens_),
+      num_decoder_embeddings_(other.num_decoder_embeddings_),
+      encoder_tokens_(other.encoder_tokens_) {}
+
+OneRecSequence& OneRecSequence::from(Sequence& sequence) {
+  auto* onerec_sequence = dynamic_cast<OneRecSequence*>(&sequence);
+  CHECK(onerec_sequence != nullptr)
+      << "sequence " << sequence.seq_id() << " is not a OneRec sequence";
+  return *onerec_sequence;
+}
+
+const OneRecSequence& OneRecSequence::from(const Sequence& sequence) {
+  const auto* onerec_sequence = dynamic_cast<const OneRecSequence*>(&sequence);
+  CHECK(onerec_sequence != nullptr)
+      << "sequence " << sequence.seq_id() << " is not a OneRec sequence";
+  return *onerec_sequence;
+}
+
+std::unique_ptr<Sequence> OneRecSequence::fork(size_t index) const {
+  return std::make_unique<OneRecSequence>(*this, index);
+}
+
+Slice<int32_t> OneRecSequence::generated_ids() const {
+  return tokens().slice(num_prompt_tokens(), num_valid_tokens());
+}
+
+std::optional<SequenceOutput> OneRecSequence::generate_streaming_output(
+    size_t /*size*/,
+    const Tokenizer& /*tokenizer*/) {
+  AUTO_COUNTER(detokenization_latency_seconds_stream);
+  SequenceOutput output;
+  output.index = index();
+  output.token_ids = generated_ids();
+  return output;
+}
+
+SequenceOutput OneRecSequence::generate_output(const Tokenizer& tokenizer) {
+  AUTO_COUNTER(detokenization_latency_seconds_non_stream);
+  const auto& rec_config = RecConfig::get_instance();
+
+  SequenceOutput output;
+  output.index = index();
+  if (output_embedding().defined()) {
+    output.embedding = output_embedding();
+  }
+  if (finish_reason() != FinishReason::NONE) {
+    output.finish_reason = finish_reason().to_string();
+  }
+  output.token_ids = generated_ids();
+
+  if (rec_config.enable_output_sku_logprobs()) {
+    const auto& token_logprobs = logprob_state()->get_logprobs();
+    const size_t begin = num_prompt_tokens();
+    const size_t end = begin + output.token_ids.size();
+    output.token_ids_logprobs.reserve(output.token_ids.size());
+    for (size_t i = begin; i < end; ++i) {
+      if (i < token_logprobs.size()) {
+        output.token_ids_logprobs.emplace_back(token_logprobs[i]);
+      } else {
+        output.token_ids_logprobs.emplace_back();
+      }
+    }
+  }
+
+  if (!rec_config.enable_convert_tokens_to_item() ||
+      output.token_ids.size() != static_cast<size_t>(REC_TOKEN_SIZE)) {
+    return output;
+  }
+
+  const Slice<int32_t> token_slice{output.token_ids.data(),
+                                   output.token_ids.size()};
+  if (rec_config.enable_extended_item_info()) {
+    const auto* rec_tokenizer = dynamic_cast<const RecTokenizer*>(&tokenizer);
+    if (rec_tokenizer == nullptr) {
+      return output;
+    }
+    std::vector<RecItemInfo> item_infos;
+    const bool ok = rec_tokenizer->decode_item_infos(token_slice, &item_infos);
+    if (!ok || item_infos.empty()) {
+      return output;
+    }
+    output.item_infos_list = normalize_rec_item_infos(item_infos, index());
+    output.item_ids_list.reserve(output.item_infos_list.size());
+    for (const RecItemInfo& item_info : output.item_infos_list) {
+      output.item_ids_list.emplace_back(item_info.item_id);
+    }
+    if (!output.item_infos_list.empty()) {
+      output.item_ids = output.item_ids_list.front();
+      output.item_info = output.item_infos_list.front();
+    }
+    return output;
+  }
+
+  std::vector<int64_t> item_ids;
+  const bool ok = tokenizer.decode(
+      token_slice, sequence_params().skip_special_tokens, &item_ids);
+  if (ok && !item_ids.empty()) {
+    output.item_ids_list = normalize_rec_item_ids(item_ids, index());
+    if (!output.item_ids_list.empty()) {
+      output.item_ids = output.item_ids_list.front();
+    }
+  }
+  return output;
+}
+
+}  // namespace xllm

--- a/xllm/core/framework/request/onerec_sequence.h
+++ b/xllm/core/framework/request/onerec_sequence.h
@@ -1,0 +1,102 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "core/framework/request/rec_sequence.h"
+
+namespace xllm {
+
+// OneRec encoder/decoder sequence. The prompt (token ids or a sparse embedding
+// carried in mm_data) feeds the encoder; the decoder is seeded with a BOS token
+// or with pre-computed context embeddings and generates REC token triples. The
+// output carries raw generated ids (optionally with per-token SKU logprobs and
+// the decoded item ids) instead of detokenized text.
+class OneRecSequence final : public RecSequence {
+ public:
+  // Keys under which OneRec inputs travel in MMData.
+  static const std::string kEncoderSparseEmbeddingName;
+  static const std::string kDecoderContextEmbeddingName;
+
+  OneRecSequence(size_t index,
+                 const std::vector<int32_t>& prompt_token_ids,
+                 torch::Tensor input_embedding,
+                 const MMData& mm_data,
+                 const IncrementalDecoder& incremental_decoder,
+                 const SequenceParams& seq_params);
+
+  OneRecSequence(const OneRecSequence& other, size_t index);
+
+  // Typed access at OneRec-only entry points; CHECK-fails otherwise.
+  static OneRecSequence& from(Sequence& sequence);
+  static const OneRecSequence& from(const Sequence& sequence);
+
+  std::unique_ptr<Sequence> fork(size_t index) const override;
+
+  // Encoder input: the prompt token ids, or empty when the encoder input is the
+  // sparse embedding.
+  const std::vector<int32_t>& encoder_tokens() const { return encoder_tokens_; }
+  // Encoder sequence length: token count or sparse embedding rows.
+  size_t encoder_seq_len() const { return num_encoder_tokens_; }
+  // Rows of decoder context embedding that precede the generated tokens; 0 when
+  // the decoder is seeded with BOS instead.
+  size_t num_decoder_embeddings() const { return num_decoder_embeddings_; }
+
+  using Sequence::generate_output;
+  std::optional<SequenceOutput> generate_streaming_output(
+      size_t size,
+      const Tokenizer& tokenizer) override;
+  SequenceOutput generate_output(const Tokenizer& tokenizer) override;
+
+ protected:
+  // OneRec appends to the decoder before any KV cache is filled and cannot
+  // finish before it generated anything.
+  bool allows_append_before_prefill() const override { return true; }
+  bool requires_generated_token_to_finish() const override { return true; }
+
+ private:
+  // Encoder/decoder layout derived from the prompt and mm_data before the
+  // base is constructed.
+  struct Layout {
+    size_t num_encoder_tokens = 0;
+    size_t num_decoder_embeddings = 0;
+    std::vector<int32_t> encoder_tokens;
+    DecoderSeed decoder_seed;
+  };
+  static Layout derive_layout(const std::vector<int32_t>& prompt_token_ids,
+                              const MMData& mm_data);
+
+  OneRecSequence(size_t index,
+                 Layout layout,
+                 torch::Tensor input_embedding,
+                 const MMData& mm_data,
+                 const IncrementalDecoder& incremental_decoder,
+                 const SequenceParams& seq_params);
+
+  Slice<int32_t> generated_ids() const;
+
+  size_t num_encoder_tokens_ = 0;
+  size_t num_decoder_embeddings_ = 0;
+  std::vector<int32_t> encoder_tokens_;
+};
+
+}  // namespace xllm

--- a/xllm/core/framework/request/rec_sequence.cpp
+++ b/xllm/core/framework/request/rec_sequence.cpp
@@ -1,0 +1,105 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "core/framework/request/rec_sequence.h"
+
+#include <glog/logging.h>
+
+#include <memory>
+#include <utility>
+
+namespace xllm {
+
+RecBeamSearchResult::RecBeamSearchResult(
+    int32_t beam_width,
+    int32_t total_rounds,
+    std::vector<std::vector<int32_t>> beams,
+    std::vector<float> last_logprobs)
+    : beam_width_(beam_width),
+      total_rounds_(total_rounds),
+      beams_(std::move(beams)),
+      last_logprobs_(std::move(last_logprobs)) {}
+
+RecSequence::RecSequence(size_t index,
+                         const std::vector<int32_t>& prompt_token_ids,
+                         torch::Tensor input_embedding,
+                         const MMData& mm_data,
+                         const IncrementalDecoder& incremental_decoder,
+                         const SequenceParams& seq_params)
+    : Sequence(index,
+               prompt_token_ids,
+               std::move(input_embedding),
+               mm_data,
+               incremental_decoder,
+               seq_params) {}
+
+RecSequence::RecSequence(size_t index,
+                         const DecoderSeed& seed,
+                         torch::Tensor input_embedding,
+                         const MMData& mm_data,
+                         const IncrementalDecoder& incremental_decoder,
+                         const SequenceParams& seq_params,
+                         bool force_token_logprobs)
+    : Sequence(index,
+               seed,
+               std::move(input_embedding),
+               mm_data,
+               incremental_decoder,
+               seq_params,
+               force_token_logprobs) {}
+
+RecSequence::RecSequence(const RecSequence& other)
+    : RecSequence(other, other.index()) {}
+
+// beam_search_result_ intentionally starts empty: the forked sequence is a new
+// beam candidate and must not report its source's cached beams.
+RecSequence::RecSequence(const RecSequence& other, size_t index)
+    : Sequence(other, index) {}
+
+RecSequence& RecSequence::from(Sequence& sequence) {
+  auto* rec_sequence = dynamic_cast<RecSequence*>(&sequence);
+  CHECK(rec_sequence != nullptr)
+      << "sequence " << sequence.seq_id() << " is not a REC sequence";
+  return *rec_sequence;
+}
+
+const RecSequence& RecSequence::from(const Sequence& sequence) {
+  const auto* rec_sequence = dynamic_cast<const RecSequence*>(&sequence);
+  CHECK(rec_sequence != nullptr)
+      << "sequence " << sequence.seq_id() << " is not a REC sequence";
+  return *rec_sequence;
+}
+
+LlmRecSequence::LlmRecSequence(size_t index,
+                               const std::vector<int32_t>& prompt_token_ids,
+                               torch::Tensor input_embedding,
+                               const MMData& mm_data,
+                               const IncrementalDecoder& incremental_decoder,
+                               const SequenceParams& seq_params)
+    : RecSequence(index,
+                  prompt_token_ids,
+                  std::move(input_embedding),
+                  mm_data,
+                  incremental_decoder,
+                  seq_params) {}
+
+LlmRecSequence::LlmRecSequence(const LlmRecSequence& other, size_t index)
+    : RecSequence(other, index) {}
+
+std::unique_ptr<Sequence> LlmRecSequence::fork(size_t index) const {
+  return std::make_unique<LlmRecSequence>(*this, index);
+}
+
+}  // namespace xllm

--- a/xllm/core/framework/request/rec_sequence.h
+++ b/xllm/core/framework/request/rec_sequence.h
@@ -1,0 +1,116 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "core/framework/request/sequence.h"
+
+namespace xllm {
+
+// Result of a multi-round beam search run on the device (written by the OneRec
+// x-attention and LlmRec multi-round pipelines, read when the request output
+// is produced). Default-constructed it is empty (not ready).
+class RecBeamSearchResult {
+ public:
+  RecBeamSearchResult() = default;
+
+  // `beams` has `beam_width` rows of total_rounds * REC_TOKEN_SIZE tokens
+  // each; `last_logprobs` has one entry per row (may be empty when the kernel
+  // did not report them).
+  RecBeamSearchResult(int32_t beam_width,
+                      int32_t total_rounds,
+                      std::vector<std::vector<int32_t>> beams,
+                      std::vector<float> last_logprobs);
+
+  bool ready() const {
+    return beam_width_ > 0 && total_rounds_ > 0 && !beams_.empty();
+  }
+
+  int32_t beam_width() const { return beam_width_; }
+  int32_t total_rounds() const { return total_rounds_; }
+  const std::vector<std::vector<int32_t>>& beams() const { return beams_; }
+  const std::vector<float>& last_logprobs() const { return last_logprobs_; }
+
+ private:
+  int32_t beam_width_ = 0;
+  int32_t total_rounds_ = 0;
+  std::vector<std::vector<int32_t>> beams_;
+  std::vector<float> last_logprobs_;
+};
+
+// Common base of the recommendation sequences: carries the device-side
+// multi-round beam result. A fork starts with an empty result; the beam
+// pipelines re-populate it for the surviving sequence.
+class RecSequence : public Sequence {
+ public:
+  RecSequence(size_t index,
+              const std::vector<int32_t>& prompt_token_ids,
+              torch::Tensor input_embedding,
+              const MMData& mm_data,
+              const IncrementalDecoder& incremental_decoder,
+              const SequenceParams& seq_params);
+
+  RecSequence(const RecSequence& other);
+  RecSequence(const RecSequence& other, size_t index);
+
+  // Typed access at REC-only entry points; CHECK-fails on a non-REC sequence.
+  static RecSequence& from(Sequence& sequence);
+  static const RecSequence& from(const Sequence& sequence);
+
+  const RecBeamSearchResult& beam_search_result() const {
+    return beam_search_result_;
+  }
+  void set_beam_search_result(RecBeamSearchResult result) {
+    beam_search_result_ = std::move(result);
+  }
+
+ protected:
+  // BOS-seeded decoder, for derived types that do not consume the prompt as
+  // decoder tokens (OneRec).
+  RecSequence(size_t index,
+              const DecoderSeed& seed,
+              torch::Tensor input_embedding,
+              const MMData& mm_data,
+              const IncrementalDecoder& incremental_decoder,
+              const SequenceParams& seq_params,
+              bool force_token_logprobs);
+
+ private:
+  RecBeamSearchResult beam_search_result_;
+};
+
+// Decoder-only recommendation model driven like an LLM: prompt-seeded decoder,
+// standard detokenizing output.
+class LlmRecSequence final : public RecSequence {
+ public:
+  LlmRecSequence(size_t index,
+                 const std::vector<int32_t>& prompt_token_ids,
+                 torch::Tensor input_embedding,
+                 const MMData& mm_data,
+                 const IncrementalDecoder& incremental_decoder,
+                 const SequenceParams& seq_params);
+
+  LlmRecSequence(const LlmRecSequence& other, size_t index);
+
+  std::unique_ptr<Sequence> fork(size_t index) const override;
+};
+
+}  // namespace xllm

--- a/xllm/core/framework/request/sequence.cpp
+++ b/xllm/core/framework/request/sequence.cpp
@@ -24,128 +24,77 @@ limitations under the License.
 #include <algorithm>
 #include <cstdint>
 #include <limits>
+#include <memory>
 #include <optional>
-#include <random>
 #include <string>
-#include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "core/common/global_flags.h"
 #include "core/common/metrics.h"
 #include "core/framework/config/disagg_pd_config.h"
-#include "core/framework/config/execution_config.h"
-#include "core/framework/config/rec_config.h"
 #include "core/framework/multimodal/embedding_output.h"
 #include "core/framework/multimodal/mm_visitor.h"
 #include "core/framework/prefix_cache/block_hasher.h"
-#include "core/framework/tokenizer/rec_tokenizer.h"
 #include "core/framework/tokenizer/tokenizer.h"
 #include "core/util/slice.h"
 #include "core/util/tensor_helper.h"
-#include "rec_type.h"
 
 namespace xllm {
 
 namespace {
-constexpr size_t kDecoderBosTokenCount = 1;
-constexpr size_t kDecoderMaxTokenCount = kRecTotalSteps + kDecoderBosTokenCount;
 constexpr char kEmptyLogprobsFinishReason[] = "empty_logprobs";
-
-std::vector<int64_t> normalize_rec_item_ids(const std::vector<int64_t>& raw_ids,
-                                            size_t sequence_index) {
-  std::vector<int64_t> item_ids;
-  item_ids.reserve(raw_ids.size());
-  std::unordered_set<int64_t> seen_item_ids;
-  for (const int64_t item_id : raw_ids) {
-    if (seen_item_ids.insert(item_id).second) {
-      item_ids.emplace_back(item_id);
-    }
-  }
-
-  const int32_t each_threshold =
-      ::xllm::RecConfig::get_instance().each_conversion_threshold();
-  if (each_threshold > 0 &&
-      static_cast<int32_t>(item_ids.size()) > each_threshold) {
-    uint32_t seed =
-        ::xllm::ExecutionConfig::get_instance().random_seed() >= 0
-            ? static_cast<uint32_t>(
-                  ::xllm::ExecutionConfig::get_instance().random_seed()) +
-                  static_cast<uint32_t>(sequence_index)
-            : std::random_device{}();
-    std::mt19937 generator(seed);
-    std::shuffle(item_ids.begin(), item_ids.end(), generator);
-    item_ids.resize(each_threshold);
-  }
-
-  return item_ids;
-}
-
-std::vector<RecItemInfo> normalize_rec_item_infos(
-    const std::vector<RecItemInfo>& raw_item_infos,
-    size_t sequence_index) {
-  std::vector<RecItemInfo> item_infos;
-  item_infos.reserve(raw_item_infos.size());
-  std::unordered_set<int64_t> seen_item_ids;
-  for (const RecItemInfo& item_info : raw_item_infos) {
-    if (seen_item_ids.insert(item_info.item_id).second) {
-      item_infos.emplace_back(item_info);
-    }
-  }
-
-  const int32_t each_threshold =
-      ::xllm::RecConfig::get_instance().each_conversion_threshold();
-  if (each_threshold > 0 &&
-      static_cast<int32_t>(item_infos.size()) > each_threshold) {
-    uint32_t seed =
-        ::xllm::ExecutionConfig::get_instance().random_seed() >= 0
-            ? static_cast<uint32_t>(
-                  ::xllm::ExecutionConfig::get_instance().random_seed()) +
-                  static_cast<uint32_t>(sequence_index)
-            : std::random_device{}();
-    std::mt19937 generator(seed);
-    std::shuffle(item_infos.begin(), item_infos.end(), generator);
-    item_infos.resize(each_threshold);
-  }
-
-  return item_infos;
-}
 }  // namespace
 
-const std::string Sequence::ENCODER_SPARSE_EMBEDDING_NAME = "sparse_embedding";
-const std::string Sequence::DECODER_CONTEXT_EMBEDDING_NAME =
-    "decoder_context_embedding";
-
-void Sequence::init_onerec_sequence(
-    const std::vector<int32_t>& prompt_token_ids,
-    torch::Tensor input_embedding) {
-  auto& onerec_state = onerec_state_.emplace();
-  if (!prompt_token_ids.empty()) {
-    onerec_state.encoder_tokens.assign(prompt_token_ids.begin(),
-                                       prompt_token_ids.end());
-    onerec_state.num_encoder_tokens = prompt_token_ids.size();
-  } else {
-    auto encoder_sparse_embedding =
-        mm_data_.get<torch::Tensor>(ENCODER_SPARSE_EMBEDDING_NAME);
-    CHECK(encoder_sparse_embedding.has_value())
-        << "encoder sparse embedding not found in mm_data";
-    onerec_state.num_encoder_tokens = encoder_sparse_embedding.value().size(0);
+void Sequence::init_request_state() {
+  if (sequence_params_.request_failure_state == nullptr) {
+    sequence_params_.request_failure_state =
+        std::make_shared<RequestFailureState>();
   }
-
-  auto decoder_context_embedding =
-      mm_data_.get<torch::Tensor>(DECODER_CONTEXT_EMBEDDING_NAME);
-
-  size_t capacity = kDecoderMaxTokenCount;
-  if (decoder_context_embedding.has_value()) {
-    num_prompt_tokens_ = 0;
-    onerec_state.num_decoder_embeddings =
-        decoder_context_embedding.value().size(0);
-    capacity =
-        onerec_state.num_decoder_embeddings + capacity - kDecoderBosTokenCount;
-  } else {
-    num_prompt_tokens_ = kDecoderBosTokenCount;
+  if (sequence_params_.json_object_grammar != nullptr) {
+    json_object_state_ = sequence_params_.json_object_grammar->initial_state(
+        sequence_params_.json_reasoning_enabled);
   }
+}
 
-  tokens_.resize(capacity);
+void Sequence::init_logprob_state(bool force_token_logprobs) {
+  // Only allocate the per-position buffers when they will actually be read.
+  // The beam readers (SequencesGroup::process_beam_search and
+  // Batch::process_beam_search_output) index both the logprob and top-k buffers
+  // by token position, so a beam request must have them allocated. The request
+  // factories already force logprobs/top_logprobs on for beam
+  // (RequestSamplingParam::enable_beam_search); tying the allocation to
+  // beam_width itself as well keeps the readers' requirement enforced where the
+  // buffers are created, independent of any upstream normalization. best_of>n
+  // forces logprobs on upstream, so it is already covered. A derived type may
+  // emit per-token logprobs in its output regardless of the request flags
+  // (OneRec SKU logprobs) and then forces the buffer on.
+  const bool is_beam_search = sequence_params_.sampling_param->beam_width > 1;
+  const bool enable_logprobs = sequence_params_.sampling_param->logprobs ||
+                               force_token_logprobs || is_beam_search;
+  const bool enable_top_logprobs =
+      sequence_params_.sampling_param->top_logprobs > 0 || is_beam_search;
+  logprob_state_ = LogprobState(
+      num_prompt_tokens_, tokens_.size(), enable_logprobs, enable_top_logprobs);
+}
+
+Sequence::Sequence(size_t index,
+                   const DecoderSeed& seed,
+                   torch::Tensor input_embedding,
+                   const MMData& mm_data,
+                   const IncrementalDecoder& decoder,
+                   const SequenceParams& seq_params,
+                   bool force_token_logprobs)
+    : index_(index),
+      mm_data_(mm_data),
+      latest_generate_time_(absl::Now()),
+      sequence_params_(seq_params),
+      decoder_(decoder),
+      stream_output_token_offset_(decoder_.output_offset()) {
+  init_request_state();
+
+  num_prompt_tokens_ = seed.num_bos_tokens;
+  tokens_.resize(seed.capacity);
   for (size_t i = 0; i < num_prompt_tokens_; ++i) {
     tokens_[num_tokens_++] = sequence_params_.bos_token_id;
     token_to_count_map_[sequence_params_.bos_token_id]++;
@@ -153,87 +102,7 @@ void Sequence::init_onerec_sequence(
   volatile_num_prompt_tokens_ = num_prompt_tokens_;
   input_embedding_ = std::move(input_embedding);
   cur_generated_token_idx_ = num_prompt_tokens_;
-  // OneRec can also emit per-token logprobs via enable_output_sku_logprobs
-  // (see generate_onerec_streaming_output), independent of the sampling flag,
-  // so allocate the logprob buffer when either path needs it. The beam readers
-  // index both buffers by token position (see the main constructor), so keep
-  // them allocated for beam requests too.
-  const bool is_beam_search = sequence_params_.sampling_param->beam_width > 1;
-  const bool enable_logprobs =
-      sequence_params_.sampling_param->logprobs ||
-      ::xllm::RecConfig::get_instance().enable_output_sku_logprobs() ||
-      is_beam_search;
-  const bool enable_top_logprobs =
-      sequence_params_.sampling_param->top_logprobs > 0 || is_beam_search;
-  logprob_state_ = LogprobState(
-      num_prompt_tokens_, capacity, enable_logprobs, enable_top_logprobs);
-}
-
-void Sequence::generate_onerec_streaming_output(const Slice<int32_t>& ids,
-                                                size_t size,
-                                                SequenceOutput& output) const {
-  output.index = index_;
-  output.token_ids = ids.slice(num_prompt_tokens_, size);
-}
-
-void Sequence::generate_onerec_output(const Slice<int32_t>& ids,
-                                      size_t size,
-                                      const Tokenizer& tokenizer,
-                                      SequenceOutput& output) const {
-  output.index = index_;
-  if (output_embedding_.defined()) {
-    output.embedding = output_embedding_;
-  }
-  if (finish_reason_ != FinishReason::NONE) {
-    output.finish_reason = finish_reason_.to_string();
-  }
-  output.token_ids = ids.slice(num_prompt_tokens_, size);
-  if (::xllm::RecConfig::get_instance().enable_output_sku_logprobs()) {
-    const auto& token_logprobs = logprob_state_.get_logprobs();
-    output.token_ids_logprobs.reserve(output.token_ids.size());
-    for (size_t i = num_prompt_tokens_; i < size; ++i) {
-      if (i < token_logprobs.size()) {
-        output.token_ids_logprobs.emplace_back(token_logprobs[i]);
-      } else {
-        output.token_ids_logprobs.emplace_back();
-      }
-    }
-  }
-  const size_t rec_token_size = static_cast<size_t>(REC_TOKEN_SIZE);
-  if (::xllm::RecConfig::get_instance().enable_convert_tokens_to_item() &&
-      output.token_ids.size() == rec_token_size) {
-    const Slice<int32_t> token_slice{output.token_ids.data(),
-                                     output.token_ids.size()};
-    if (::xllm::RecConfig::get_instance().enable_extended_item_info()) {
-      const auto* rec_tokenizer = dynamic_cast<const RecTokenizer*>(&tokenizer);
-      if (rec_tokenizer != nullptr) {
-        std::vector<RecItemInfo> item_infos;
-        const bool ok =
-            rec_tokenizer->decode_item_infos(token_slice, &item_infos);
-        if (ok && !item_infos.empty()) {
-          output.item_infos_list = normalize_rec_item_infos(item_infos, index_);
-          output.item_ids_list.reserve(output.item_infos_list.size());
-          for (const RecItemInfo& item_info : output.item_infos_list) {
-            output.item_ids_list.emplace_back(item_info.item_id);
-          }
-          if (!output.item_infos_list.empty()) {
-            output.item_ids = output.item_ids_list.front();
-            output.item_info = output.item_infos_list.front();
-          }
-        }
-      }
-    } else {
-      std::vector<int64_t> item_ids;
-      const bool ok = tokenizer.decode(
-          token_slice, sequence_params_.skip_special_tokens, &item_ids);
-      if (ok && !item_ids.empty()) {
-        output.item_ids_list = normalize_rec_item_ids(item_ids, index_);
-        if (!output.item_ids_list.empty()) {
-          output.item_ids = output.item_ids_list.front();
-        }
-      }
-    }
-  }
+  init_logprob_state(force_token_logprobs);
 }
 
 Sequence::Sequence(size_t index,
@@ -246,20 +115,9 @@ Sequence::Sequence(size_t index,
       mm_data_(mm_data),
       latest_generate_time_(absl::Now()),
       sequence_params_(seq_params),
-      decoder_(std::move(decoder)),
+      decoder_(decoder),
       stream_output_token_offset_(decoder_.output_offset()) {
-  if (sequence_params_.request_failure_state == nullptr) {
-    sequence_params_.request_failure_state =
-        std::make_shared<RequestFailureState>();
-  }
-  if (sequence_params_.json_object_grammar != nullptr) {
-    json_object_state_ = sequence_params_.json_object_grammar->initial_state(
-        sequence_params_.json_reasoning_enabled);
-  }
-  if (is_onerec_model()) {
-    init_onerec_sequence(prompt_token_ids, std::move(input_embedding));
-    return;
-  }
+  init_request_state();
 
   CHECK(!prompt_token_ids.empty()) << "empty prompt token ids";
   auto capacity = sequence_params_.seq_capacity;
@@ -279,22 +137,7 @@ Sequence::Sequence(size_t index,
   tokens_.resize(capacity);
   num_tokens_ = num_prompt_tokens_;
 
-  // init logprob state. Only allocate the per-position buffers when they will
-  // actually be read. The beam readers (SequencesGroup::process_beam_search and
-  // Batch::process_beam_search_output) index both the logprob and top-k buffers
-  // by token position, so a beam request must have them allocated. The request
-  // factories already force logprobs/top_logprobs on for beam
-  // (RequestSamplingParam::enable_beam_search); tying the allocation to
-  // beam_width itself as well keeps the readers' requirement enforced where the
-  // buffers are created, independent of any upstream normalization. best_of>n
-  // forces logprobs on upstream, so it is already covered.
-  const bool is_beam_search = sequence_params_.sampling_param->beam_width > 1;
-  const bool enable_logprobs =
-      sequence_params_.sampling_param->logprobs || is_beam_search;
-  const bool enable_top_logprobs =
-      sequence_params_.sampling_param->top_logprobs > 0 || is_beam_search;
-  logprob_state_ = LogprobState(
-      num_prompt_tokens_, capacity, enable_logprobs, enable_top_logprobs);
+  init_logprob_state(/*force_token_logprobs=*/false);
 
   if (sequence_params_.sampling_param->frequency_penalty != 0 ||
       sequence_params_.sampling_param->presence_penalty != 0 ||
@@ -311,8 +154,12 @@ Sequence::Sequence(size_t index,
   }
   // need one token to padding even dont need token count
   token_to_count_map_[prompt_token_ids.back()] = 0;
-  input_embedding_ = input_embedding;
+  input_embedding_ = std::move(input_embedding);
   cur_generated_token_idx_ = num_prompt_tokens_;
+}
+
+std::unique_ptr<Sequence> Sequence::fork(size_t index) const {
+  return std::make_unique<Sequence>(*this, index);
 }
 
 Sequence::Sequence(const Sequence& other) : Sequence(other, other.index_) {}
@@ -344,7 +191,6 @@ Sequence::Sequence(const Sequence& other, size_t index)
       hash_block_size_(other.hash_block_size_),
       linear_state_hashes_(other.linear_state_hashes_),
       linear_hash_stride_(other.linear_hash_stride_),
-      onerec_state_(other.onerec_state_),
       json_object_state_(other.json_object_state_),
       volatile_num_prompt_tokens_(other.volatile_num_prompt_tokens_),
       finished_(other.finished_),
@@ -471,7 +317,7 @@ void Sequence::append_token(const Token& token) {
       << "exceed the token capacity of the sequence";
   CHECK(!finished_ && !error_status().has_value())
       << "cannot append token to a finished sequence";
-  if (!is_onerec_model()) {
+  if (!allows_append_before_prefill()) {
     CHECK(kv_state_.kv_cache_tokens_num() > 0 && !is_chunked_prefill_stage())
         << "cannot append token to a prefill sequence";
   }
@@ -640,26 +486,27 @@ void Sequence::update_mtp_bootstrap_embedding(const torch::Tensor& embedding) {
   }
 }
 
-std::optional<SequenceOutput> Sequence::generate_streaming_output(
-    size_t size,
-    const Tokenizer& tokenizer) {
-  // figure out the valid generated token
-  // because there might be fake token -1 if enable_schedule_overlap
-  for (auto i = num_tokens_ - 1; i >= 0; --i) {
-    if (tokens_[i] >= 0) {
-      size = i + 1;
-      break;
+size_t Sequence::num_valid_tokens() const {
+  // There might be placeholder tokens (-1) at the tail when
+  // enable_schedule_overlap; only the tokens before them are real.
+  for (size_t i = num_tokens_; i > 0; --i) {
+    if (tokens_[i - 1] >= 0) {
+      return i;
     }
   }
-  CHECK_LE(size, num_tokens_);
+  return 0;
+}
+
+std::optional<SequenceOutput> Sequence::generate_streaming_output(
+    size_t /*size*/,
+    const Tokenizer& tokenizer) {
+  // The requested size has always been superseded by the scan for the last
+  // real token (placeholders under schedule overlap); keep that behavior.
+  const size_t size = num_valid_tokens();
   AUTO_COUNTER(detokenization_latency_seconds_stream);
   const auto ids = Slice<int32_t>(tokens_, size);
 
   SequenceOutput output;
-  if (is_onerec_model()) {
-    generate_onerec_streaming_output(ids, size, output);
-    return output;
-  }
 
   // Hold back a potential multi-token stop suffix. The max with the decoder
   // offset also keeps delayed streaming callbacks from moving it backwards.
@@ -819,23 +666,10 @@ SequenceOutput Sequence::generate_output(const Tokenizer& tokenizer) {
   // NOTE: enable_schedule_overlap will generate an extra '-1' token.
   // we need to ignore these '-1' tokens.
   const auto ids = tokens();
-  size_t size;
-  for (auto i = num_tokens_ - 1; i >= 0; --i) {
-    if (tokens_[i] >= 0) {
-      size = i + 1;
-      break;
-    }
-  }
-
-  // 3. generate onerec output
-  if (is_onerec_model()) {
-    generate_onerec_output(ids, size, tokenizer, output);
-    return output;
-  }
-
+  const size_t size = num_valid_tokens();
   const size_t decodable_token_count = get_decodable_token_count(size);
 
-  // 4. generate tokens output
+  // 3. generate tokens output
   output.index = index_;
   if (output_embedding_.defined()) {
     output.embedding = output_embedding_;
@@ -1013,7 +847,8 @@ bool Sequence::finished() const {
     return finished_;
   }
 
-  if (is_onerec_model() && num_tokens_ == num_prompt_tokens_) {
+  if (requires_generated_token_to_finish() &&
+      num_tokens_ == num_prompt_tokens_) {
     return false;
   }
 

--- a/xllm/core/framework/request/sequence.h
+++ b/xllm/core/framework/request/sequence.h
@@ -123,8 +123,14 @@ struct SequenceParams {
   std::shared_ptr<SpeculativeTokenStats> speculative_token_stats;
 };
 
-class Sequence final {
+// One generation stream of a request: the token buffer, KV/logprob state,
+// stopping and timing bookkeeping, and the detokenizing output path of a plain
+// LLM / VLM request. Request kinds whose sequences behave differently derive
+// from it (see RecSequence / OneRecSequence) and override the few hooks below;
+// create_sequence() picks the concrete type.
+class Sequence {
  public:
+  // Decoder seeded by the prompt tokens (LLM / VLM).
   Sequence(size_t index,
            const std::vector<int32_t>& prompt_token_ids,
            torch::Tensor input_embedding,
@@ -134,6 +140,13 @@ class Sequence final {
 
   Sequence(const Sequence& other);
   Sequence(const Sequence& other, size_t index);
+  virtual ~Sequence() = default;
+
+  // Polymorphic copy for beam / best_of expansion: same request, new index.
+  // Derived types return their own type so no state is sliced away.
+  virtual std::unique_ptr<Sequence> fork(size_t index) const;
+
+  size_t index() const { return index_; }
 
   // get mm data
   const MMData& mm_data() const { return mm_data_; }
@@ -324,11 +337,11 @@ class Sequence final {
 
   // get the output of the sequence until the specified number of tokens,
   // returns nullopt if no delta text and not finished
-  std::optional<SequenceOutput> generate_streaming_output(
+  virtual std::optional<SequenceOutput> generate_streaming_output(
       size_t size,
       const Tokenizer& tokenizer);
   // get the full output of the sequence
-  SequenceOutput generate_output(const Tokenizer& tokenizer);
+  virtual SequenceOutput generate_output(const Tokenizer& tokenizer);
   SequenceOutput generate_output();
   void generate_sample_outputs(std::vector<SequenceOutput>& outputs,
                                const Tokenizer& tokenizer);
@@ -455,29 +468,6 @@ class Sequence final {
   // re-evaluated from current tokens.
   void reset_finish_state_for_beam_search();
 
-  // Multi-round beam search result caching
-  void set_beam_result(int32_t bw,
-                       int32_t total_rounds,
-                       const std::vector<std::vector<int32_t>>& flat,
-                       const std::vector<float>& last_logprobs) {
-    beam_width_cached_ = bw;
-    total_rounds_cached_ = total_rounds;
-    beam_seq_group_flat_ = flat;
-    beam_last_logprobs_ = last_logprobs;
-  }
-  bool has_beam_result() const {
-    return beam_width_cached_ > 0 && total_rounds_cached_ > 0 &&
-           !beam_seq_group_flat_.empty();
-  }
-  const std::vector<std::vector<int32_t>>& beam_seq_group_flat() const {
-    return beam_seq_group_flat_;
-  }
-  const std::vector<float>& beam_last_logprobs() const {
-    return beam_last_logprobs_;
-  }
-  int32_t beam_width_cached() const { return beam_width_cached_; }
-  int32_t total_rounds_cached() const { return total_rounds_cached_; }
-
   LogprobState* logprob_state() { return &logprob_state_; }
   void set_estimated_latency(double estimated_latency) {
     estimated_latency_ = estimated_latency;
@@ -491,30 +481,7 @@ class Sequence final {
   // get sequence id
   int32_t seq_id() const { return seq_id_; }
 
-  const std::vector<int32_t>& encoder_tokens() const {
-    static const std::vector<int32_t> kEmpty;
-    if (!onerec_state_.has_value()) {
-      return kEmpty;
-    }
-    return onerec_state_->encoder_tokens;
-  }
-
-  size_t encoder_seq_len() const {
-    return onerec_state_.has_value() ? onerec_state_->num_encoder_tokens : 0;
-  }
-
-  size_t num_decoder_embeddings() const {
-    return onerec_state_.has_value() ? onerec_state_->num_decoder_embeddings
-                                     : 0;
-  }
-
   RecType rec_type() const { return sequence_params_.rec_type; }
-  bool is_onerec_model() const {
-    return sequence_params_.rec_type == RecType::kOneRec;
-  }
-
-  static const std::string ENCODER_SPARSE_EMBEDDING_NAME;
-  static const std::string DECODER_CONTEXT_EMBEDDING_NAME;
 
   void set_cancel() { cancelled_.store(true, std::memory_order_relaxed); }
 
@@ -528,7 +495,42 @@ class Sequence final {
     return last_token_handled_.load(std::memory_order_relaxed);
   }
 
+ protected:
+  // How a derived type seeds the decoder instead of using the prompt tokens:
+  // `num_bos_tokens` BOS tokens in a buffer of `capacity` slots.
+  struct DecoderSeed {
+    size_t num_bos_tokens = 0;
+    size_t capacity = 0;
+  };
+
+  // Decoder seeded by BOS tokens (OneRec). `force_token_logprobs` keeps the
+  // per-token logprob buffer allocated even when the request did not ask for
+  // logprobs, for derived types that emit them in their output anyway.
+  Sequence(size_t index,
+           const DecoderSeed& seed,
+           torch::Tensor input_embedding,
+           const MMData& mm_data,
+           const IncrementalDecoder& incremental_decoder,
+           const SequenceParams& seq_params,
+           bool force_token_logprobs);
+
+  // Hooks for derived types. Defaults are the plain LLM behavior.
+  // Whether a token may be appended before any KV cache has been filled.
+  virtual bool allows_append_before_prefill() const { return false; }
+  // Whether the sequence can only be finished once it generated a token.
+  virtual bool requires_generated_token_to_finish() const { return false; }
+
+  // Read access for derived output paths.
+  const SequenceParams& sequence_params() const { return sequence_params_; }
+  const torch::Tensor& output_embedding() const { return output_embedding_; }
+  // Number of leading tokens that are real: trailing placeholder tokens (< 0,
+  // appended under schedule overlap) are excluded.
+  size_t num_valid_tokens() const;
+
  private:
+  void init_request_state();
+  void init_logprob_state(bool force_token_logprobs);
+
   void record_first_token(const Token& token);
   bool try_commit_json_object_token(int32_t token_id, int64_t token_offset);
 
@@ -549,23 +551,6 @@ class Sequence final {
   void generate_embeddings_output(SequenceOutput& output);
   void generate_mm_embeddings_output(SequenceOutput& output);
 
-  void init_onerec_sequence(const std::vector<int32_t>& prompt_token_ids,
-                            torch::Tensor input_embedding);
-
-  void generate_onerec_streaming_output(const Slice<int32_t>& ids,
-                                        size_t size,
-                                        SequenceOutput& output) const;
-
-  void generate_onerec_output(const Slice<int32_t>& ids,
-                              size_t size,
-                              const Tokenizer& tokenizer,
-                              SequenceOutput& output) const;
-
-  struct OneRecState {
-    size_t num_encoder_tokens = 0;
-    size_t num_decoder_embeddings = 0;
-    std::vector<int32_t> encoder_tokens;
-  };
   int32_t wait_time_ms_ = 0;
   double estimated_latency_ = 0.0;
 
@@ -658,8 +643,6 @@ class Sequence final {
   // computed).
   uint32_t linear_hash_stride_ = 0;
 
-  std::optional<OneRecState> onerec_state_;
-
   std::optional<JsonObjectGrammarState> json_object_state_;
 
   // NOTE: MUST FIXME Later
@@ -719,12 +702,6 @@ class Sequence final {
 
   // whether the last token is handled
   std::atomic<bool> last_token_handled_{false};
-
-  // Multi-round beam search result caching
-  int32_t beam_width_cached_ = 0;
-  int32_t total_rounds_cached_ = 0;
-  std::vector<std::vector<int32_t>> beam_seq_group_flat_;
-  std::vector<float> beam_last_logprobs_;
 
   // Mark whether the sequence has new token updates in current decode step.
   // This is only consumed by software beam search to distinguish:

--- a/xllm/core/framework/request/sequence_factory.cpp
+++ b/xllm/core/framework/request/sequence_factory.cpp
@@ -1,0 +1,63 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "core/framework/request/sequence_factory.h"
+
+#include <glog/logging.h>
+
+#include <memory>
+#include <utility>
+
+#include "core/framework/request/onerec_sequence.h"
+#include "core/framework/request/rec_sequence.h"
+#include "core/framework/request/rec_type.h"
+
+namespace xllm {
+
+std::unique_ptr<Sequence> create_sequence(
+    size_t index,
+    const std::vector<int32_t>& prompt_token_ids,
+    torch::Tensor input_embedding,
+    const MMData& mm_data,
+    const IncrementalDecoder& incremental_decoder,
+    const SequenceParams& seq_params) {
+  switch (seq_params.rec_type) {
+    case RecType::kNone:
+      return std::make_unique<Sequence>(index,
+                                        prompt_token_ids,
+                                        std::move(input_embedding),
+                                        mm_data,
+                                        incremental_decoder,
+                                        seq_params);
+    case RecType::kLlmRec:
+      return std::make_unique<LlmRecSequence>(index,
+                                              prompt_token_ids,
+                                              std::move(input_embedding),
+                                              mm_data,
+                                              incremental_decoder,
+                                              seq_params);
+    case RecType::kOneRec:
+      return std::make_unique<OneRecSequence>(index,
+                                              prompt_token_ids,
+                                              std::move(input_embedding),
+                                              mm_data,
+                                              incremental_decoder,
+                                              seq_params);
+  }
+  LOG(FATAL) << "unknown rec type " << static_cast<int>(seq_params.rec_type);
+  return nullptr;
+}
+
+}  // namespace xllm

--- a/xllm/core/framework/request/sequence_factory.h
+++ b/xllm/core/framework/request/sequence_factory.h
@@ -1,0 +1,38 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/jd-opensource/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "core/framework/request/sequence.h"
+
+namespace xllm {
+
+// Creates the Sequence type matching `seq_params.rec_type`: a plain Sequence
+// for LLM / VLM requests, LlmRecSequence or OneRecSequence for recommendation
+// requests.
+std::unique_ptr<Sequence> create_sequence(
+    size_t index,
+    const std::vector<int32_t>& prompt_token_ids,
+    torch::Tensor input_embedding,
+    const MMData& mm_data,
+    const IncrementalDecoder& incremental_decoder,
+    const SequenceParams& seq_params);
+
+}  // namespace xllm

--- a/xllm/core/framework/request/sequences_group.cpp
+++ b/xllm/core/framework/request/sequences_group.cpp
@@ -21,6 +21,8 @@ limitations under the License.
 
 #include "common/global_flags.h"
 #include "core/framework/config/rec_config.h"
+#include "core/framework/request/rec_sequence.h"
+#include "core/framework/request/sequence_factory.h"
 #include "core/util/rec_model_utils.h"
 #include "framework/batch/beam_search.h"
 #include "util/blocking_counter.h"
@@ -47,12 +49,12 @@ void SequencesGroup::add() {
                              prompt_tokens_.size(),
                              sequence_params_.echo,
                              sequence_params_.skip_special_tokens);
-  sequences_.emplace_back(std::make_unique<Sequence>(index,
-                                                     prompt_tokens_,
-                                                     input_embedding_,
-                                                     mm_data_,
-                                                     std::move(decoder),
-                                                     sequence_params_));
+  sequences_.emplace_back(create_sequence(index,
+                                          prompt_tokens_,
+                                          input_embedding_,
+                                          mm_data_,
+                                          std::move(decoder),
+                                          sequence_params_));
 }
 
 bool SequencesGroup::finished() const {
@@ -128,8 +130,10 @@ void SequencesGroup::generate_outputs(std::vector<SequenceOutput>& outputs,
   // Check for multi-round beam search results
   if (is_rec_multi_round_mode() && check_beam_search() &&
       sequences_.size() == 1) {
-    auto* base = sequences_[0].get();
-    if (base->has_beam_result()) {
+    // Multi-round mode is a deployment-wide flag; only REC sequences carry a
+    // device-side beam result.
+    const auto* base = dynamic_cast<const RecSequence*>(sequences_[0].get());
+    if (base != nullptr && base->beam_search_result().ready()) {
       generate_multi_round_output(outputs, tokenizer, *base);
       return;
     }
@@ -374,11 +378,11 @@ void SequencesGroup::process_beam_search(bool force_requested_result_size) {
     CHECK_LT(candidate.source_index, sequences_.size());
     CHECK(sequences_[candidate.source_index] != nullptr);
     if (i < existing_size) {
-      replacement_sequences[i] = std::make_unique<Sequence>(
-          *sequences_[candidate.source_index], /*index=*/i);
+      replacement_sequences[i] =
+          sequences_[candidate.source_index]->fork(/*index=*/i);
     } else {
-      tail_sequences.emplace_back(std::make_unique<Sequence>(
-          *sequences_[candidate.source_index], /*index=*/i));
+      tail_sequences.emplace_back(
+          sequences_[candidate.source_index]->fork(/*index=*/i));
     }
   }
 
@@ -455,9 +459,10 @@ void SequencesGroup::finish() {
 void SequencesGroup::generate_multi_round_output(
     std::vector<SequenceOutput>& outputs,
     const Tokenizer& tokenizer,
-    const Sequence& base) {
-  size_t bw = static_cast<size_t>(base.beam_width_cached());
-  const auto& last_lps = base.beam_last_logprobs();
+    const RecSequence& base) {
+  const RecBeamSearchResult& beam_result = base.beam_search_result();
+  size_t bw = static_cast<size_t>(beam_result.beam_width());
+  const auto& last_lps = beam_result.last_logprobs();
 
   // Rank by logprob
   std::vector<std::pair<float, size_t>> rank;
@@ -470,8 +475,7 @@ void SequencesGroup::generate_multi_round_output(
     return l.first > r.first;
   });
 
-  const auto& flat2d = base.beam_seq_group_flat();
-  size_t rounds = static_cast<size_t>(base.total_rounds_cached());
+  const auto& flat2d = beam_result.beams();
   outputs.reserve(bw);
 
   for (size_t i = 0; i < bw; ++i) {

--- a/xllm/core/framework/request/sequences_group.h
+++ b/xllm/core/framework/request/sequences_group.h
@@ -32,6 +32,8 @@ limitations under the License.
 
 namespace xllm {
 
+class RecSequence;
+
 class SequencesGroup {
  public:
   SequencesGroup(const std::string& prompt,
@@ -75,7 +77,7 @@ class SequencesGroup {
   // Generate output for multi-round beam search
   void generate_multi_round_output(std::vector<SequenceOutput>& outputs,
                                    const Tokenizer& tokenizer,
-                                   const Sequence& base);
+                                   const RecSequence& base);
 
  private:
   const std::string& prompt_;                  // ref from request


### PR DESCRIPTION
Sequence carried OneRec's encoder/decoder layout, the multi-round beam result cache and a set of is_onerec_model() branches (decoder seeding, append-before-prefill, finish rule, output format) that every LLM / VLM request paid for and every reader had to know about.

- Sequence is now the plain LLM / VLM sequence and the non-final base: it keeps the shared state (tokens, KV / logprob state, stopping, timing, block hashes, mm_data) and exposes a protected BOS-seeded constructor plus two small virtual hooks (allows_append_before_prefill, requires_generated_token_to_finish); the output methods are virtual. All REC state, accessors and constants are gone from it.
- RecSequence owns the device-side RecBeamSearchResult (written by both the OneRec x-attention and the LlmRec multi-round pipelines); a fork starts with an empty result. LlmRecSequence is the prompt-driven REC decoder; OneRecSequence derives its encoder/decoder layout from the prompt or the sparse / context embeddings in mm_data, seeds the decoder with BOS, and produces the raw-id / SKU-logprob / item output.
- Forks go through virtual fork(index) so beam / best_of expansion never slices a derived sequence; create_sequence() picks the concrete type from SequenceParams::rec_type at the single creation site in SequencesGroup.
- REC-only readers (Batch beam output, SequencesGroup multi-round output, the OneRec input builders) reach REC state through RecSequence::from() / OneRecSequence::from() instead of base-class accessors; the beam rows are moved into the result instead of copied.
- Add rec_sequence_test covering factory selection, typed access, beam result / fork semantics, OneRec layout derivation and output.

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
