### PR TITLE
feat: support more ep size for glm52 pytorch graph execution.

### DIFF
--- a/tests/python/test_glm5_2_parallel.py
+++ b/tests/python/test_glm5_2_parallel.py
@@ -83,6 +83,44 @@ def test_full_world_ep_partitions_glm_experts() -> None:
     assert moe.experts_w2.shape == (2, 16, 8)
 
 
+def test_proper_divisor_ep_partitions_experts_and_moe_intermediate() -> None:
+    values = _config(ep_size=2, ep_rank=1, moe_tp_size=2, moe_tp_rank=1)
+    cfg = Glm52Config.from_dict(values)
+
+    cfg.validate()
+    model = Glm52ForCausalLM(values)
+    moe = model.model.layers[0].mlp
+
+    assert moe.local_expert_start == 4
+    assert moe.local_expert_end == 8
+    assert moe.num_local_experts == 4
+    assert moe.inter_local == 4
+
+    moe.allocate_experts_w13_for_loading()
+    moe.allocate_experts_w2_for_loading()
+    assert moe.experts_w13.shape == (4, 8, 16)
+    assert moe.experts_w2.shape == (4, 16, 4)
+
+
+def test_glm_ep8_moe_tp2_topology_is_valid() -> None:
+    cfg = Glm52Config.from_dict(
+        _config(
+            num_attention_heads=64,
+            n_routed_experts=256,
+            moe_intermediate_size=2048,
+            tp_size=8,
+            dp_size=2,
+            world_size=16,
+            ep_size=8,
+            ep_rank=7,
+            moe_tp_size=2,
+            moe_tp_rank=1,
+        )
+    )
+
+    cfg.validate()
+
+
 def test_glm_parallel_world_size_defaults_to_tp_dp_product() -> None:
     values = _config()
     values.pop("world_size")
@@ -128,7 +166,8 @@ def test_glm_layerwise_split_cannot_overlap_context_parallel() -> None:
 @pytest.mark.parametrize(
     ("overrides", "message"),
     [
-        ({"ep_size": 2}, "ep_size must be 1 or world_size"),
+        ({"ep_size": 3}, "ep_size must divide world_size"),
+        ({"ep_size": 2}, r"moe_tp_size \* ep_size"),
         ({"world_size": 8}, r"world_size must equal tp_size \* dp_size \* cp_size"),
         ({"cp_rank": 2}, "cp_rank must be in"),
         ({"n_routed_experts": 10}, "n_routed_experts must be divisible by ep_size"),
@@ -204,3 +243,22 @@ def test_glm_weight_loader_reads_only_local_ep_experts(monkeypatch) -> None:
     assert loader.tp_size == 2
     assert loader.tp_rank == 0
     assert loader.shared_shards == [("model.layers.0.mlp.shared_experts.", 1, 0)]
+
+
+def test_glm_weight_loader_shards_proper_divisor_ep_with_moe_tp(monkeypatch) -> None:
+    values = _config(ep_size=2, ep_rank=1, moe_tp_size=2, moe_tp_rank=1)
+    model = Glm52ForCausalLM(values)
+    model.model.layers[0].self_attn.process_weights_after_loading = MagicMock()
+    model.model.layers[0].mlp.process_experts_w13_after_loading = MagicMock()
+    model.model.layers[0].mlp.process_experts_w2_after_loading = MagicMock()
+    model.model.layers[0].mlp.shared_experts.process_weights_after_loading = MagicMock()
+    monkeypatch.setattr(glm5_2, "W8A8WeightLoader", _RecordingLoader)
+
+    model.load_weights([], tp_rank=0, tp_size=2)
+
+    loader = _RecordingLoader.latest
+    assert loader is not None
+    expert_names = [name for name in loader.loaded if ".mlp.experts." in name]
+    assert expert_names
+    assert all(any(f".experts.{expert}." in name for expert in range(4, 8)) for name in expert_names)
+    assert loader.shared_shards == [("model.layers.0.mlp.shared_experts.", 2, 1)]

--- a/xllm/python/models/glm5_2.py
+++ b/xllm/python/models/glm5_2.py
@@ -262,8 +262,8 @@ class Glm52Config:
             raise ValueError("parallel sizes must be positive")
         if self.tp_size * self.dp_size * self.cp_size != self.world_size:
             raise ValueError("world_size must equal tp_size * dp_size * cp_size")
-        if self.ep_size not in (1, self.world_size):
-            raise ValueError(f"ep_size must be 1 or world_size ({self.world_size})")
+        if self.world_size % self.ep_size:
+            raise ValueError(f"ep_size must divide world_size: ep_size={self.ep_size}, world_size={self.world_size}")
         if self.ep_size > 1:
             if self.n_routed_experts % self.ep_size:
                 raise ValueError("n_routed_experts must be divisible by ep_size")


### PR DESCRIPTION

## Description

Allow expert parallel sizes that divide the global world size while retaining the MoE tensor-parallel and expert-partition constraints. Cover EP8 with MoE TP2 and proper-divisor expert weight loading.

Validation: 34 Python tests passed; NPU binary built successfully. On 16 NPUs with DP2 and EP8, prefill and four ACL graph buckets passed. GSM8K 64-sample smoke test: 61/64, with graph/eager mixed execution.

<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
