### PR TITLE
perf: add per-hop benchmarks for the api_service -> executor request path.

### DIFF
--- a/xllm/api_service/CMakeLists.txt
+++ b/xllm/api_service/CMakeLists.txt
@@ -1,4 +1,5 @@
 include(cc_library)
+include(cc_binary)
 
 cc_library(
   NAME
@@ -68,3 +69,27 @@ cc_library(
     torch
     $<$<BOOL:${USE_NPU}>:torch_npu>
 )
+
+# Request-path hop 1: JSON -> proto -> RequestParams, response proto -> JSON.
+cc_binary(
+  NAME
+    api_service_benchmark
+  SRCS
+    api_service_benchmark.cpp
+  DEPS
+    :api_service
+    proto::xllm_proto
+    torch
+    benchmark::benchmark
+    benchmark::benchmark_main
+)
+target_link_libraries(api_service_benchmark
+                      PUBLIC
+                      Python::Python
+                      $<$<BOOL:${USE_NPU}>:ascendcl>
+                      $<$<BOOL:${USE_NPU}>:hccl>
+                      $<$<BOOL:${USE_NPU}>:c_sec>
+                      $<$<BOOL:${USE_NPU}>:nnopbase>)
+target_link_options(api_service_benchmark
+                    PRIVATE
+                    $<$<BOOL:${USE_MLU}>:-Wl,--no-as-needed>)

--- a/xllm/api_service/api_service_benchmark.cpp
+++ b/xllm/api_service/api_service_benchmark.cpp
@@ -1,0 +1,367 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Hop 1 of the request path: api_service.
+//
+// Micro-benchmarks for the CPU work the API layer performs on every request
+// before it hands off to LLMMaster, and on every streamed token on the way
+// back out. None of this touches the model or a device.
+//
+//   Ingress (APIService::CompletionsHttp / ChatCompletionsHttp):
+//   * BM_ApiService_CompletionJsonToProto   - preprocess_completion_prompt +
+//                                             json2pb::JsonToProtoMessage
+//   * BM_ApiService_ChatJsonToProto         - LlmChatJsonParser::preprocess +
+//                                             protobuf JsonStringToMessage
+//   * BM_ApiService_RequestParamsFromCompletion - proto -> RequestParams
+//   * BM_ApiService_RequestParamsFromChat       - proto -> RequestParams
+//
+//   Egress (send_delta_to_client_brpc / send_result_to_client_brpc):
+//   * BM_ApiService_StreamChunkToJson - one SSE delta: build the
+//                                       CompletionResponse chunk and serialize
+//                                       it with json2pb the way StreamCall
+//                                       does. This is the per-token cost of a
+//                                       streaming request.
+//   * BM_ApiService_ResultToJson      - one non-stream result with n generated
+//                                       tokens (+ logprobs) -> JSON.
+//
+// Build & run (example):
+//   python setup.py test --test-name api_service_benchmark
+//   ./api_service_benchmark --benchmark_min_time=0.2s
+
+#include <benchmark/benchmark.h>
+#include <butil/iobuf.h>
+#include <google/protobuf/util/json_util.h>
+#include <json2pb/json_to_pb.h>
+#include <json2pb/pb_to_json.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "api_service/chat_json_parser.h"
+#include "api_service/completion_json_parser.h"
+#include "api_service/serving_mode.h"
+#include "chat.pb.h"
+#include "completion.pb.h"
+#include "core/framework/request/request_output.h"
+#include "core/framework/request/request_params.h"
+#include "core/framework/request/usage.h"
+
+namespace xllm {
+namespace {
+
+// benchmark 1.8.x exposes only DoNotOptimize(Tp const&) -- deprecated -- and
+// DoNotOptimize(Tp&); there is no rvalue overload, so a temporary or a const
+// local resolves to the deprecated one. Sinking the value into a non-const
+// parameter first selects the supported overload.
+template <typename T>
+inline BENCHMARK_ALWAYS_INLINE void do_not_optimize(T value) {
+  benchmark::DoNotOptimize(value);
+}
+
+constexpr char kModel[] = "bench-model";
+constexpr char kRequestId[] = "cmpl-0123456789abcdef0123456789abcdef";
+constexpr uint32_t kCreatedTime = 1700000000;
+
+std::string make_completion_json(size_t prompt_chars) {
+  std::string json = R"({"model":"bench-model","prompt":")";
+  json.append(prompt_chars, 'x');
+  json += R"(","max_tokens":128,"temperature":0.7,"top_p":0.9,)";
+  json += R"("stream":true,"stop":["</s>","<|im_end|>"]})";
+  return json;
+}
+
+std::string make_chat_json(size_t num_messages) {
+  std::string json = R"({"model":"bench-model","messages":[)";
+  json += R"({"role":"system","content":"You are a helpful assistant."})";
+  for (size_t i = 1; i < num_messages; ++i) {
+    json += (i % 2 == 1) ? R"(,{"role":"user","content":")"
+                         : R"(,{"role":"assistant","content":")";
+    json.append(256, 'y');
+    json += R"("})";
+  }
+  json += R"(],"max_tokens":128,"temperature":0.7,"stream":true})";
+  return json;
+}
+
+proto::CompletionRequest make_completion_request(size_t prompt_chars) {
+  proto::CompletionRequest request;
+  request.set_model(kModel);
+  request.set_prompt(std::string(prompt_chars, 'x'));
+  request.set_max_tokens(128);
+  request.set_temperature(0.7f);
+  request.set_top_p(0.9f);
+  request.set_stream(true);
+  request.add_stop("</s>");
+  request.add_stop("<|im_end|>");
+  request.add_stop_token_ids(2);
+  return request;
+}
+
+proto::ChatRequest make_chat_request(size_t num_messages) {
+  proto::ChatRequest request;
+  request.set_model(kModel);
+  auto* system = request.add_messages();
+  system->set_role("system");
+  system->set_content("You are a helpful assistant.");
+  for (size_t i = 1; i < num_messages; ++i) {
+    auto* message = request.add_messages();
+    message->set_role((i % 2 == 1) ? "user" : "assistant");
+    message->set_content(std::string(256, 'y'));
+  }
+  request.set_max_tokens(128);
+  request.set_temperature(0.7f);
+  request.set_stream(true);
+  request.add_stop("</s>");
+  return request;
+}
+
+// Mirrors the Pb2JsonOptions StreamCall configures in its constructor.
+json2pb::Pb2JsonOptions stream_call_json_options() {
+  json2pb::Pb2JsonOptions options;
+  options.bytes_to_base64 = false;
+  options.jsonify_empty_array = false;
+  return options;
+}
+
+std::vector<LogProb> make_logprobs(size_t num_tokens) {
+  std::vector<LogProb> logprobs;
+  logprobs.reserve(num_tokens);
+  for (size_t i = 0; i < num_tokens; ++i) {
+    LogProb logprob;
+    logprob.token = "tok";
+    logprob.token_id = static_cast<int32_t>(1000 + i);
+    logprob.logprob = -0.25f;
+    logprobs.emplace_back(std::move(logprob));
+  }
+  return logprobs;
+}
+
+// Same field-by-field copy CompletionServiceImpl's set_logprobs performs.
+void set_logprobs(proto::Choice* choice,
+                  const std::optional<std::vector<LogProb>>& logprobs) {
+  if (!logprobs.has_value() || logprobs->empty()) {
+    return;
+  }
+  auto* proto_logprobs = choice->mutable_logprobs();
+  for (const auto& logprob : *logprobs) {
+    proto_logprobs->add_tokens(logprob.token);
+    proto_logprobs->add_token_ids(logprob.token_id);
+    proto_logprobs->add_token_logprobs(logprob.logprob);
+  }
+}
+
+// Same as StreamCall::write minus the brpc ProgressiveAttachment::Write.
+bool write_sse_chunk(const proto::CompletionResponse& response,
+                     const json2pb::Pb2JsonOptions& options,
+                     butil::IOBuf* io_buf) {
+  io_buf->clear();
+  io_buf->append("data: ");
+  butil::IOBufAsZeroCopyOutputStream json_output(io_buf);
+  std::string err_msg;
+  if (!json2pb::ProtoMessageToJson(response, &json_output, options, &err_msg)) {
+    return false;
+  }
+  io_buf->append("\n\n");
+  return true;
+}
+
+// --------------------------------------------------------------------------
+// Ingress
+// --------------------------------------------------------------------------
+
+void BM_ApiService_CompletionJsonToProto(benchmark::State& state) {
+  const std::string body =
+      make_completion_json(static_cast<size_t>(state.range(0)));
+  proto::CompletionRequest request;
+
+  for (auto _ : state) {
+    // preprocess_completion_prompt takes the body by value, exactly like the
+    // HTTP handler hands it `request_attachment().to_string()`.
+    auto [status, processed_json] = preprocess_completion_prompt(body);
+    request.Clear();
+    std::string error;
+    json2pb::Json2PbOptions options;
+    const bool ok =
+        json2pb::JsonToProtoMessage(processed_json, &request, options, &error);
+    do_not_optimize(ok);
+    do_not_optimize(request.prompt().data());
+  }
+  state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) *
+                          static_cast<int64_t>(body.size()));
+}
+
+void BM_ApiService_ChatJsonToProto(benchmark::State& state) {
+  const std::string body = make_chat_json(static_cast<size_t>(state.range(0)));
+  const ChatJsonParser& parser = ChatJsonParser::get(ServingMode::LLM);
+  proto::ChatRequest request;
+
+  for (auto _ : state) {
+    auto [status, processed_json] = parser.preprocess(body);
+    request.Clear();
+    google::protobuf::util::JsonParseOptions options;
+    options.ignore_unknown_fields = true;
+    const auto parse_status = google::protobuf::util::JsonStringToMessage(
+        processed_json, &request, options);
+    do_not_optimize(parse_status.ok());
+    do_not_optimize(request.messages_size());
+  }
+  state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) *
+                          static_cast<int64_t>(body.size()));
+}
+
+void BM_ApiService_RequestParamsFromCompletion(benchmark::State& state) {
+  const proto::CompletionRequest request =
+      make_completion_request(static_cast<size_t>(state.range(0)));
+  const std::string x_request_id = "x-rid";
+  const std::string x_request_time = "x-rtime";
+
+  for (auto _ : state) {
+    RequestParams params(request, x_request_id, x_request_time);
+    do_not_optimize(params.request_id.data());
+    do_not_optimize(params.stop.has_value());
+  }
+}
+
+void BM_ApiService_RequestParamsFromChat(benchmark::State& state) {
+  const proto::ChatRequest request =
+      make_chat_request(static_cast<size_t>(state.range(0)));
+  const std::string x_request_id = "x-rid";
+  const std::string x_request_time = "x-rtime";
+
+  for (auto _ : state) {
+    RequestParams params(request, x_request_id, x_request_time);
+    do_not_optimize(params.request_id.data());
+    do_not_optimize(params.stop.has_value());
+  }
+}
+
+// --------------------------------------------------------------------------
+// Egress
+// --------------------------------------------------------------------------
+
+// range(0): number of logprob entries carried by the delta (0 = logprobs off).
+void BM_ApiService_StreamChunkToJson(benchmark::State& state) {
+  const size_t num_logprobs = static_cast<size_t>(state.range(0));
+  SequenceOutput seq_output;
+  seq_output.index = 0;
+  seq_output.text = "Hello";
+  if (num_logprobs > 0) {
+    seq_output.logprobs = make_logprobs(num_logprobs);
+  }
+  const json2pb::Pb2JsonOptions options = stream_call_json_options();
+  proto::CompletionResponse response;
+  butil::IOBuf io_buf;
+
+  for (auto _ : state) {
+    // Text delta chunk, as built by send_delta_to_client_brpc.
+    response.Clear();
+    response.set_object("text_completion");
+    response.set_id(kRequestId);
+    response.set_created(kCreatedTime);
+    response.set_model(kModel);
+    auto* choice = response.add_choices();
+    choice->set_index(static_cast<uint32_t>(seq_output.index));
+    choice->set_text(seq_output.text);
+    set_logprobs(choice, seq_output.logprobs);
+    const bool ok = write_sse_chunk(response, options, &io_buf);
+    do_not_optimize(ok);
+    do_not_optimize(io_buf.size());
+  }
+}
+
+// range(0): number of generated tokens in the finished (non-stream) result.
+void BM_ApiService_ResultToJson(benchmark::State& state) {
+  const size_t num_tokens = static_cast<size_t>(state.range(0));
+  RequestOutput req_output;
+  SequenceOutput seq_output;
+  seq_output.index = 0;
+  seq_output.text = std::string(num_tokens * 4, 'z');
+  seq_output.finish_reason = "stop";
+  seq_output.logprobs = make_logprobs(num_tokens);
+  req_output.outputs.emplace_back(std::move(seq_output));
+  Usage usage;
+  usage.num_prompt_tokens = 128;
+  usage.num_generated_tokens = static_cast<int32_t>(num_tokens);
+  usage.num_total_tokens = usage.num_prompt_tokens + usage.num_generated_tokens;
+  req_output.usage = usage;
+  const json2pb::Pb2JsonOptions options = stream_call_json_options();
+  proto::CompletionResponse response;
+  butil::IOBuf io_buf;
+
+  for (auto _ : state) {
+    // Result proto, as built by send_result_to_client_brpc ...
+    response.Clear();
+    response.set_object("text_completion");
+    response.set_id(kRequestId);
+    response.set_created(kCreatedTime);
+    response.set_model(kModel);
+    response.mutable_choices()->Reserve(
+        static_cast<int32_t>(req_output.outputs.size()));
+    for (const auto& output : req_output.outputs) {
+      auto* choice = response.add_choices();
+      choice->set_index(static_cast<uint32_t>(output.index));
+      choice->set_text(output.text);
+      set_logprobs(choice, output.logprobs);
+      choice->set_finish_reason(output.finish_reason.value());
+    }
+    auto* proto_usage = response.mutable_usage();
+    proto_usage->set_prompt_tokens(req_output.usage->num_prompt_tokens);
+    proto_usage->set_completion_tokens(req_output.usage->num_generated_tokens);
+    proto_usage->set_total_tokens(req_output.usage->num_total_tokens);
+    // ... then serialized as StreamCall::write_and_finish does.
+    io_buf.clear();
+    butil::IOBufAsZeroCopyOutputStream json_output(&io_buf);
+    std::string err_msg;
+    const bool ok =
+        json2pb::ProtoMessageToJson(response, &json_output, options, &err_msg);
+    do_not_optimize(ok);
+    do_not_optimize(io_buf.size());
+  }
+}
+
+// Prompt length in characters: 64 chars .. 64K chars.
+BENCHMARK(BM_ApiService_CompletionJsonToProto)
+    ->RangeMultiplier(8)
+    ->Range(64, 64 << 10)
+    ->Unit(benchmark::kMicrosecond);
+// Conversation length in messages.
+BENCHMARK(BM_ApiService_ChatJsonToProto)
+    ->RangeMultiplier(4)
+    ->Range(1, 64)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_ApiService_RequestParamsFromCompletion)
+    ->RangeMultiplier(8)
+    ->Range(64, 64 << 10)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_ApiService_RequestParamsFromChat)
+    ->RangeMultiplier(4)
+    ->Range(1, 64)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_ApiService_StreamChunkToJson)
+    ->Arg(0)
+    ->Arg(1)
+    ->Unit(benchmark::kNanosecond);
+// Generated tokens in the final result.
+BENCHMARK(BM_ApiService_ResultToJson)
+    ->RangeMultiplier(8)
+    ->Range(8, 4096)
+    ->Unit(benchmark::kMicrosecond);
+
+}  // namespace
+}  // namespace xllm

