### PR TITLE
test: align glm attention mock with forward context.

### DIFF
--- a/tests/python/test_glm5_2_cp.py
+++ b/tests/python/test_glm5_2_cp.py
@@ -372,7 +372,12 @@ def test_glm_attention_reduces_o_projection_in_fp32_for_tensor_parallel() -> Non
     attention.qk_rope_head_dim = 1
     attention.kv_lora_rank = 1
     attention.v_head_dim = 2
-    attention.cfg = SimpleNamespace(tp_size=2)
+    attention.layer_id = 0
+    attention.cfg = SimpleNamespace(
+        tp_size=2,
+        layerwise_split_size=1,
+        layerwise_split_rank=0,
+    )
     attention.W_UK = torch.ones(1, 1, 1)
     attention.W_UV = torch.ones(1, 1, 2)
 
@@ -396,7 +401,11 @@ def test_glm_attention_reduces_o_projection_in_fp32_for_tensor_parallel() -> Non
         patch.object(
             glm5_2,
             "get_forward_context",
-            return_value=SimpleNamespace(attention_backend=backend),
+            return_value=SimpleNamespace(
+                attention_backend=backend,
+                cp_context=None,
+                metadata=SimpleNamespace(is_prefill=False, is_chunked_prefill=False),
+            ),
         ),
         patch.object(
             glm5_2,


### PR DESCRIPTION
## Description

Fix the GLM-5.2 context-parallel attention test fixture to match the current forward-context contract.

After context-parallel and layerwise execution support was added, `Glm52MLAAttention.forward` started reading the layer ID, layerwise configuration, context-parallel state, and prefill metadata. The test fixture still provided only `attention_backend`, so `python_executor_test` failed with an `AttributeError` before reaching its tensor-parallel FP32 reduction assertions.

This change supplies explicit non-CP and non-layerwise context values while preserving the existing tensor-parallel reduction coverage. No production code is changed.

## Change Type

- [x] Test

## Validation

- [x] Targeted GLM attention test: `1 passed`.
- [x] NPU CTest `python_executor_test`: `1/1` passed.
- [x] NPU Python test suite: `323 passed, 4 skipped`.
- [ ] CUDA tests were not run because this change only updates an NPU model test fixture.
- [ ] MLU tests were not run because this change only updates an NPU model test fixture.

## Reviewer Notes

The test continues to validate that tensor-parallel output reduction is performed in FP32 and converted back to the projected output dtype.