### PR TITLE
bugfix: fix glm52 index cache writes during acl graph capture.

### DIFF
--- a/tests/core/kernels/npu/npu_xllm_ops_test.cpp
+++ b/tests/core/kernels/npu/npu_xllm_ops_test.cpp
@@ -244,6 +244,73 @@ TEST_F(NpuXllmOpsTest, EmbeddedInterpreterSeesOps) {
              .item<float>();
 }
 
+TEST_F(NpuXllmOpsTest, MlaIndexCacheWriteReplaysWithChangingPadding) {
+  py::gil_scoped_acquire gil;
+  py::exec(R"PY(
+import torch
+from xllm.python.attention.npu_paged_attention import NpuPagedAttentionBackend
+
+device = torch.device("npu:0")
+for cache_dtype in (torch.bfloat16, torch.float16, torch.int8):
+    for slot_dtype in (torch.int32, torch.int64):
+        cache = torch.full((2, 4, 1, 128), -3, dtype=cache_dtype, device=device)
+        values = (torch.arange(6 * 128).reshape(6, 128) % 97).to(
+            device=device, dtype=cache_dtype
+        )
+        slots = torch.tensor([0, -1, 3, -2, 7, -1], dtype=slot_dtype, device=device)
+        scale_cache = None
+        scales = None
+        if cache_dtype == torch.int8:
+            scale_cache = torch.full((2, 4, 1, 1), -3, dtype=torch.float16, device=device)
+            scales = torch.arange(1, 7, dtype=torch.float16, device=device).view(6, 1)
+
+        def _write() -> None:
+            NpuPagedAttentionBackend._update_mla_index_cache(
+                cache, scale_cache, slots, values, scales
+            )
+
+        def _check() -> None:
+            expected = torch.full((8, 128), -3, dtype=cache_dtype)
+            expected_scale = torch.full((8, 1), -3, dtype=torch.float16)
+            for row, slot in enumerate(slots.cpu().tolist()):
+                if slot >= 0:
+                    expected[slot] = values[row].cpu()
+                    if scales is not None:
+                        expected_scale[slot] = scales[row].cpu()
+            torch.testing.assert_close(cache.cpu().view(8, 128), expected, rtol=0, atol=0)
+            if scale_cache is not None:
+                torch.testing.assert_close(
+                    scale_cache.cpu().view(8, 1), expected_scale, rtol=0, atol=0
+                )
+
+        _write()
+        _check()
+        stream = torch.npu.Stream()
+        stream.wait_stream(torch.npu.current_stream())
+        with torch.npu.stream(stream):
+            _write()
+        stream.synchronize()
+        graph = torch.npu.NPUGraph()
+        with torch.npu.graph(graph, stream=stream):
+            _write()
+        for replay_slots in ([7, -1, 0, -1, 3, -1], [-1] * 6):
+            cache.fill_(-3)
+            values.add_(1)
+            slots.copy_(torch.tensor(replay_slots, dtype=slot_dtype, device=device))
+            if scale_cache is not None:
+                scale_cache.fill_(-3)
+                scales.add_(1)
+            graph.replay()
+            torch.npu.synchronize()
+            _check()
+        NpuPagedAttentionBackend._update_mla_index_cache(
+            cache, scale_cache, slots[:0], values[:0],
+            None if scales is None else scales[:0]
+        )
+        _check()
+)PY");
+}
+
 TEST_F(NpuXllmOpsTest, Dsv4OpsUseNpuDispatchKeys) {
   py::gil_scoped_acquire gil;
 

--- a/tests/python/test_npu_paged_attention_cp.py
+++ b/tests/python/test_npu_paged_attention_cp.py
@@ -78,13 +78,20 @@ def test_mla_index_context_accepts_decode_graph_static_metadata() -> None:
     assert context.slot_mapping.data_ptr() == slot_mapping.data_ptr()
 
 
-def test_owner_local_index_write_ignores_non_owned_slots() -> None:
-    cache = torch.full((2, 2, 1, 1), -1.0)
-    slots = torch.tensor([0, -1, 1, -1, 2], dtype=torch.int64)
-    values = torch.arange(5, dtype=torch.float32).view(-1, 1)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.int8])
+@pytest.mark.parametrize("slot_values", [[0, -1, 1, -2, 2], [-1] * 5, []])
+def test_owner_local_index_write_ignores_non_owned_slots(dtype: torch.dtype, slot_values: list[int]) -> None:
+    cache = torch.full((2, 2, 1, 1), -1, dtype=dtype)
+    slots = torch.tensor(slot_values, dtype=torch.int64)
+    values = torch.arange(len(slot_values)).to(dtype).view(-1, 1)
+    scale_cache = torch.full((2, 2, 1, 1), -1, dtype=torch.float16) if dtype == torch.int8 else None
+    scales = values.to(torch.float16) + 1 if scale_cache is not None else None
 
     def scatter(var: torch.Tensor, indices: torch.Tensor, updates: torch.Tensor) -> None:
-        var.index_copy_(0, indices.flatten(), updates)
+        # Model the native operator's device-side negative-index handling.
+        indices = indices.flatten()
+        valid = indices >= 0
+        var.index_copy_(0, indices[valid], updates[valid])
 
     with patch(
         "xllm.python.attention.npu_paged_attention.kernels.scatter_nd_update",
@@ -93,13 +100,21 @@ def test_owner_local_index_write_ignores_non_owned_slots() -> None:
     ):
         NpuPagedAttentionBackend._update_mla_index_cache(
             cache,
-            None,
+            scale_cache,
             slots,
             values,
-            None,
+            scales,
         )
 
-    torch.testing.assert_close(cache.view(-1), torch.tensor([0.0, 2.0, 4.0, -1.0]))
+    expected = torch.full((4,), -1, dtype=dtype)
+    expected_scale = torch.full((4,), -1, dtype=torch.float16)
+    for row, slot in enumerate(slot_values):
+        if slot >= 0:
+            expected[slot] = row
+            expected_scale[slot] = row + 1
+    torch.testing.assert_close(cache.view(-1), expected)
+    if scale_cache is not None:
+        torch.testing.assert_close(scale_cache.view(-1), expected_scale)
 
 
 def test_proper_divisor_materialization_selects_one_replica_per_owner() -> None:

--- a/xllm/python/attention/npu_paged_attention.py
+++ b/xllm/python/attention/npu_paged_attention.py
@@ -736,22 +736,19 @@ class NpuPagedAttentionBackend(AttentionBackend):
         values: torch.Tensor,
         scales: torch.Tensor | None,
     ) -> None:
-        valid_rows = torch.nonzero(slot_mapping >= 0, as_tuple=False).flatten()
-        if valid_rows.numel() == 0:
+        if slot_mapping.numel() == 0:
             return
         cache_view = index_cache.view(-1, index_cache.size(-1))
-        scatter_indices = slot_mapping.index_select(0, valid_rows).reshape(-1, 1)
-        kernels.scatter_nd_update(
-            cache_view,
-            scatter_indices,
-            values.index_select(0, valid_rows),
-        )
+        # ScatterNdUpdateV2 skips negative slots on device. Keep the row count
+        # static: nonzero would synchronize the captured ACLGraph stream.
+        scatter_indices = slot_mapping.reshape(-1, 1)
+        kernels.scatter_nd_update(cache_view, scatter_indices, values)
         if index_cache_scale is not None and scales is not None:
             scale_view = index_cache_scale.view(-1, index_cache_scale.size(-1))
             kernels.scatter_nd_update(
                 scale_view,
                 scatter_indices,
-                scales.index_select(0, valid_rows),
+                scales,
             )
 
     def _materialize_cp_cache(

--- a/xllm/python/kernels_npu/sparse_attention.py
+++ b/xllm/python/kernels_npu/sparse_attention.py
@@ -190,6 +190,7 @@ def scatter_nd_update(
     Args:
         value: Destination tensor, updated in place.
         indices: Index of every updated row, shape ``[num_updates, 1]``.
+            Negative indices are ignored on device, including graph padding.
         updates: Rows written into ``value``.
     """
     torch.ops.xllm_ops.scatter_nd_update(value, indices, updates)


### PR DESCRIPTION
## Description

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

Remove dynamic nonzero filtering and let ScatterNdUpdateV2 ignore negative slots on device. Preserve fixed update shapes for graph capture and replay, including index scales.

Add regression coverage for BF16, FP16, INT8, slot zero, mixed and all-negative padding, empty updates, and changing graph inputs. The NPU regression fails on main before this fix and passes after it; related Python tests pass 38 cases (one pre-existing fixture failure excluded).


## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