--- a/xllm/core/framework/batch/CMakeLists.txt
+++ b/xllm/core/framework/batch/CMakeLists.txt
@@ -32,3 +32,30 @@ cc_library(
     glog::glog
     xxHash
 )
+
+# Request-path hop 4: Batch -> ForwardInput -> packed proto -> worker output
+# proto -> Batch::process_sample_output (all host-side, CPU tensors).
+cc_binary(
+  NAME
+    batch_benchmark
+  SRCS
+    batch_benchmark.cpp
+  DEPS
+    :config
+    :batch
+    torch
+    benchmark::benchmark
+    benchmark::benchmark_main
+    $<$<BOOL:${USE_MLU}>:torch_mlu>
+    $<$<BOOL:${USE_NPU}>:torch_npu>
+)
+target_link_libraries(batch_benchmark
+                      PUBLIC
+                      Python::Python
+                      $<$<BOOL:${USE_NPU}>:ascendcl>
+                      $<$<BOOL:${USE_NPU}>:hccl>
+                      $<$<BOOL:${USE_NPU}>:c_sec>
+                      $<$<BOOL:${USE_NPU}>:nnopbase>)
+target_link_options(batch_benchmark
+                    PRIVATE
+                    $<$<BOOL:${USE_MLU}>:-Wl,--no-as-needed>)

--- a/xllm/core/framework/batch/batch_benchmark.cpp
+++ b/xllm/core/framework/batch/batch_benchmark.cpp
@@ -1,0 +1,512 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Hop 4 of the request path: Batch -> ForwardInput -> worker -> output.
+//
+// Once the scheduler has built a Batch, LLMEngine::step turns it into a
+// ForwardInput (BatchInputBuilder), serialises that for the remote worker
+// (packed proto), the worker unpacks it before the H2D copy, and after the
+// model + sampler have run the worker serialises the sampled tokens back
+// (proto::ForwardOutput), which the engine turns into a RawForwardOutput and
+// feeds to Batch::process_sample_output. Everything here is host-side CPU work
+// and is timed with CPU tensors; the model forward, sampler and device copies
+// are the only steps of the pipeline that are not covered.
+//
+//   * BM_BlockManagerPool_AllocateRelease - prefix match + block allocation
+//                                           + release for one prompt.
+//   * BM_Batch_PrepareForwardInput_Prefill - BatchInputBuilder for one prefill
+//                                            sequence, swept over prompt
+//                                            length.
+//   * BM_Batch_PrepareForwardInput_Decode  - BatchInputBuilder for N decode
+//                                            sequences.
+//   * BM_ForwardInput_ToPackedProto   - engine side: ForwardInput -> proto.
+//   * BM_ForwardInput_FromPackedProto - worker side: proto -> ForwardInput
+//                                       (lazy) -> unpacked host tensors.
+//   * BM_ForwardOutput_ToProto        - worker side: sampled tensors -> proto.
+//   * BM_ForwardOutput_FromProto      - engine side: proto -> RawForwardOutput.
+//   * BM_Batch_ProcessSampleOutput    - RawForwardOutput -> Sequence::
+//                                       append_token for N sequences.
+//
+// Build & run (example):
+//   python setup.py test --test-name batch_benchmark
+//   ./batch_benchmark --benchmark_min_time=0.2s
+
+#include <benchmark/benchmark.h>
+#include <glog/logging.h>
+#include <torch/torch.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "core/common/types.h"
+#include "core/framework/batch/batch.h"
+#include "core/framework/block/block.h"
+#include "core/framework/block/block_manager_pool.h"
+#include "core/framework/model/model_args.h"
+#include "core/framework/multimodal/mm_data.h"
+#include "core/framework/request/incremental_decoder.h"
+#include "core/framework/request/sequence.h"
+#include "core/framework/request/stopping_checker.h"
+#include "core/framework/sampling/sampling_params.h"
+#include "core/runtime/forward_params.h"
+#include "core/runtime/params_utils.h"
+#include "core/util/threadpool.h"
+#include "worker.pb.h"
+
+namespace xllm {
+namespace {
+
+// benchmark 1.8.x exposes only DoNotOptimize(Tp const&) -- deprecated -- and
+// DoNotOptimize(Tp&); there is no rvalue overload, so a temporary or a const
+// local resolves to the deprecated one. Sinking the value into a non-const
+// parameter first selects the supported overload.
+template <typename T>
+inline BENCHMARK_ALWAYS_INLINE void do_not_optimize(T value) {
+  benchmark::DoNotOptimize(value);
+}
+
+constexpr int32_t kBlockSize = 128;
+constexpr uint32_t kNumBlocks = 16384;
+constexpr uint32_t kMaxSeqsPerBatch = 1024;
+constexpr size_t kDecodePromptTokens = 512;
+// LLMEngine sizes its "LLMEngine.forward_input" pool with 16 threads; the
+// builder only fans out to it above 65536 query tokens.
+constexpr size_t kForwardInputThreads = 16;
+
+// Token ids that do not repeat for ~4M requests (ids are never fed to a model
+// or tokenizer here), so no sequence can hit the prefix cache with an earlier
+// sequence's prompt.
+std::vector<int32_t> next_prompt_tokens(size_t num_tokens) {
+  static int64_t next_token = 0;
+  std::vector<int32_t> tokens(num_tokens);
+  for (int32_t& token : tokens) {
+    token = static_cast<int32_t>(next_token++ %
+                                 std::numeric_limits<int32_t>::max());
+  }
+  return tokens;
+}
+
+// One pool for the whole process. Google Benchmark invokes each BM_* function
+// several times per argument while sizing the run, and tearing down a pool
+// with the prefix cache enabled sleeps for seconds in PrefixCache's
+// destructor; every benchmark releases its blocks, so sharing is safe.
+BlockManagerPool::Options make_block_manager_options() {
+  BlockManagerPool::Options options;
+  options.num_blocks(kNumBlocks)
+      .block_size(kBlockSize)
+      .max_seqs_per_batch(kMaxSeqsPerBatch)
+      .enable_prefix_cache(true);
+  return options;
+}
+
+BlockManagerPool& shared_block_manager_pool() {
+  static BlockManagerPool pool(make_block_manager_options(), /*dp_size=*/1);
+  return pool;
+}
+
+// Owns the per-request parameter objects every Sequence borrows by pointer.
+class SequenceFixture final {
+ public:
+  explicit SequenceFixture(bool logprobs = false) {
+    sampling_param_.logprobs = logprobs;
+    stopping_checker_.set_max_generated_tokens(1 << 20);
+    stopping_checker_.set_ignore_eos(true);
+  }
+
+  // Non-const: SequenceParams holds non-owning mutable pointers to the
+  // sampling param and stopping checker.
+  std::unique_ptr<Sequence> make_sequence(size_t index,
+                                          size_t num_prompt_tokens) {
+    const std::vector<int32_t> prompt_token_ids =
+        next_prompt_tokens(num_prompt_tokens);
+    SequenceParams seq_params;
+    seq_params.seq_capacity = num_prompt_tokens + 64;
+    seq_params.stopping_checker = &stopping_checker_;
+    seq_params.sampling_param = &sampling_param_;
+    seq_params.skip_special_tokens = true;
+    seq_params.echo = false;
+    seq_params.logprobs = sampling_param_.logprobs;
+    seq_params.enable_schedule_overlap = false;
+    IncrementalDecoder decoder(/*prompt=*/"",
+                               num_prompt_tokens,
+                               /*echo=*/false,
+                               /*skip_special_tokens=*/true);
+    return std::make_unique<Sequence>(index,
+                                      prompt_token_ids,
+                                      /*input_embedding=*/torch::Tensor(),
+                                      /*mm_data=*/MMData(),
+                                      decoder,
+                                      seq_params);
+  }
+
+ private:
+  RequestSamplingParam sampling_param_;
+  StoppingChecker stopping_checker_;
+};
+
+// Allocates KV blocks for the whole prompt the way the scheduler does for a
+// prefill: prefix match first, then fresh blocks for the remainder.
+void allocate_prefill(BlockManagerPool& pool, Sequence& sequence) {
+  pool.allocate_shared(&sequence);
+  const bool allocated = pool.allocate(&sequence);
+  CHECK(allocated) << "block manager pool ran out of blocks";
+}
+
+// Moves a prefilled sequence into the decode stage: KV cache covers the prompt
+// and one token has been sampled.
+void advance_to_decode(BlockManagerPool& pool, Sequence& sequence) {
+  sequence.kv_state().set_kv_cache_tokens_num(sequence.num_prompt_tokens());
+  sequence.append_token(Token(/*id=*/1));
+  const bool allocated = pool.allocate(&sequence);
+  CHECK(allocated) << "block manager pool ran out of blocks";
+}
+
+// A decode batch of `batch_size` sequences with blocks allocated from a shared
+// pool, ready for prepare_forward_input. Blocks are released on destruction so
+// the pool can be reused across iterations.
+class DecodeBatchFixture final {
+ public:
+  DecodeBatchFixture(SequenceFixture& sequence_fixture,
+                     BlockManagerPool* pool,
+                     size_t batch_size)
+      : pool_(pool) {
+    sequences_.reserve(batch_size);
+    for (size_t i = 0; i < batch_size; ++i) {
+      sequences_.emplace_back(
+          sequence_fixture.make_sequence(i, kDecodePromptTokens));
+      allocate_prefill(*pool_, *sequences_.back());
+      advance_to_decode(*pool_, *sequences_.back());
+      batch_.add(sequences_.back().get());
+    }
+  }
+
+  ~DecodeBatchFixture() {
+    for (auto& sequence : sequences_) {
+      pool_->deallocate(sequence.get());
+    }
+  }
+
+  DecodeBatchFixture(const DecodeBatchFixture&) = delete;
+  DecodeBatchFixture& operator=(const DecodeBatchFixture&) = delete;
+
+  Batch& batch() { return batch_; }
+
+  // prepare_forward_input advances kv_cache_tokens_num by the tokens it
+  // schedules; rewind so the next call sees the same decode step again.
+  void rewind_kv_cache() {
+    for (auto& sequence : sequences_) {
+      sequence->kv_state().set_kv_cache_tokens_num(
+          sequence->num_prompt_tokens());
+    }
+  }
+
+ private:
+  BlockManagerPool* pool_ = nullptr;
+  std::vector<std::unique_ptr<Sequence>> sequences_;
+  Batch batch_;
+};
+
+ForwardInput build_decode_forward_input(size_t batch_size) {
+  SequenceFixture sequence_fixture;
+  BlockManagerPool& pool = shared_block_manager_pool();
+  DecodeBatchFixture fixture(sequence_fixture, &pool, batch_size);
+  ThreadPool thread_pool(kForwardInputThreads);
+  return fixture.batch().prepare_forward_input(ModelArgs(), &thread_pool);
+}
+
+RawForwardOutput make_raw_output(size_t batch_size, bool logprobs) {
+  RawForwardOutput raw_output;
+  raw_output.outputs.reserve(batch_size);
+  for (size_t i = 0; i < batch_size; ++i) {
+    RawToken token;
+    token.id = static_cast<int64_t>(100 + i);
+    if (logprobs) {
+      token.logprob = -0.5f;
+    }
+    RawSampleOutput sample_output;
+    sample_output.tokens.emplace_back(std::move(token));
+    raw_output.outputs.emplace_back(std::move(sample_output));
+  }
+  return raw_output;
+}
+
+// --------------------------------------------------------------------------
+// Scheduler-side block allocation
+// --------------------------------------------------------------------------
+
+void BM_BlockManagerPool_AllocateRelease(benchmark::State& state) {
+  const size_t num_prompt_tokens = static_cast<size_t>(state.range(0));
+  SequenceFixture sequence_fixture;
+  BlockManagerPool& pool = shared_block_manager_pool();
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    std::unique_ptr<Sequence> sequence =
+        sequence_fixture.make_sequence(/*index=*/0, num_prompt_tokens);
+    state.ResumeTiming();
+
+    allocate_prefill(pool, *sequence);
+    do_not_optimize(sequence->kv_state().num_blocks(BlockType::KV));
+    pool.deallocate(sequence.get());
+
+    state.PauseTiming();
+    sequence.reset();
+    state.ResumeTiming();
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+                          static_cast<int64_t>(num_prompt_tokens));
+}
+
+// --------------------------------------------------------------------------
+// Engine side: Batch -> ForwardInput -> packed proto
+// --------------------------------------------------------------------------
+
+void BM_Batch_PrepareForwardInput_Prefill(benchmark::State& state) {
+  const size_t num_prompt_tokens = static_cast<size_t>(state.range(0));
+  SequenceFixture sequence_fixture;
+  BlockManagerPool& pool = shared_block_manager_pool();
+  std::unique_ptr<Sequence> sequence =
+      sequence_fixture.make_sequence(/*index=*/0, num_prompt_tokens);
+  allocate_prefill(pool, *sequence);
+  ThreadPool thread_pool(kForwardInputThreads);
+  const ModelArgs args;
+
+  for (auto _ : state) {
+    // The builder advances kv_cache_tokens_num past the prompt; rewind so every
+    // iteration builds the same full prefill.
+    sequence->kv_state().set_kv_cache_tokens_num(0);
+    Batch batch(sequence.get());
+    ForwardInput forward_input =
+        batch.prepare_forward_input(args, &thread_pool);
+    do_not_optimize(forward_input.token_ids.data_ptr());
+  }
+  // Return the blocks to the shared pool before the sequence goes away.
+  pool.deallocate(sequence.get());
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+                          static_cast<int64_t>(num_prompt_tokens));
+}
+
+void BM_Batch_PrepareForwardInput_Decode(benchmark::State& state) {
+  const size_t batch_size = static_cast<size_t>(state.range(0));
+  SequenceFixture sequence_fixture;
+  BlockManagerPool& pool = shared_block_manager_pool();
+  DecodeBatchFixture fixture(sequence_fixture, &pool, batch_size);
+  ThreadPool thread_pool(kForwardInputThreads);
+  const ModelArgs args;
+
+  for (auto _ : state) {
+    fixture.rewind_kv_cache();
+    ForwardInput forward_input =
+        fixture.batch().prepare_forward_input(args, &thread_pool);
+    do_not_optimize(forward_input.token_ids.data_ptr());
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+                          static_cast<int64_t>(batch_size));
+}
+
+void BM_ForwardInput_ToPackedProto(benchmark::State& state) {
+  const size_t batch_size = static_cast<size_t>(state.range(0));
+  const ForwardInput forward_input = build_decode_forward_input(batch_size);
+  proto::PackedForwardInput packed_input;
+
+  for (auto _ : state) {
+    packed_input.Clear();
+    const bool ok = forward_input_to_packed_proto(forward_input, &packed_input);
+    do_not_optimize(ok);
+    do_not_optimize(packed_input.ByteSizeLong());
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+                          static_cast<int64_t>(batch_size));
+}
+
+// --------------------------------------------------------------------------
+// Worker side: packed proto -> ForwardInput (host tensors)
+// --------------------------------------------------------------------------
+
+void BM_ForwardInput_FromPackedProto(benchmark::State& state) {
+  const size_t batch_size = static_cast<size_t>(state.range(0));
+  const ForwardInput forward_input = build_decode_forward_input(batch_size);
+  proto::PackedForwardInput packed_input;
+  CHECK(forward_input_to_packed_proto(forward_input, &packed_input));
+  const torch::Device cpu(torch::kCPU);
+
+  for (auto _ : state) {
+    // WorkerService::ExecuteModel: proto -> lazily unpacked ForwardInput ...
+    ForwardInput lazy_input;
+    packed_proto_to_forward_input(packed_input, lazy_input, cpu, nullptr);
+    // ... which the worker materialises into individual host tensors before
+    // the (device-only, not benchmarked) H2D copy.
+    ForwardInput unpacked_input;
+    const bool ok = detail::unpack_from_input_host_buffer(
+        lazy_input,
+        cpu,
+        torch::kFloat32,
+        unpacked_input,
+        /*materialize_device_buffer=*/false);
+    do_not_optimize(ok);
+    do_not_optimize(unpacked_input.token_ids.data_ptr());
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+                          static_cast<int64_t>(batch_size));
+}
+
+// --------------------------------------------------------------------------
+// Worker side: sampled tokens -> proto::ForwardOutput
+// --------------------------------------------------------------------------
+
+// range(0): batch size, range(1): logprobs (0/1).
+void BM_ForwardOutput_ToProto(benchmark::State& state) {
+  const int64_t batch_size = state.range(0);
+  const bool logprobs = state.range(1) != 0;
+  const torch::Tensor next_tokens =
+      torch::arange(batch_size, torch::dtype(torch::kInt64));
+  const torch::Tensor token_logprobs =
+      logprobs ? torch::full({batch_size}, -0.5f, torch::dtype(torch::kFloat32))
+               : torch::Tensor();
+  proto::ForwardOutput pb_output;
+
+  for (auto _ : state) {
+    pb_output.Clear();
+    forward_output_to_proto(next_tokens,
+                            token_logprobs,
+                            /*top_tokens=*/torch::Tensor(),
+                            /*top_logprobs=*/torch::Tensor(),
+                            /*embeddings=*/torch::Tensor(),
+                            /*mm_embeddings=*/{},
+                            /*speculative_token_stats=*/{},
+                            /*expert_load_data=*/torch::Tensor(),
+                            /*prepared_token=*/-1,
+                            /*src_seq_idxes=*/torch::Tensor(),
+                            /*out_tokens=*/torch::Tensor(),
+                            /*out_logprobs=*/torch::Tensor(),
+                            /*dit_images=*/{},
+                            /*dit_text_output=*/{},
+                            /*json_object_errors=*/{},
+                            &pb_output);
+    do_not_optimize(pb_output.outputs_size());
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+                          batch_size);
+}
+
+// --------------------------------------------------------------------------
+// Engine side: proto::ForwardOutput -> RawForwardOutput -> Sequence
+// --------------------------------------------------------------------------
+
+void BM_ForwardOutput_FromProto(benchmark::State& state) {
+  const int64_t batch_size = state.range(0);
+  const bool logprobs = state.range(1) != 0;
+  const torch::Tensor next_tokens =
+      torch::arange(batch_size, torch::dtype(torch::kInt64));
+  const torch::Tensor token_logprobs =
+      logprobs ? torch::full({batch_size}, -0.5f, torch::dtype(torch::kFloat32))
+               : torch::Tensor();
+  proto::ForwardOutput pb_output;
+  forward_output_to_proto(next_tokens,
+                          token_logprobs,
+                          /*top_tokens=*/torch::Tensor(),
+                          /*top_logprobs=*/torch::Tensor(),
+                          /*embeddings=*/torch::Tensor(),
+                          /*mm_embeddings=*/{},
+                          /*speculative_token_stats=*/{},
+                          /*expert_load_data=*/torch::Tensor(),
+                          /*prepared_token=*/-1,
+                          /*src_seq_idxes=*/torch::Tensor(),
+                          /*out_tokens=*/torch::Tensor(),
+                          /*out_logprobs=*/torch::Tensor(),
+                          /*dit_images=*/{},
+                          /*dit_text_output=*/{},
+                          /*json_object_errors=*/{},
+                          &pb_output);
+
+  for (auto _ : state) {
+    RawForwardOutput raw_output;
+    proto_to_forward_output(pb_output, raw_output);
+    do_not_optimize(raw_output.outputs.data());
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+                          batch_size);
+}
+
+// range(0): batch size, range(1): logprobs (0/1).
+void BM_Batch_ProcessSampleOutput(benchmark::State& state) {
+  const size_t batch_size = static_cast<size_t>(state.range(0));
+  const bool logprobs = state.range(1) != 0;
+  const RawForwardOutput raw_output = make_raw_output(batch_size, logprobs);
+  SequenceFixture sequence_fixture(logprobs);
+  BlockManagerPool& pool = shared_block_manager_pool();
+  ThreadPool thread_pool(kForwardInputThreads);
+  const ModelArgs args;
+
+  for (auto _ : state) {
+    // process_sample_output appends to the sequences and consumes the output
+    // targets recorded by the preceding prepare_forward_input, so the batch is
+    // rebuilt per iteration (outside the timed region).
+    state.PauseTiming();
+    auto fixture = std::make_unique<DecodeBatchFixture>(
+        sequence_fixture, &pool, batch_size);
+    (void)fixture->batch().prepare_forward_input(args, &thread_pool);
+    state.ResumeTiming();
+
+    fixture->batch().process_sample_output(raw_output,
+                                           /*replace_fake_token=*/false);
+
+    state.PauseTiming();
+    fixture.reset();
+    state.ResumeTiming();
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+                          static_cast<int64_t>(batch_size));
+}
+
+// Prompt length in tokens.
+BENCHMARK(BM_BlockManagerPool_AllocateRelease)
+    ->RangeMultiplier(8)
+    ->Range(128, 128 << 10)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_Batch_PrepareForwardInput_Prefill)
+    ->RangeMultiplier(8)
+    ->Range(128, 128 << 10)
+    ->Unit(benchmark::kMicrosecond);
+// Decode batch size in sequences.
+BENCHMARK(BM_Batch_PrepareForwardInput_Decode)
+    ->RangeMultiplier(4)
+    ->Range(1, 256)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_ForwardInput_ToPackedProto)
+    ->RangeMultiplier(4)
+    ->Range(1, 256)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_ForwardInput_FromPackedProto)
+    ->RangeMultiplier(4)
+    ->Range(1, 256)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_ForwardOutput_ToProto)
+    ->ArgsProduct({{1, 16, 256}, {0, 1}})
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_ForwardOutput_FromProto)
+    ->ArgsProduct({{1, 16, 256}, {0, 1}})
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_Batch_ProcessSampleOutput)
+    ->ArgsProduct({{1, 16, 256}, {0, 1}})
+    ->Unit(benchmark::kMicrosecond);
+
+}  // namespace
+}  // namespace xllm

--- a/xllm/core/framework/request/CMakeLists.txt
+++ b/xllm/core/framework/request/CMakeLists.txt
@@ -95,3 +95,51 @@ target_link_libraries(request_state_benchmark
 target_link_options(request_state_benchmark
                     PRIVATE
                     $<$<BOOL:${USE_MLU}>:-Wl,--no-as-needed>)
+
+# Request-path hop 2: LLMMaster thread-pool hand-off + LLMRequestFactory.
+cc_binary(
+  NAME
+    llm_request_factory_benchmark
+  SRCS
+    llm_request_factory_benchmark.cpp
+  DEPS
+    :common
+    :config
+    :request
+    torch
+    benchmark::benchmark
+    benchmark::benchmark_main
+)
+target_link_libraries(llm_request_factory_benchmark
+                      PUBLIC
+                      Python::Python
+                      $<$<BOOL:${USE_NPU}>:ascendcl>
+                      $<$<BOOL:${USE_NPU}>:hccl>
+                      $<$<BOOL:${USE_NPU}>:c_sec>
+                      $<$<BOOL:${USE_NPU}>:nnopbase>)
+target_link_options(llm_request_factory_benchmark
+                    PRIVATE
+                    $<$<BOOL:${USE_MLU}>:-Wl,--no-as-needed>)
+
+# Request-path hop 5: sampled tokens -> streaming / final RequestOutput.
+cc_binary(
+  NAME
+    request_output_benchmark
+  SRCS
+    request_output_benchmark.cpp
+  DEPS
+    :request
+    torch
+    benchmark::benchmark
+    benchmark::benchmark_main
+)
+target_link_libraries(request_output_benchmark
+                      PUBLIC
+                      Python::Python
+                      $<$<BOOL:${USE_NPU}>:ascendcl>
+                      $<$<BOOL:${USE_NPU}>:hccl>
+                      $<$<BOOL:${USE_NPU}>:c_sec>
+                      $<$<BOOL:${USE_NPU}>:nnopbase>)
+target_link_options(request_output_benchmark
+                    PRIVATE
+                    $<$<BOOL:${USE_MLU}>:-Wl,--no-as-needed>)

--- a/xllm/core/framework/request/llm_request_factory_benchmark.cpp
+++ b/xllm/core/framework/request/llm_request_factory_benchmark.cpp
@@ -1,0 +1,285 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Hop 2 of the request path: LLMMaster::handle_request -> LLMRequestFactory.
+//
+// LLMMaster::handle_request schedules a closure onto the "LLMMaster.request"
+// thread pool; that closure runs RequestParams::verify_params and then
+// LLMRequestFactory::create (tokenize, build sampling / scheduler params and
+// the StoppingChecker, construct RequestState + Request + the first Sequence)
+// before handing the Request to the scheduler. These benchmarks time exactly
+// that work, with a deterministic char->id tokenizer and a constant chat
+// template so the numbers isolate xLLM's own overhead from the tokenizer /
+// Jinja library cost.
+//
+//   * BM_Master_ThreadPoolHandoff        - schedule a closure on a 4-thread
+//                                          ThreadPool and wait for it to run:
+//                                          the pure hand-off latency of the
+//                                          LLMMaster.request pool.
+//   * BM_RequestFactory_CreateFromPrompt - verify_params + create() from text
+//                                          (tokenize + Request build), swept
+//                                          over prompt length.
+//   * BM_RequestFactory_CreateFromTokens - same, pre-tokenized prompt (vocab
+//                                          scan + Request build), swept over
+//                                          token count.
+//   * BM_RequestFactory_CreateFromMessages - chat overload (Message copy +
+//                                          template + create), swept over the
+//                                          number of messages.
+//
+// Build & run (example):
+//   python setup.py test --test-name llm_request_factory_benchmark
+//   ./llm_request_factory_benchmark --benchmark_min_time=0.2s
+
+#include <benchmark/benchmark.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <future>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "core/common/message.h"
+#include "core/common/options.h"
+#include "core/common/rate_limiter.h"
+#include "core/framework/chat_template/chat_template.h"
+#include "core/framework/model/model_args.h"
+#include "core/framework/request/llm_request_factory.h"
+#include "core/framework/request/request.h"
+#include "core/framework/request/request_output.h"
+#include "core/framework/request/request_params.h"
+#include "core/framework/tokenizer/tokenizer.h"
+#include "core/util/threadpool.h"
+
+namespace xllm {
+namespace {
+
+// benchmark 1.8.x exposes only DoNotOptimize(Tp const&) -- deprecated -- and
+// DoNotOptimize(Tp&); there is no rvalue overload, so a temporary or a const
+// local resolves to the deprecated one. Sinking the value into a non-const
+// parameter first selects the supported overload.
+template <typename T>
+inline BENCHMARK_ALWAYS_INLINE void do_not_optimize(T value) {
+  benchmark::DoNotOptimize(value);
+}
+
+constexpr int32_t kVocabSize = 32000;
+constexpr int32_t kMaxPositionEmbeddings = 1 << 20;
+// Matches the default size of the LLMMaster.request pool (Options::
+// num_request_handling_threads).
+constexpr size_t kMasterRequestThreads = 4;
+
+// Deterministic tokenizer: one token per character. Cheap on purpose, so the
+// measured time is the factory's own work rather than a real BPE encode.
+class FakeTokenizer final : public Tokenizer {
+ public:
+  bool encode(const std::string_view& text,
+              std::vector<int32_t>* ids,
+              bool /*add_special_tokens*/ = true) const override {
+    ids->clear();
+    ids->reserve(text.size());
+    for (const char c : text) {
+      ids->emplace_back(static_cast<int32_t>(static_cast<unsigned char>(c)) %
+                        kVocabSize);
+    }
+    return true;
+  }
+
+  size_t vocab_size() const override { return static_cast<size_t>(kVocabSize); }
+
+  std::unique_ptr<Tokenizer> clone() const override {
+    return std::make_unique<FakeTokenizer>(*this);
+  }
+};
+
+// Renders every conversation to the same fixed prompt so the chat benchmark
+// measures the messages path without a Jinja engine in the loop.
+class FakeChatTemplate final : public ChatTemplate {
+ public:
+  std::optional<std::string> apply(
+      const ChatMessages& messages) const override {
+    return apply(messages, {}, nlohmann::ordered_json::object());
+  }
+
+  std::optional<std::string> apply(
+      const ChatMessages& /*messages*/,
+      const std::vector<xllm::JsonTool>& /*json_tools*/,
+      const nlohmann::ordered_json& /*chat_template_kwargs*/) const override {
+    return rendered_prompt_;
+  }
+
+ private:
+  std::string rendered_prompt_ = std::string(512, 'p');
+};
+
+OutputCallback noop_callback() {
+  return [](RequestOutput /*output*/) { return true; };
+}
+
+// Owns everything LLMRequestFactory borrows by pointer, in the same shape
+// LLMMaster wires it up.
+class FactoryFixture final {
+ public:
+  FactoryFixture() {
+    model_args_.vocab_size(kVocabSize)
+        .max_position_embeddings(kMaxPositionEmbeddings)
+        .eos_token_id(2);
+    options_.enable_service_routing(false).num_speculative_tokens(0);
+    factory_ = std::make_unique<LLMRequestFactory>(
+        &tokenizer_,
+        &chat_template_,
+        &model_args_,
+        &options_,
+        &rate_limiter_,
+        /*task_type=*/"generate",
+        [](const std::vector<RequestOutput>&) { return std::vector<bool>{}; });
+  }
+
+  LLMRequestFactory& factory() { return *factory_; }
+  RateLimiter& rate_limiter() { return rate_limiter_; }
+
+ private:
+  FakeTokenizer tokenizer_;
+  FakeChatTemplate chat_template_;
+  ModelArgs model_args_;
+  Options options_;
+  RateLimiter rate_limiter_;
+  std::unique_ptr<LLMRequestFactory> factory_;
+};
+
+RequestParams make_request_params() {
+  RequestParams params;
+  params.request_id = "cmpl-bench";
+  params.max_tokens = 128;
+  params.temperature = 0.7f;
+  params.top_p = 0.9f;
+  params.stop = std::vector<std::string>{"</s>", "<|im_end|>"};
+  params.streaming = true;
+  return params;
+}
+
+std::vector<Message> make_messages(size_t num_messages) {
+  std::vector<Message> messages;
+  messages.reserve(num_messages);
+  messages.emplace_back("system", "You are a helpful assistant.");
+  for (size_t i = 1; i < num_messages; ++i) {
+    messages.emplace_back((i % 2 == 1) ? "user" : "assistant",
+                          std::string(256, 'y'));
+  }
+  return messages;
+}
+
+void BM_Master_ThreadPoolHandoff(benchmark::State& state) {
+  ThreadPool threadpool(kMasterRequestThreads);
+
+  for (auto _ : state) {
+    std::promise<void> done;
+    std::future<void> future = done.get_future();
+    threadpool.schedule([&done]() { done.set_value(); });
+    future.wait();
+  }
+}
+
+void BM_RequestFactory_CreateFromPrompt(benchmark::State& state) {
+  FactoryFixture fixture;
+  const std::string prompt(static_cast<size_t>(state.range(0)), 'x');
+  const RequestParams params = make_request_params();
+  const OutputCallback callback = noop_callback();
+
+  for (auto _ : state) {
+    // The API layer acquires the rate-limit slot before handing off; the
+    // Request releases it when destroyed at the end of the iteration.
+    const bool limited = fixture.rate_limiter().is_limited();
+    do_not_optimize(limited);
+    const bool verified = params.verify_params(callback);
+    do_not_optimize(verified);
+    // create() takes the prompt by value. Passing the lvalue copies it, which
+    // matches the production path: CompletionServiceImpl copies the prompt out
+    // of the const proto before it is moved through the master's closure.
+    std::shared_ptr<Request> request =
+        fixture.factory().create(prompt,
+                                 /*prompt_tokens=*/std::nullopt,
+                                 params,
+                                 /*call=*/std::nullopt,
+                                 callback);
+    do_not_optimize(request.get());
+  }
+}
+
+void BM_RequestFactory_CreateFromTokens(benchmark::State& state) {
+  FactoryFixture fixture;
+  const std::vector<int> prompt_tokens(static_cast<size_t>(state.range(0)), 7);
+  const RequestParams params = make_request_params();
+  const OutputCallback callback = noop_callback();
+
+  for (auto _ : state) {
+    const bool limited = fixture.rate_limiter().is_limited();
+    do_not_optimize(limited);
+    const bool verified = params.verify_params(callback);
+    do_not_optimize(verified);
+    // The lvalue vector is copied into the std::optional parameter, matching
+    // the API layer materialising token_ids out of the proto per request.
+    std::shared_ptr<Request> request =
+        fixture.factory().create(/*prompt=*/"",
+                                 prompt_tokens,
+                                 params,
+                                 /*call=*/std::nullopt,
+                                 callback);
+    do_not_optimize(request.get());
+  }
+}
+
+void BM_RequestFactory_CreateFromMessages(benchmark::State& state) {
+  FactoryFixture fixture;
+  const std::vector<Message> messages =
+      make_messages(static_cast<size_t>(state.range(0)));
+  const RequestParams params = make_request_params();
+  const OutputCallback callback = noop_callback();
+
+  for (auto _ : state) {
+    const bool limited = fixture.rate_limiter().is_limited();
+    do_not_optimize(limited);
+    const bool verified = params.verify_params(callback);
+    do_not_optimize(verified);
+    std::shared_ptr<Request> request =
+        fixture.factory().create(messages,
+                                 /*prompt_tokens=*/std::nullopt,
+                                 params,
+                                 /*call=*/std::nullopt,
+                                 callback);
+    do_not_optimize(request.get());
+  }
+}
+
+BENCHMARK(BM_Master_ThreadPoolHandoff)->Unit(benchmark::kNanosecond);
+// Prompt length in characters (== tokens with the char tokenizer).
+BENCHMARK(BM_RequestFactory_CreateFromPrompt)
+    ->RangeMultiplier(8)
+    ->Range(128, 128 << 10)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_RequestFactory_CreateFromTokens)
+    ->RangeMultiplier(8)
+    ->Range(128, 128 << 10)
+    ->Unit(benchmark::kNanosecond);
+// Conversation length in messages.
+BENCHMARK(BM_RequestFactory_CreateFromMessages)
+    ->RangeMultiplier(4)
+    ->Range(1, 64)
+    ->Unit(benchmark::kNanosecond);
+
+}  // namespace
+}  // namespace xllm

--- a/xllm/core/framework/request/request_output_benchmark.cpp
+++ b/xllm/core/framework/request/request_output_benchmark.cpp
@@ -1,0 +1,197 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Hop 5 of the request path: sampled tokens -> RequestOutput.
+//
+// After Batch::process_sample_output has appended the sampled tokens,
+// AsyncResponseProcessor turns sequences into RequestOutputs on its response
+// thread pool: Sequence::generate_streaming_output for every stream step
+// (incremental detokenization of the new suffix) and Request::generate_output
+// once a non-stream request finishes (full detokenization + usage). These
+// benchmarks time that conversion with a tokenizer whose decode is O(tokens)
+// but otherwise trivial, so they measure xLLM's own bookkeeping rather than a
+// real tokenizer.
+//
+//   * BM_Sequence_GenerateStreamingOutput - one stream step that has to emit
+//                                           `k` newly sampled tokens.
+//   * BM_Request_GenerateOutput           - final output for a request with
+//                                           `n` generated tokens, logprobs
+//                                           on/off.
+//
+// Build & run (example):
+//   python setup.py test --test-name request_output_benchmark
+//   ./request_output_benchmark --benchmark_min_time=0.2s
+
+#include <benchmark/benchmark.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "core/common/types.h"
+#include "core/framework/request/request.h"
+#include "core/framework/request/request_output.h"
+#include "core/framework/request/request_state.h"
+#include "core/framework/request/sequence.h"
+#include "core/framework/request/stopping_checker.h"
+#include "core/framework/sampling/sampling_params.h"
+#include "core/framework/tokenizer/tokenizer.h"
+#include "core/util/slice.h"
+
+namespace xllm {
+namespace {
+
+// benchmark 1.8.x exposes only DoNotOptimize(Tp const&) -- deprecated -- and
+// DoNotOptimize(Tp&); there is no rvalue overload, so a temporary or a const
+// local resolves to the deprecated one. Sinking the value into a non-const
+// parameter first selects the supported overload.
+template <typename T>
+inline BENCHMARK_ALWAYS_INLINE void do_not_optimize(T value) {
+  benchmark::DoNotOptimize(value);
+}
+
+constexpr size_t kPromptTokens = 512;
+constexpr int32_t kMaxContextLen = 1 << 20;
+
+// Decodes every token to one character: O(tokens) like a real detokenizer,
+// without the vocabulary lookups.
+class FakeTokenizer final : public Tokenizer {
+ public:
+  std::string decode(const Slice<int32_t>& ids,
+                     bool /*skip_special_tokens*/) const override {
+    return std::string(ids.size(), 'a');
+  }
+
+  std::unique_ptr<Tokenizer> clone() const override {
+    return std::make_unique<FakeTokenizer>();
+  }
+};
+
+OutputFunc noop_output() {
+  return [](const RequestOutput& /*output*/) { return true; };
+}
+
+std::unique_ptr<Request> make_request(size_t num_generated_tokens,
+                                      bool stream,
+                                      bool logprobs) {
+  RequestSamplingParam sampling_param;
+  sampling_param.logprobs = logprobs;
+  StoppingChecker stopping_checker;
+  stopping_checker.set_max_generated_tokens(1 << 20);
+  stopping_checker.set_max_context_len(kMaxContextLen);
+  stopping_checker.set_ignore_eos(true);
+
+  RequestState state(std::string(kPromptTokens, 'p'),
+                     std::vector<int32_t>(kPromptTokens, 7),
+                     std::move(sampling_param),
+                     SchedulerParam{},
+                     std::move(stopping_checker),
+                     /*seq_capacity=*/kPromptTokens + num_generated_tokens + 8,
+                     /*n=*/1,
+                     /*best_of=*/1,
+                     logprobs,
+                     stream,
+                     /*echo=*/false,
+                     /*skip_special_tokens=*/true,
+                     /*enable_schedule_overlap=*/false,
+                     noop_output(),
+                     OutputsFunc{});
+  return std::make_unique<Request>(
+      "bench-req", "x-rid", "x-rtime", std::move(state), "");
+}
+
+// Appends `count` sampled tokens to the request's only sequence, carrying a
+// logprob when the request asked for them (as the sampler would).
+void append_generated_tokens(Request& request, size_t count, bool logprobs) {
+  Sequence& sequence = *request.sequences()[0];
+  // append_token CHECKs that the prompt already has KV cache, as it does after
+  // the real prefill step.
+  sequence.kv_state().set_kv_cache_tokens_num(sequence.num_prompt_tokens());
+  for (size_t i = 0; i < count; ++i) {
+    Token token(static_cast<int64_t>(100 + i));
+    if (logprobs) {
+      token.logprob = -0.5f;
+    }
+    sequence.append_token(token);
+  }
+}
+
+// range(0): newly sampled tokens emitted by this stream step.
+void BM_Sequence_GenerateStreamingOutput(benchmark::State& state) {
+  const size_t new_tokens = static_cast<size_t>(state.range(0));
+  const FakeTokenizer tokenizer;
+
+  for (auto _ : state) {
+    // A stream step decodes only the suffix appended since the previous step;
+    // a fresh sequence with `new_tokens` appended is exactly that state.
+    state.PauseTiming();
+    std::unique_ptr<Request> request =
+        make_request(new_tokens, /*stream=*/true, /*logprobs=*/false);
+    append_generated_tokens(*request, new_tokens, /*logprobs=*/false);
+    Sequence& sequence = *request->sequences()[0];
+    state.ResumeTiming();
+
+    std::optional<SequenceOutput> output =
+        sequence.generate_streaming_output(sequence.num_tokens(), tokenizer);
+    do_not_optimize(output.has_value());
+
+    state.PauseTiming();
+    request.reset();
+    state.ResumeTiming();
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+                          static_cast<int64_t>(new_tokens));
+}
+
+// range(0): generated tokens, range(1): logprobs (0/1).
+void BM_Request_GenerateOutput(benchmark::State& state) {
+  const size_t num_generated_tokens = static_cast<size_t>(state.range(0));
+  const bool logprobs = state.range(1) != 0;
+  const FakeTokenizer tokenizer;
+
+  for (auto _ : state) {
+    // generate_output advances the incremental decoder, so a request can only
+    // be decoded once; rebuild it outside the timed region.
+    state.PauseTiming();
+    std::unique_ptr<Request> request =
+        make_request(num_generated_tokens, /*stream=*/false, logprobs);
+    append_generated_tokens(*request, num_generated_tokens, logprobs);
+    state.ResumeTiming();
+
+    RequestOutput output = request->generate_output(tokenizer);
+    do_not_optimize(output.outputs.data());
+
+    state.PauseTiming();
+    request.reset();
+    state.ResumeTiming();
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+                          static_cast<int64_t>(num_generated_tokens));
+}
+
+BENCHMARK(BM_Sequence_GenerateStreamingOutput)
+    ->RangeMultiplier(4)
+    ->Range(1, 64)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_Request_GenerateOutput)
+    ->ArgsProduct({{16, 256, 4096}, {0, 1}})
+    ->Unit(benchmark::kMicrosecond);
+
+}  // namespace
+}  // namespace xllm

--- a/xllm/core/scheduler/CMakeLists.txt
+++ b/xllm/core/scheduler/CMakeLists.txt
@@ -1,5 +1,5 @@
 include(cc_library)
-
+include(cc_binary)
 
 add_subdirectory(profile)
 
@@ -45,3 +45,31 @@ cc_library(
     absl::time
     absl::synchronization
 )
+
+# Request-path hop 3: add_request, prepare_batch, process_batch_output.
+cc_binary(
+  NAME
+    continuous_scheduler_benchmark
+  SRCS
+    continuous_scheduler_benchmark.cpp
+  DEPS
+    :config
+    :scheduler
+    :xllm_server
+    :block
+    torch
+    benchmark::benchmark
+    benchmark::benchmark_main
+    $<$<BOOL:${USE_NPU}>:nnopbase>
+)
+target_link_libraries(continuous_scheduler_benchmark
+                      PUBLIC
+                      Python::Python
+                      $<$<BOOL:${USE_NPU}>:ascendcl>
+                      $<$<BOOL:${USE_NPU}>:hccl>
+                      $<$<BOOL:${USE_NPU}>:c_sec>)
+target_link_libraries(continuous_scheduler_benchmark PRIVATE
+  "$<LINK_GROUP:RESCAN,xtensor,xllm_server>")
+target_link_options(continuous_scheduler_benchmark
+                    PRIVATE
+                    $<$<BOOL:${USE_MLU}>:-Wl,--no-as-needed>)

--- a/xllm/core/scheduler/continuous_scheduler_benchmark.cpp
+++ b/xllm/core/scheduler/continuous_scheduler_benchmark.cpp
@@ -1,0 +1,364 @@
+/* Copyright 2026 The xLLM Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Hop 3 of the request path: ContinuousScheduler.
+//
+// The master hands a Request to ContinuousScheduler::add_request; the
+// scheduler loop then runs prepare_batch (drain the queue, collect finished
+// requests, allocate KV blocks through BlockManagerPool, build Batch objects)
+// and, after the engine step, process_batch_output. These benchmarks time each
+// of those scheduler-side steps against a FakeEngine that owns a real
+// BlockManagerPool but never runs a model, so the numbers are pure scheduler +
+// block-manager CPU cost.
+//
+//   * BM_Scheduler_AddRequest           - enqueue N requests.
+//   * BM_Scheduler_PrepareBatch_Prefill - schedule N waiting requests into a
+//                                         prefill batch (block allocation
+//                                         included).
+//   * BM_Scheduler_PrepareBatch_Decode  - schedule N running requests into a
+//                                         decode batch.
+//   * BM_Scheduler_ProcessBatchOutput   - post-step bookkeeping over N running
+//                                         requests, stream on/off.
+//
+// Every request carries fresh token ids so the prefix cache never short-cuts
+// allocation, which is the common case for unrelated online requests.
+//
+// Build & run (example):
+//   python setup.py test --test-name continuous_scheduler_benchmark
+//   ./continuous_scheduler_benchmark --benchmark_min_time=0.2s
+
+#include <benchmark/benchmark.h>
+#include <glog/logging.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "core/common/types.h"
+#include "core/distributed_runtime/engine.h"
+#include "core/framework/block/block_manager_pool.h"
+#include "core/framework/model/model_args.h"
+#include "core/framework/request/request.h"
+#include "core/framework/request/request_output.h"
+#include "core/framework/request/request_state.h"
+#include "core/framework/request/stopping_checker.h"
+#include "core/framework/sampling/sampling_params.h"
+#include "core/framework/tokenizer/tokenizer.h"
+#include "core/scheduler/continuous_scheduler.h"
+
+namespace xllm {
+namespace {
+
+// benchmark 1.8.x exposes only DoNotOptimize(Tp const&) -- deprecated -- and
+// DoNotOptimize(Tp&); there is no rvalue overload, so a temporary or a const
+// local resolves to the deprecated one. Sinking the value into a non-const
+// parameter first selects the supported overload.
+template <typename T>
+inline BENCHMARK_ALWAYS_INLINE void do_not_optimize(T value) {
+  benchmark::DoNotOptimize(value);
+}
+
+constexpr int32_t kBlockSize = 128;
+constexpr uint32_t kNumBlocks = 8192;
+constexpr int32_t kMaxSeqsPerBatch = 1024;
+constexpr int32_t kMaxTokensPerBatch = 1 << 20;
+constexpr size_t kPromptTokens = 512;
+constexpr int32_t kMaxContextLen = 1 << 20;
+
+class FakeTokenizer final : public Tokenizer {
+ public:
+  std::unique_ptr<Tokenizer> clone() const override {
+    return std::make_unique<FakeTokenizer>();
+  }
+};
+
+// Engine stand-in: real BlockManagerPool, no model.
+class FakeEngine final : public Engine {
+ public:
+  FakeEngine() {
+    BlockManagerPool::Options options;
+    options.num_blocks(kNumBlocks)
+        .block_size(kBlockSize)
+        .max_seqs_per_batch(kMaxSeqsPerBatch)
+        .enable_prefix_cache(true);
+    block_manager_pool_ =
+        std::make_unique<BlockManagerPool>(options, /*dp_size=*/1);
+  }
+
+  ForwardOutput step(std::vector<Batch>& /*batch*/) override { return {}; }
+  void update_last_step_result(std::vector<Batch>& /*batch*/) override {}
+  const Tokenizer* tokenizer() const override { return &fake_tokenizer_; }
+  BlockManagerPool* block_manager_pool() const override {
+    return block_manager_pool_.get();
+  }
+  const ModelArgs& model_args() const override { return model_args_; }
+  std::vector<int64_t> get_active_activation_memory() const override {
+    return {0};
+  }
+
+ private:
+  FakeTokenizer fake_tokenizer_;
+  std::unique_ptr<BlockManagerPool> block_manager_pool_;
+  ModelArgs model_args_;
+};
+
+// Exposes the response processor so each iteration can drain the async
+// completion callbacks before the next one starts.
+class BenchContinuousScheduler final : public ContinuousScheduler {
+ public:
+  BenchContinuousScheduler(Engine* engine, const Options& options)
+      : ContinuousScheduler(engine, options) {}
+
+  void wait_for_responses() { response_processor_->wait_completion(); }
+};
+
+// One engine + scheduler for the whole process. Google Benchmark invokes each
+// BM_* function several times per argument while sizing the run, and tearing
+// down a BlockManagerPool with the prefix cache enabled sleeps for seconds in
+// PrefixCache's destructor; every iteration leaves the scheduler empty, so
+// sharing one instance is safe.
+class SchedulerFixture final {
+ public:
+  static BenchContinuousScheduler& scheduler() {
+    static SchedulerFixture fixture;
+    return fixture.scheduler_;
+  }
+
+ private:
+  SchedulerFixture() : scheduler_(&engine_, make_scheduler_options()) {}
+
+  static ContinuousScheduler::Options make_scheduler_options() {
+    ContinuousScheduler::Options options;
+    options.max_tokens_per_batch(kMaxTokensPerBatch)
+        .max_seqs_per_batch(kMaxSeqsPerBatch)
+        .max_tokens_per_chunk_for_prefill(kMaxTokensPerBatch)
+        .num_speculative_tokens(0)
+        .dp_size(1)
+        .enable_schedule_overlap(false);
+    return options;
+  }
+
+  // Declared before the scheduler so it outlives it.
+  FakeEngine engine_;
+  BenchContinuousScheduler scheduler_;
+};
+
+OutputFunc noop_output() {
+  return [](const RequestOutput& /*output*/) { return true; };
+}
+
+// Token ids that do not repeat for ~4M requests (ids are never fed to a model
+// or tokenizer here), so no request can hit the prefix cache with an earlier
+// request's prompt.
+std::vector<int32_t> next_prompt_tokens() {
+  static int64_t next_token = 0;
+  std::vector<int32_t> tokens(kPromptTokens);
+  for (int32_t& token : tokens) {
+    token = static_cast<int32_t>(next_token++ %
+                                 std::numeric_limits<int32_t>::max());
+  }
+  return tokens;
+}
+
+std::shared_ptr<Request> make_request(int32_t max_generated_tokens,
+                                      bool stream) {
+  StoppingChecker stopping_checker;
+  stopping_checker.set_max_generated_tokens(max_generated_tokens);
+  stopping_checker.set_max_context_len(kMaxContextLen);
+  stopping_checker.set_ignore_eos(true);
+
+  RequestState state(/*prompt=*/"bench",
+                     next_prompt_tokens(),
+                     RequestSamplingParam{},
+                     SchedulerParam{},
+                     std::move(stopping_checker),
+                     /*seq_capacity=*/kPromptTokens + 8,
+                     /*n=*/1,
+                     /*best_of=*/1,
+                     /*logprobs=*/false,
+                     stream,
+                     /*echo=*/false,
+                     /*skip_special_tokens=*/true,
+                     /*enable_schedule_overlap=*/false,
+                     noop_output(),
+                     OutputsFunc{});
+  return std::make_shared<Request>(
+      "bench-req", "x-rid", "x-rtime", std::move(state), "");
+}
+
+std::vector<std::shared_ptr<Request>> make_requests(
+    size_t num_requests,
+    int32_t max_generated_tokens,
+    bool stream = false) {
+  std::vector<std::shared_ptr<Request>> requests;
+  requests.reserve(num_requests);
+  for (size_t i = 0; i < num_requests; ++i) {
+    requests.emplace_back(make_request(max_generated_tokens, stream));
+  }
+  return requests;
+}
+
+void add_requests(BenchContinuousScheduler& scheduler,
+                  std::vector<std::shared_ptr<Request>>& requests) {
+  for (auto& request : requests) {
+    const bool added = scheduler.add_request(request);
+    CHECK(added) << "scheduler rejected a benchmark request";
+  }
+}
+
+// Simulates the engine having produced one token for every sequence: the KV
+// cache now covers everything that was scheduled, and one token was sampled.
+void append_one_token(const std::vector<std::shared_ptr<Request>>& requests) {
+  for (const auto& request : requests) {
+    for (auto& sequence : request->sequences()) {
+      sequence->kv_state().set_kv_cache_tokens_num(sequence->num_tokens());
+      sequence->append_token(Token(/*id=*/1));
+    }
+  }
+}
+
+// Retires requests that have hit their max_generated_tokens: prepare_batch's
+// collect_finished step frees their blocks and dispatches the completion
+// callbacks, which are then awaited so the next iteration starts clean.
+void retire_finished(BenchContinuousScheduler& scheduler) {
+  std::vector<Batch> batches = scheduler.prepare_batch_test();
+  CHECK(batches.empty() || batches[0].empty())
+      << "unfinished requests leaked into the next iteration";
+  scheduler.wait_for_responses();
+}
+
+void BM_Scheduler_AddRequest(benchmark::State& state) {
+  const size_t num_requests = static_cast<size_t>(state.range(0));
+  BenchContinuousScheduler& scheduler = SchedulerFixture::scheduler();
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    std::vector<std::shared_ptr<Request>> requests =
+        make_requests(num_requests, /*max_generated_tokens=*/1);
+    state.ResumeTiming();
+
+    add_requests(scheduler, requests);
+
+    state.PauseTiming();
+    (void)scheduler.prepare_batch_test();
+    append_one_token(requests);
+    retire_finished(scheduler);
+    state.ResumeTiming();
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+                          static_cast<int64_t>(num_requests));
+}
+
+void BM_Scheduler_PrepareBatch_Prefill(benchmark::State& state) {
+  const size_t num_requests = static_cast<size_t>(state.range(0));
+  BenchContinuousScheduler& scheduler = SchedulerFixture::scheduler();
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    std::vector<std::shared_ptr<Request>> requests =
+        make_requests(num_requests, /*max_generated_tokens=*/1);
+    add_requests(scheduler, requests);
+    state.ResumeTiming();
+
+    std::vector<Batch> batches = scheduler.prepare_batch_test();
+    do_not_optimize(batches.data());
+
+    state.PauseTiming();
+    CHECK_EQ(batches[0].size(), num_requests) << "prefill batch is incomplete";
+    append_one_token(requests);
+    retire_finished(scheduler);
+    state.ResumeTiming();
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+                          static_cast<int64_t>(num_requests));
+}
+
+void BM_Scheduler_PrepareBatch_Decode(benchmark::State& state) {
+  const size_t num_requests = static_cast<size_t>(state.range(0));
+  BenchContinuousScheduler& scheduler = SchedulerFixture::scheduler();
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    std::vector<std::shared_ptr<Request>> requests =
+        make_requests(num_requests, /*max_generated_tokens=*/2);
+    add_requests(scheduler, requests);
+    (void)scheduler.prepare_batch_test();  // prefill step
+    append_one_token(requests);            // first token sampled
+    state.ResumeTiming();
+
+    std::vector<Batch> batches = scheduler.prepare_batch_test();
+    do_not_optimize(batches.data());
+
+    state.PauseTiming();
+    CHECK_EQ(batches[0].size(), num_requests) << "decode batch is incomplete";
+    append_one_token(requests);  // second token -> finished
+    retire_finished(scheduler);
+    state.ResumeTiming();
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+                          static_cast<int64_t>(num_requests));
+}
+
+// range(0): running requests, range(1): stream (0/1).
+void BM_Scheduler_ProcessBatchOutput(benchmark::State& state) {
+  const size_t num_requests = static_cast<size_t>(state.range(0));
+  const bool stream = state.range(1) != 0;
+  BenchContinuousScheduler& scheduler = SchedulerFixture::scheduler();
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    std::vector<std::shared_ptr<Request>> requests =
+        make_requests(num_requests, /*max_generated_tokens=*/2, stream);
+    add_requests(scheduler, requests);
+    (void)scheduler.prepare_batch_test();  // prefill step
+    append_one_token(requests);            // first token sampled
+    state.ResumeTiming();
+
+    // Stream requests are dispatched to the response thread pool here; the
+    // dispatch is timed, the asynchronous decode + callback is not.
+    scheduler.process_batch_output_test(/*enable_schedule_overlap=*/false);
+
+    state.PauseTiming();
+    scheduler.wait_for_responses();
+    append_one_token(requests);  // second token -> finished
+    retire_finished(scheduler);
+    state.ResumeTiming();
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+                          static_cast<int64_t>(num_requests));
+}
+
+BENCHMARK(BM_Scheduler_AddRequest)
+    ->RangeMultiplier(4)
+    ->Range(1, 256)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_Scheduler_PrepareBatch_Prefill)
+    ->RangeMultiplier(4)
+    ->Range(1, 256)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_Scheduler_PrepareBatch_Decode)
+    ->RangeMultiplier(4)
+    ->Range(1, 256)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_Scheduler_ProcessBatchOutput)
+    ->ArgsProduct({{16, 64, 256}, {0, 1}})
+    ->Unit(benchmark::kMicrosecond);
+
+}  // namespace
+}  // namespace xllm


### PR DESCRIPTION
Add five Google Benchmark binaries, one per hop of a completion request, so the host-side cost of each stage can be measured in isolation:

- api_service_benchmark: JSON -> proto, proto -> RequestParams, and the per-token SSE chunk / final result proto -> JSON serialisation.
- llm_request_factory_benchmark: LLMMaster thread-pool hand-off and LLMRequestFactory::create from prompt / tokens / messages.
- continuous_scheduler_benchmark: add_request, prefill and decode prepare_batch (block allocation included), process_batch_output.
- batch_benchmark: BlockManagerPool allocate/release, BatchInputBuilder for prefill/decode, packed ForwardInput proto in both directions, ForwardOutput proto in both directions, Batch::process_sample_output.
- request_output_benchmark: streaming and final output generation.

All benchmarks use deterministic fakes (char tokenizer, constant chat template, FakeEngine with a real BlockManagerPool) and never-repeating prompt ids so the prefix cache cannot short-circuit allocation. Model forward, sampler and device copies are out of scope (device only).

## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
