### PR TITLE
feat: add fp8 kvcache for npu glm5.2.

### DIFF
--- a/docs/src/content/docs/en/cli_reference.md
+++ b/docs/src/content/docs/en/cli_reference.md
@@ -67,8 +67,8 @@ xLLM uses gflags to manage service startup parameters. `--model <PATH>` is the o
 | `block_size` | `int32` | `128` | Number of slots per KV Cache block. |
 | `max_cache_size` | `int64` | `0` | Maximum GPU memory size for KV Cache. `0` means calculated from available memory. |
 | `max_memory_utilization` | `double` | `0.8` | Fraction of GPU memory used for model inference, including model weights and KV Cache. |
-| `kv_cache_dtype` | `string` | `"auto"` | KV Cache dtype for quantization. `auto` aligns with model dtype and disables quantization. `int8` enables INT8 quantization and is only supported on the MLU backend. |
-| `indexer_cache_dtype` | `string` | `"auto"` | Indexer cache dtype for models with an indexer cache. Supported values are `auto` and `int8`. `auto` aligns with model dtype and disables indexer cache quantization. `int8` enables INT8 indexer cache quantization. |
+| `kv_cache_dtype` | `string` | `"auto"` | KV Cache dtype for quantization. `auto` aligns with model dtype and disables quantization. `int8` enables INT8 quantization on MLU. `fp8_e4m3` stores PyTorch GLM-5.2 NPU caches as raw E4M3 bytes; supported decode shapes use fused MLA, and other shapes dequantize to BF16 before attention. |
+| `indexer_cache_dtype` | `string` | `"auto"` | Indexer cache dtype for models with an indexer cache. `auto` disables quantization, `int8` enables INT8 quantization, and `fp8_e4m3` stores the PyTorch GLM-5.2 NPU index cache in E4M3 format and dequantizes it to BF16 for index attention. |
 | `enable_prefix_cache` | `bool` | `true` | Whether to enable prefix cache in the block manager. See [Prefix Cache](/en/features/prefix_cache/). |
 | `enable_in_batch_prefix_cache` | `bool` | `false` | Whether to cache admitted prefill full blocks into the prefix cache so that later requests in the same batch can share them. |
 | `max_linear_state_cache_slots` | `int64` | `0` | Maximum number of active linear-attention state cache slots. `0` derives an automatic capacity from the available KV Cache budget. |

--- a/docs/src/content/docs/zh/cli_reference.md
+++ b/docs/src/content/docs/zh/cli_reference.md
@@ -67,8 +67,8 @@ xLLM 使用 gflags 管理服务启动参数。`--model <PATH>` 是唯一必填�
 | `block_size` | `int32` | `128` | 每个 KV Cache block 的 slot 数。 |
 | `max_cache_size` | `int64` | `0` | KV Cache 可使用的 GPU 显存大小；`0` 表示根据可用显存自动计算。 |
 | `max_memory_utilization` | `double` | `0.8` | 模型推理可使用的 GPU 显存比例，包括模型权重和 KV Cache。 |
-| `kv_cache_dtype` | `string` | `"auto"` | KV Cache 量化数据类型；`auto` 表示与模型 dtype 对齐且不量化，`int8` 表示启用 INT8 量化，仅 MLU 后端支持。 |
-| `indexer_cache_dtype` | `string` | `"auto"` | 带 indexer cache 的模型所使用的 indexer cache 数据类型。支持 `auto` 和 `int8`；`auto` 表示与模型 dtype 对齐且不量化，`int8` 表示启用 INT8 indexer cache 量化。 |
+| `kv_cache_dtype` | `string` | `"auto"` | KV Cache 量化数据类型；`auto` 表示与模型 dtype 对齐且不量化，`int8` 仅支持 MLU，`fp8_e4m3` 将 NPU PyTorch GLM-5.2 cache 存储为 E4M3 原始字节；受支持的 decode 形状使用融合 MLA，其余形状先反量化为 BF16 再计算 attention。 |
+| `indexer_cache_dtype` | `string` | `"auto"` | 带 indexer cache 的模型所使用的数据类型；`auto` 表示不量化，`int8` 表示启用 INT8 量化，`fp8_e4m3` 将 NPU PyTorch GLM-5.2 index cache 存储为 E4M3 格式，并在 index attention 计算前反量化为 BF16。 |
 | `enable_prefix_cache` | `bool` | `true` | 是否在 block manager 中启用 prefix cache；详见 [Prefix Cache](/zh/features/prefix_cache/)。 |
 | `enable_in_batch_prefix_cache` | `bool` | `false` | 是否将已准入的 prefill 完整 block 缓存进 prefix cache，使同一 batch 内的后续请求可以共享。 |
 | `max_linear_state_cache_slots` | `int64` | `0` | linear-attention state cache 的最大活跃槽位数；`0` 表示根据可用 KV Cache 预算自动推导容量。 |

--- a/tests/core/framework/config/config_json_test.cpp
+++ b/tests/core/framework/config/config_json_test.cpp
@@ -305,30 +305,51 @@ TEST(KVCacheConfigValidationTest, AcceptsSupportedIndexerCacheDtypes) {
 
   config.indexer_cache_dtype("int8");
   config.validate();
+
+#if defined(USE_NPU)
+  config.indexer_cache_dtype("fp8_e4m3");
+  config.validate();
+#endif
 }
 
 TEST(KVCacheConfigValidationTest, RejectsUnsupportedIndexerCacheDtypes) {
+#if defined(USE_NPU)
+  constexpr const char* kSupportedIndexerCacheDtypes =
+      "indexer_cache_dtype.*auto.*int8.*fp8_e4m3";
+#else
+  constexpr const char* kSupportedIndexerCacheDtypes =
+      "indexer_cache_dtype.*auto.*int8";
+#endif
+#if !defined(USE_NPU)
+  EXPECT_DEATH(
+      {
+        KVCacheConfig config;
+        config.indexer_cache_dtype("fp8_e4m3");
+        config.validate();
+      },
+      kSupportedIndexerCacheDtypes);
+#endif
   EXPECT_DEATH(
       {
         KVCacheConfig config;
         config.indexer_cache_dtype("fp8");
         config.validate();
       },
-      "indexer_cache_dtype.*auto.*int8");
+      kSupportedIndexerCacheDtypes);
   EXPECT_DEATH(
       {
         KVCacheConfig config;
         config.indexer_cache_dtype("INT8");
         config.validate();
       },
-      "indexer_cache_dtype.*auto.*int8");
+      kSupportedIndexerCacheDtypes);
   EXPECT_DEATH(
       {
         KVCacheConfig config;
         config.indexer_cache_dtype(" int8 ");
         config.validate();
       },
-      "indexer_cache_dtype.*auto.*int8");
+      kSupportedIndexerCacheDtypes);
 }
 
 TEST(ConfigJsonTest, ParallelConfigReadsContextParallelSize) {

--- a/tests/core/framework/kv_cache/kv_cache_estimation_test.cpp
+++ b/tests/core/framework/kv_cache/kv_cache_estimation_test.cpp
@@ -106,6 +106,31 @@ TEST(KVCacheEstimationTest, IndexerScaleUsesLogicalCacheCapacity) {
   EXPECT_EQ(capacity.n_blocks(), 1107);
 }
 
+#if defined(USE_NPU)
+TEST(KVCacheEstimationTest, NpuGlm52Fp8CachesDoNotRequireScales) {
+  ModelArgs model_args = make_standard_args();
+  model_args.model_type("glm_moe_dsa")
+      .enable_mla(true)
+      .kv_lora_rank(512)
+      .qk_rope_head_dim(64)
+      .index_n_heads(1)
+      .index_head_dim(128);
+  KVCacheEstimateOptions options = make_estimate_options();
+  options.dtype = torch::kBFloat16;
+  options.kv_cache_dtype = "fp8_e4m3";
+  options.indexer_cache_dtype = "fp8_e4m3";
+
+  const KVCacheCapacity capacity =
+      estimate_kv_cache_capacity(model_args, options);
+
+  EXPECT_EQ(capacity.slot_size(), 576);
+  EXPECT_EQ(capacity.scale_slot_size(), 0);
+  EXPECT_EQ(capacity.index_slot_size(), 128);
+  EXPECT_TRUE(capacity.enable_indexer_cache_quant());
+  EXPECT_FALSE(capacity.enable_indexer_cache_scale());
+}
+#endif
+
 #if defined(USE_MLU) || defined(USE_NPU)
 TEST(KVCacheEstimationTest, SharedDsaLayersDoNotConsumeIndexerCacheBudget) {
   ModelArgs model_args = make_standard_args();

--- a/tests/core/framework/kv_cache/kv_cache_test.cpp
+++ b/tests/core/framework/kv_cache/kv_cache_test.cpp
@@ -857,6 +857,61 @@ TEST(KVCacheTest, MluMixedDsaLayersUseInjectedAllocatorForActualRoles) {
 
 #endif
 
+#if defined(USE_NPU)
+TEST(KVCacheTest, NpuGlm52Fp8CachesUseRawBytesWithoutScales) {
+  constexpr int64_t kBlockCount = 2;
+  constexpr int64_t kBlockSize = 16;
+  constexpr int64_t kKvLoraRank = 512;
+  constexpr int64_t kRopeHeadDim = 64;
+  constexpr int64_t kIndexHeadDim = 128;
+
+  KVCacheCapacity capacity;
+  capacity.n_blocks(kBlockCount)
+      .block_size(kBlockSize)
+      .enable_indexer_cache_quant(true)
+      .enable_indexer_cache_scale(false);
+  ModelArgs model_args;
+  model_args.model_type("glm_moe_dsa")
+      .enable_mla(true)
+      .n_heads(64)
+      .n_kv_heads(1)
+      .head_dim(kKvLoraRank)
+      .kv_lora_rank(kKvLoraRank)
+      .qk_rope_head_dim(kRopeHeadDim)
+      .index_n_heads(1)
+      .index_head_dim(kIndexHeadDim);
+  const KVCacheShape shape(capacity, model_args, /*world_size=*/1);
+
+  KVCacheCreateOptions options;
+  options.device(torch::Device("npu:0"))
+      .dtype(torch::kBFloat16)
+      .num_layers(2)
+      .model_type("glm_moe_dsa")
+      .enable_lighting_indexer(true)
+      .indexer_cache_enabled_layers({true, false})
+      .enable_kv_cache_quant(true)
+      .kv_cache_dtype("fp8_e4m3")
+      .enable_indexer_cache_quant(true)
+      .indexer_cache_dtype("fp8_e4m3");
+
+  std::vector<KVCache> caches;
+  allocate_kv_caches(caches, shape, options);
+
+  ASSERT_EQ(caches.size(), 2U);
+  EXPECT_EQ(caches[0].get_k_cache().scalar_type(), torch::kByte);
+  EXPECT_EQ(caches[0].get_v_cache().scalar_type(), torch::kByte);
+  EXPECT_EQ(caches[0].get_index_cache().scalar_type(), torch::kByte);
+  EXPECT_FALSE(caches[0].get_k_cache_scale().has_value());
+  EXPECT_FALSE(caches[0].get_v_cache_scale().has_value());
+  EXPECT_FALSE(caches[0].get_indexer_cache_scale().has_value());
+  EXPECT_EQ(caches[1].get_k_cache().scalar_type(), torch::kByte);
+  EXPECT_EQ(caches[1].get_v_cache().scalar_type(), torch::kByte);
+  EXPECT_FALSE(caches[1].get_index_cache().defined());
+  EXPECT_FALSE(caches[1].get_k_cache_scale().has_value());
+  EXPECT_FALSE(caches[1].get_v_cache_scale().has_value());
+}
+#endif
+
 TEST_F(HostKVCacheTest, HostKVCacheNormalLayoutAddsLayerDim) {
   constexpr int64_t kNumBlocks = 16;
   constexpr int64_t kBlockSize = 128;

--- a/tests/core/kernels/npu/npu_xllm_ops_test.cpp
+++ b/tests/core/kernels/npu/npu_xllm_ops_test.cpp
@@ -747,6 +747,125 @@ TEST_F(NpuXllmOpsTest,
            /*block_table_width=*/kNumPhysicalBlocks);
 }
 
+TEST_F(NpuXllmOpsTest, Fp8CacheUpdatesPreserveBytesAndSkipPadding) {
+  py::gil_scoped_acquire gil;
+  py::exec(R"PY(
+import torch
+from xllm.python.attention.npu_paged_attention import NpuPagedAttentionBackend
+
+cache = torch.full((2, 2, 1, 128), 42, dtype=torch.uint8, device="npu:0")
+updates = (torch.arange(384) + 128).reshape(3, 128).remainder(256).to(torch.uint8)
+slots = torch.tensor([0, -1, 3], dtype=torch.int64, device="npu:0")
+NpuPagedAttentionBackend._update_paged_cache(cache, slots, updates.to("npu:0"))
+expected = torch.full((4, 128), 42, dtype=torch.uint8)
+expected[0] = updates[0]
+expected[3] = updates[2]
+assert torch.equal(cache.view(4, 128).cpu(), expected)
+
+# The same fixed-size graph must follow updated slots, including padding.
+values = updates.to("npu:0")
+stream = torch.npu.Stream()
+stream.wait_stream(torch.npu.current_stream())
+with torch.npu.stream(stream):
+    NpuPagedAttentionBackend._update_paged_cache(cache, slots, values)
+stream.synchronize()
+graph = torch.npu.NPUGraph()
+with torch.npu.graph(graph, stream=stream):
+    NpuPagedAttentionBackend._update_paged_cache(cache, slots, values)
+slots.copy_(torch.tensor([-1, 1, 2], dtype=torch.int64, device="npu:0"))
+values.fill_(199)
+graph.replay()
+torch.npu.synchronize()
+expected[1:3] = 199
+assert torch.equal(cache.view(4, 128).cpu(), expected)
+)PY");
+}
+
+TEST_F(NpuXllmOpsTest, Fp8DequantizationReplaysWithinMemoryBudget) {
+  py::gil_scoped_acquire gil;
+  py::exec(R"PY(
+import torch
+from xllm.python.attention.fp8_cache import dequantize_e4m3
+
+raw_cpu = torch.arange(256, dtype=torch.int32).to(torch.uint8).reshape(16, 16).T
+raw = raw_cpu.to("npu:0")
+for dtype in (torch.bfloat16, torch.float16, torch.float32):
+    expected = dequantize_e4m3(raw_cpu, dtype)
+    actual = dequantize_e4m3(raw, dtype)
+    assert torch.equal(actual.cpu(), expected)
+
+# Large-cache conversion must not retain full-sized arithmetic intermediates.
+raw = raw_cpu.contiguous().repeat(1024, 16).to("npu:0")
+torch.npu.synchronize()
+torch.npu.reset_peak_memory_stats()
+allocated = torch.npu.memory_allocated()
+out = dequantize_e4m3(raw)
+torch.npu.synchronize()
+extra_peak = torch.npu.max_memory_allocated() - allocated
+assert extra_peak < raw.numel() * 8, extra_peak
+
+stream = torch.npu.Stream()
+stream.wait_stream(torch.npu.current_stream())
+with torch.npu.stream(stream):
+    out = dequantize_e4m3(raw)
+stream.synchronize()
+graph = torch.npu.NPUGraph()
+with torch.npu.graph(graph, stream=stream):
+    out = dequantize_e4m3(raw)
+raw.fill_(188)
+graph.replay()
+torch.npu.synchronize()
+assert torch.all(out.cpu() == -1.5)
+)PY");
+}
+
+TEST_F(NpuXllmOpsTest, Fp8SparseMlaMatchesReferenceAcrossPageBoundary) {
+  py::gil_scoped_acquire gil;
+  py::exec(R"PY(
+import torch
+from xllm.python.attention.fp8_cache import (
+    create_e4m3_decode_table, dequantize_e4m3, quantize_e4m3,
+)
+from xllm.python.kernels_npu.sparse_attention import glm52_fp8_sparse_mla_attention_out
+
+torch.manual_seed(20260910)
+device = torch.device("npu:0")
+nope_raw = quantize_e4m3(torch.randn(4, 128, 1, 512).bfloat16() * 0.25)
+rope_raw = quantize_e4m3(torch.randn(4, 128, 1, 64).bfloat16() * 0.25)
+nope = nope_raw.to(device)
+rope = rope_raw.to(device)
+decode_table = create_e4m3_decode_table(device)
+block_table = torch.tensor([[2, 0], [1, 3]], dtype=torch.int32, device=device)
+lengths = torch.tensor([127, 129], dtype=torch.int32, device=device)
+indices = torch.full((2, 1, 2048), -1, dtype=torch.int32)
+indices[:, 0, :130] = torch.arange(130, dtype=torch.int32)
+topk = indices.to(device)
+workspaces = (
+    torch.empty((24, 64, 512), dtype=torch.bfloat16, device=device),
+    torch.empty((24, 64, 64), dtype=torch.bfloat16, device=device),
+    torch.empty((24, 16, 64), dtype=torch.float32, device=device),
+    torch.empty((24, 16, 64), dtype=torch.bfloat16, device=device),
+    torch.empty((24, 16, 512), dtype=torch.float32, device=device),
+    torch.empty((24, 16, 512), dtype=torch.bfloat16, device=device),
+    torch.empty((24, 16, 64), dtype=torch.bfloat16, device=device),
+)
+for heads in (4, 8, 16):
+    q = (torch.randn(heads, 2, 512).bfloat16() * 0.25).to(device).transpose(0, 1)
+    q_rope = (torch.randn(heads, 2, 64).bfloat16() * 0.25).to(device).transpose(0, 1)
+    out = torch.empty((2, heads, 512), dtype=torch.bfloat16, device=device)
+    glm52_fp8_sparse_mla_attention_out(
+        q, q_rope, nope, rope, topk, block_table, lengths, decode_table,
+        out, *workspaces, 0.0625,
+    )
+    for row, length, pages in ((0, 127, [2, 0]), (1, 129, [1, 3])):
+        keys = dequantize_e4m3(nope_raw[pages], torch.float32).reshape(-1, 512)[:length]
+        rope_keys = dequantize_e4m3(rope_raw[pages], torch.float32).reshape(-1, 64)[:length]
+        scores = (q[row].cpu().float() @ keys.T + q_rope[row].cpu().float() @ rope_keys.T) * 0.0625
+        expected = torch.softmax(scores, -1) @ keys
+        torch.testing.assert_close(out[row].cpu().float(), expected, atol=2e-3, rtol=2e-2)
+)PY");
+}
+
 TEST_F(NpuXllmOpsTest, Qwen35_27B_TP4_FullAttentionMatchesReference) {
   py::gil_scoped_acquire gil;
   if (!is_ascend950_device()) {

--- a/tests/python/test_fp8_mla.py
+++ b/tests/python/test_fp8_mla.py
@@ -1,0 +1,307 @@
+# Copyright 2026 The xLLM Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from xllm.python.attention import npu_paged_attention
+from xllm.python.attention.backend import MlaIndexContext
+from xllm.python.attention.fp8_cache import (
+    create_e4m3_decode_table,
+    dequantize_e4m3,
+    quantize_e4m3,
+)
+from xllm.python.models import glm5_2
+
+
+def test_e4m3_cache_encoding_matches_pytorch_float8_bits() -> None:
+    values = torch.tensor(
+        [
+            -448.0,
+            -16.0,
+            -1.5,
+            -(2.0**-6),
+            -(2.0**-9),
+            0.0,
+            2.0**-9,
+            2.0**-6,
+            1.5,
+            16.0,
+            448.0,
+        ],
+        dtype=torch.bfloat16,
+    )
+
+    encoded = quantize_e4m3(values)
+    expected = values.to(torch.float8_e4m3fn).view(torch.uint8)
+
+    assert torch.equal(encoded, expected)
+    assert torch.equal(dequantize_e4m3(encoded), expected.view(torch.float8_e4m3fn).to(torch.bfloat16))
+
+
+def test_e4m3_cache_encoding_saturates_out_of_range_values() -> None:
+    values = torch.tensor([-float("inf"), -500.0, 500.0, float("inf"), float("nan")])
+
+    decoded = dequantize_e4m3(quantize_e4m3(values), torch.float32)
+
+    torch.testing.assert_close(decoded[:4], torch.tensor([-448.0, -448.0, 448.0, 448.0]))
+    assert decoded[4].item() == 0.0
+
+
+def test_e4m3_decode_table_covers_every_raw_byte() -> None:
+    raw = torch.arange(256, dtype=torch.int32).to(torch.uint8)
+
+    table = create_e4m3_decode_table(torch.device("cpu"))
+
+    assert table.dtype == torch.float32
+    torch.testing.assert_close(table, dequantize_e4m3(raw, torch.float32))
+
+
+def test_e4m3_paged_cache_update_preserves_raw_high_bits(monkeypatch: pytest.MonkeyPatch) -> None:
+    cache = torch.zeros(1, 2, 1, 3, dtype=torch.uint8)
+    slot_mapping = torch.tensor([0, 1], dtype=torch.int64)
+    values = torch.tensor([[[254, 216, 188]], [[129, 1, 126]]], dtype=torch.uint8)
+
+    def scatter_nd_update(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("uint8 cache updates must not use ScatterNdUpdateV2")
+
+    monkeypatch.setattr(
+        npu_paged_attention.kernels,
+        "scatter_nd_update",
+        scatter_nd_update,
+        raising=False,
+    )
+
+    npu_paged_attention.NpuPagedAttentionBackend._update_paged_cache(cache, slot_mapping, values)
+
+    assert torch.equal(cache.view(2, 3), values.view(2, 3))
+
+
+@pytest.mark.parametrize("slots", [[-1, 0, -1, 2], [-1, -1, -1, -1]])
+def test_e4m3_cache_padding_does_not_overwrite_valid_slots(slots: list[int]) -> None:
+    cache = torch.full((1, 3, 1, 4), 42, dtype=torch.uint8)
+    values = torch.arange(16, dtype=torch.uint8).reshape(4, 1, 4) + 128
+    expected = cache.clone().view(3, 4)
+    for row, slot in enumerate(slots):
+        if slot >= 0:
+            expected[slot] = values[row, 0]
+
+    npu_paged_attention.NpuPagedAttentionBackend._update_paged_cache(cache, torch.tensor(slots), values)
+
+    assert torch.equal(cache.view(3, 4), expected)
+
+
+def test_e4m3_mla_cache_writer_quantizes_latent_and_rope() -> None:
+    latent = torch.tensor([[[1.1, -2.2]], [[3.3, -4.4]]], dtype=torch.bfloat16)
+    rope = torch.tensor([[[0.2]], [[-0.3]]], dtype=torch.bfloat16)
+    nope_cache = torch.zeros((1, 3, 1, 2), dtype=torch.uint8)
+    rope_cache = torch.zeros((1, 3, 1, 1), dtype=torch.uint8)
+
+    npu_paged_attention.NpuPagedAttentionBackend._update_mla_cache(
+        torch.tensor([2, 0]), latent, rope, nope_cache, rope_cache
+    )
+
+    assert torch.equal(nope_cache[0, [2, 0]], quantize_e4m3(latent))
+    assert torch.equal(rope_cache[0, [2, 0]], quantize_e4m3(rope))
+    assert torch.count_nonzero(nope_cache[0, 1]) == 0
+
+
+def test_fp8_indexer_uses_materialized_cache_and_matching_block_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    indexer = glm5_2.Glm52Indexer.__new__(glm5_2.Glm52Indexer)
+    nn.Module.__init__(indexer)
+    indexer.n_head = 1
+    indexer.head_dim = 4
+    indexer.rope_dim = 2
+    indexer.topk = 2
+    indexer.indexer_rope_interleave = False
+    indexer.wq_b = nn.Identity()
+    indexer.wk = nn.Identity()
+    indexer.k_norm = nn.Identity()
+    indexer.weights_proj = nn.Linear(4, 1, bias=False, dtype=torch.bfloat16)
+    cache = torch.zeros((2, 1, 1, 4), dtype=torch.uint8)
+    slots = torch.tensor([1, 0])
+    block_table = torch.tensor([[1, 0]], dtype=torch.int32)
+    materialized_table = torch.tensor([[0, 1]], dtype=torch.int32)
+    lengths = torch.tensor([2], dtype=torch.int32)
+    hidden = torch.tensor([[1.1, -2.2, 3.3, -4.4], [0.1, 0.2, 0.3, 0.4]], dtype=torch.bfloat16)
+
+    def update(values: torch.Tensor, scales: torch.Tensor | None) -> None:
+        assert values.dtype == torch.uint8
+        assert scales is None
+        npu_paged_attention.NpuPagedAttentionBackend._update_mla_index_cache(cache, None, slots, values, scales)
+
+    def lightning_indexer(query: torch.Tensor, key: torch.Tensor, *args: object) -> torch.Tensor:
+        assert key.dtype == torch.bfloat16
+        assert args[3] is materialized_table
+        torch.testing.assert_close(key[:, 0, 0], dequantize_e4m3(quantize_e4m3(hidden)))
+        return torch.zeros((query.size(0), 1, 2), dtype=torch.int32)
+
+    monkeypatch.setattr(glm5_2.kernels, "lightning_indexer", lightning_indexer, raising=False)
+    ctx = MlaIndexContext(
+        index_cache=cache,
+        slot_mapping=slots,
+        block_table=block_table,
+        actual_seq_q=lengths,
+        actual_seq_kv=lengths,
+        index_cache_scale=None,
+        get_quant_indexer_metadata=lambda *_args: torch.empty(0),
+        update_index_cache=update,
+        materialize_index_cache=lambda: (cache.flip(0), None, materialized_table),
+    )
+
+    result = indexer.select_qli(hidden, hidden, torch.tensor([0, 1]), ctx, torch.tensor([[1.0, 0.0], [1.0, 0.0]]))
+    assert result.shape == (2, 1, 2)
+
+
+def test_fp8_mla_dequantizes_caches_before_sparse_attention(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    q_latent = torch.zeros(2, 1, 2, dtype=torch.bfloat16)
+    q_pe = torch.zeros(2, 1, 1, dtype=torch.bfloat16)
+    nope_values = torch.tensor(
+        [[[[1.0, 0.0]], [[0.0, 2.0]], [[0.5, 0.5]], [[-1.0, 1.0]]]],
+        dtype=torch.bfloat16,
+    )
+    rope_values = torch.zeros(1, 4, 1, 1, dtype=torch.bfloat16)
+    topk = torch.tensor([[[0, 2, 3]], [[1, 2, 3]]], dtype=torch.int32)
+    block_table = torch.tensor([[0]], dtype=torch.int32)
+    actual_seq_q = torch.tensor([2], dtype=torch.int32)
+    actual_seq_kv = torch.tensor([4], dtype=torch.int32)
+    backend = object.__new__(npu_paged_attention.NpuPagedAttentionBackend)
+    backend._mla_actual_seq_q = actual_seq_q
+    backend._mla_actual_seq_kv = actual_seq_kv
+    backend.scale = 1.0
+    captured: dict[str, torch.Tensor] = {}
+
+    def sparse_flash_attention_out(
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        *_args: object,
+    ) -> torch.Tensor:
+        captured["query"] = query
+        captured["key"] = key
+        captured["value"] = value
+        captured["rope"] = _args[5]
+        return _args[-1]
+
+    monkeypatch.setattr(
+        npu_paged_attention,
+        "get_execution_buffer",
+        lambda _key, factory: factory(),
+    )
+    monkeypatch.setattr(
+        npu_paged_attention.kernels,
+        "sparse_flash_attention_out",
+        sparse_flash_attention_out,
+        raising=False,
+    )
+
+    output = backend._mla_sparse(
+        q_latent,
+        q_pe,
+        quantize_e4m3(nope_values),
+        quantize_e4m3(rope_values),
+        topk,
+        block_table,
+        backend._mla_actual_seq_q,
+        actual_seq_kv,
+        0,
+    )
+
+    assert output.dtype == torch.bfloat16
+    assert captured["query"] is q_latent
+    torch.testing.assert_close(captured["key"], nope_values)
+    torch.testing.assert_close(captured["value"], nope_values)
+    torch.testing.assert_close(captured["rope"], rope_values)
+
+
+def test_fp8_mla_decode_uses_tilelang_sparse_attention(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    num_queries = 2
+    num_heads = 4
+    q_latent = torch.zeros(num_heads, num_queries, 512, dtype=torch.bfloat16).transpose(0, 1)
+    q_pe = torch.zeros(num_heads, num_queries, 64, dtype=torch.bfloat16).transpose(0, 1)
+    nope_cache = torch.zeros(1, 128, 1, 512, dtype=torch.uint8)
+    rope_cache = torch.zeros(1, 128, 1, 64, dtype=torch.uint8)
+    topk = torch.zeros(num_queries, 1, 2048, dtype=torch.int32)
+    block_table = torch.zeros(num_queries, 1, dtype=torch.int32)
+    actual_seq_kv = torch.full((num_queries,), 128, dtype=torch.int32)
+    backend = object.__new__(npu_paged_attention.NpuPagedAttentionBackend)
+    backend._metadata = SimpleNamespace(
+        is_prefill=False, is_chunked_prefill=False, is_mixed=False, is_spec_verify=False
+    )
+    backend._mla_actual_seq_q = torch.arange(1, num_queries + 1, dtype=torch.int32)
+    backend._mla_actual_seq_kv = actual_seq_kv
+    backend._fp8_e4m3_decode_table = None
+    backend._fp8_mla_workspaces = None
+    backend.scale = 0.0625
+    captured: dict[str, object] = {}
+
+    def glm52_fp8_sparse_mla_attention_out(*args: object) -> torch.Tensor:
+        captured["args"] = args
+        return args[8]  # type: ignore[return-value]
+
+    def sparse_flash_attention_out(*_args: object) -> torch.Tensor:
+        raise AssertionError("eligible FP8 decode must use the fused TileLang kernel")
+
+    monkeypatch.setattr(
+        npu_paged_attention,
+        "get_execution_buffer",
+        lambda _key, factory: factory(),
+    )
+    monkeypatch.setattr(
+        npu_paged_attention.kernels,
+        "glm52_fp8_sparse_mla_attention_out",
+        glm52_fp8_sparse_mla_attention_out,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        npu_paged_attention.kernels,
+        "sparse_flash_attention_out",
+        sparse_flash_attention_out,
+        raising=False,
+    )
+
+    output = backend._mla_sparse(
+        q_latent,
+        q_pe,
+        nope_cache,
+        rope_cache,
+        topk,
+        block_table,
+        backend._mla_actual_seq_q,
+        actual_seq_kv,
+        0,
+    )
+
+    assert output.shape == q_latent.shape
+    assert output.is_contiguous()
+    args = captured["args"]
+    assert isinstance(args, tuple)
+    assert args[0] is q_latent
+    assert args[1] is q_pe
+    assert args[2] is nope_cache
+    assert args[3] is rope_cache
+    assert args[6] is actual_seq_kv
+    assert args[7].shape == (256,)
+    assert args[-1] == backend.scale

--- a/xllm/compiler/tilelang/targets/ascend/aot/fp8_cache_write.py
+++ b/xllm/compiler/tilelang/targets/ascend/aot/fp8_cache_write.py
@@ -1,0 +1,40 @@
+# Copyright 2026 The xLLM Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://github.com/xLLM-AI/xllm/blob/main/LICENSE
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tilelang
+from compiler.tilelang.common.spec import DispatchField, TilelangKernel, register_kernel
+
+from xllm.python.kernels_npu.tilelang import fp8_cache_write as kernel_impl
+from xllm.python.kernels_npu.tilelang import utils as tilelang_utils
+from xllm.python.kernels_npu.tilelang.fp8_cache_write import (
+    SUPPORTED_HEAD_DIMS,
+    build_fp8_cache_write_kernel,
+)
+from xllm.python.kernels_npu.tilelang.utils import DEFAULT_ASCEND_PASS_CONFIGS
+
+DEPENDENCY_MODULES = (kernel_impl, tilelang_utils)
+
+
+@register_kernel
+class Fp8CacheWriteKernel(TilelangKernel):
+    DISPATCH_SCHEMA = [DispatchField("head_dim", "int32")]
+    SPECIALIZATIONS = [{"variant_key": f"d{head_dim}", "head_dim": head_dim} for head_dim in SUPPORTED_HEAD_DIMS]
+
+    @staticmethod
+    def generate_source(head_dim: int) -> str:
+        tilelang.disable_cache()
+        kernel = build_fp8_cache_write_kernel(head_dim)
+        with tilelang.tvm.transform.PassContext(opt_level=3, config=DEFAULT_ASCEND_PASS_CONFIGS):
+            lowered = tilelang.engine.lower(kernel)
+        return lowered.kernel_source

--- a/xllm/compiler/tilelang/targets/ascend/aot/glm52_fp8_sparse_mla_attention.py
+++ b/xllm/compiler/tilelang/targets/ascend/aot/glm52_fp8_sparse_mla_attention.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 The xLLM Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from pathlib import Path
+
+import tilelang
+from compiler.tilelang.common.spec import DispatchField, TilelangKernel, register_kernel
+
+from xllm.python.kernels_npu.tilelang import glm52_fp8_sparse_mla_attention as kernel_impl
+from xllm.python.kernels_npu.tilelang import utils as tilelang_utils
+from xllm.python.kernels_npu.tilelang.glm52_fp8_sparse_mla_attention import (
+    DEFAULT_ASCEND_PASS_CONFIGS,
+    DEFAULT_DTYPE,
+    SUPPORTED_NUM_HEADS,
+    build_glm52_fp8_sparse_mla_attention_kernel,
+)
+
+DEPENDENCY_MODULES = (kernel_impl, tilelang_utils)
+
+
+@register_kernel
+class Glm52Fp8SparseMlaAttentionKernel(TilelangKernel):
+    DISPATCH_SCHEMA = [
+        DispatchField("num_heads", "int32"),
+        DispatchField("dtype", "dtype"),
+    ]
+    SPECIALIZATIONS = [
+        {
+            "variant_key": f"h{num_heads}_bf16",
+            "num_heads": num_heads,
+            "dtype": DEFAULT_DTYPE,
+        }
+        for num_heads in SUPPORTED_NUM_HEADS
+    ]
+
+    @staticmethod
+    def generate_source(num_heads: int, dtype: str) -> str:
+        if dtype != DEFAULT_DTYPE:
+            raise ValueError(f"GLM-5.2 FP8 sparse MLA attention only supports dtype={DEFAULT_DTYPE}, got {dtype}")
+        tilelang.disable_cache()
+        tilelang_kernel = build_glm52_fp8_sparse_mla_attention_kernel(
+            num_heads=num_heads,
+        )
+        with tilelang.tvm.transform.PassContext(
+            opt_level=3,
+            config=DEFAULT_ASCEND_PASS_CONFIGS,
+        ):
+            kernel = tilelang.engine.lower(tilelang_kernel)
+        return kernel.kernel_source
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate the GLM-5.2 FP8 sparse MLA TileLang Ascend-C source.")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--num-heads", type=int, default=8)
+    parser.add_argument("--dtype", default=DEFAULT_DTYPE)
+    args = parser.parse_args()
+
+    output = Path(args.output).resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        Glm52Fp8SparseMlaAttentionKernel.generate_source(
+            num_heads=args.num_heads,
+            dtype=args.dtype,
+        ),
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/xllm/core/common/options.h
+++ b/xllm/core/common/options.h
@@ -275,6 +275,7 @@ class Options {
   // KV cache data type for quantization.
   // "auto" (default): KV cache dtype aligns with model dtype (no quantization).
   // "int8": Enables INT8 quantization. Only supported on MLU backend.
+  // "fp8_e4m3": Enables raw E4M3 cache storage for PyTorch GLM-5.2 on NPU.
   PROPERTY(std::string, kv_cache_dtype) = "auto";
 
   // max concurrency for rec worker

--- a/xllm/core/framework/config/kv_cache_config.cpp
+++ b/xllm/core/framework/config/kv_cache_config.cpp
@@ -39,14 +39,17 @@ DEFINE_string(
     "auto",
     "KV cache data type for quantization. \"auto\" (default): KV "
     "cache dtype aligns with model dtype (no quantization). "
-    "\"int8\": Enables INT8 quantization. Only supported on MLU backend.");
+    "\"int8\": Enables INT8 quantization on MLU. "
+    "\"fp8_e4m3\": Enables E4M3 cache storage for the NPU PyTorch GLM-5.2 "
+    "implementation.");
 
 DEFINE_string(indexer_cache_dtype,
               "auto",
               "Indexer cache data type for quantization. \"auto\" (default): "
               "Indexer cache dtype aligns with model dtype (no "
               "quantization). \"int8\": Enables INT8 quantization when "
-              "supported. Supported on NPU and MLU backends.");
+              "supported. \"fp8_e4m3\": Enables E4M3 cache storage for the "
+              "NPU PyTorch GLM-5.2 implementation.");
 
 DEFINE_bool(enable_prefix_cache,
             true,
@@ -146,9 +149,21 @@ void KVCacheConfig::initialize() {
 }
 
 void KVCacheConfig::validate() const {
-  if (indexer_cache_dtype_ != "auto" && indexer_cache_dtype_ != "int8") {
+#if defined(USE_NPU)
+  const bool indexer_cache_dtype_supported = indexer_cache_dtype_ == "auto" ||
+                                             indexer_cache_dtype_ == "int8" ||
+                                             indexer_cache_dtype_ == "fp8_e4m3";
+  constexpr const char* kSupportedIndexerCacheDtypes =
+      "\"auto\", \"int8\", and \"fp8_e4m3\"";
+#else
+  const bool indexer_cache_dtype_supported =
+      indexer_cache_dtype_ == "auto" || indexer_cache_dtype_ == "int8";
+  constexpr const char* kSupportedIndexerCacheDtypes = "\"auto\" and \"int8\"";
+#endif
+  if (!indexer_cache_dtype_supported) {
     LOG(FATAL) << "Invalid indexer_cache_dtype=\"" << indexer_cache_dtype_
-               << "\". Supported values are exactly \"auto\" and \"int8\".";
+               << "\". Supported values are exactly "
+               << kSupportedIndexerCacheDtypes << ".";
   }
 }
 

--- a/xllm/core/framework/kv_cache/indexed_kv_cache_impl.cpp
+++ b/xllm/core/framework/kv_cache/indexed_kv_cache_impl.cpp
@@ -93,11 +93,13 @@ IndexedKVCacheImpl::IndexedKVCacheImpl(
         &value_cache_shape_);
   }
   if (kv_cache_shape.has_index_cache_shape()) {
-    // Mirror the device index dtype: INT8 when indexer cache is quantized (see
-    // create_indexed_kv_cache_tensors), otherwise the model dtype.
+    // Mirror the device index dtype: raw FP8 bytes, INT8, or the model dtype.
     const torch::ScalarType index_dtype =
-        create_options.enable_indexer_cache_quant() ? torch::kChar
-                                                    : create_options.dtype();
+        create_options.indexer_cache_dtype() == "fp8_e4m3"
+            ? torch::kByte
+            : (create_options.enable_indexer_cache_quant()
+                   ? torch::kChar
+                   : create_options.dtype());
     create_host_tensor(
         build_host_group_tensor_shape(kv_cache_shape.index_cache_shape(),
                                       create_options.host_blocks_factor(),
@@ -108,6 +110,7 @@ IndexedKVCacheImpl::IndexedKVCacheImpl(
   }
   // Keep INT8 per-token scales with their values during offload/reload.
   if (create_options.enable_indexer_cache_quant() &&
+      create_options.indexer_cache_dtype() != "fp8_e4m3" &&
       kv_cache_shape.has_index_cache_scale_shape()) {
     torch::Tensor index_scale;
     const torch::ScalarType index_scale_dtype =
@@ -214,8 +217,7 @@ void IndexedKVCacheImpl::swap_blocks(torch::Tensor& src_tensor,
       torch::index_select(index_cache_, 0, src_tensor);
   index_cache_.index_copy_(0, dst_tensor, selected_index);
 
-  // INT8 indexer cache keeps a per-token fp32 scale that must move with the
-  // int8 values, otherwise dequantization reads mismatched coefficients.
+  // INT8 indexer cache scales move with their quantized values.
   if (index_cache_scale_.has_value() && has_data(index_cache_scale_.value())) {
     torch::Tensor selected_index_scales =
         torch::index_select(index_cache_scale_.value(), 0, src_tensor);

--- a/xllm/core/framework/kv_cache/kv_cache.cpp
+++ b/xllm/core/framework/kv_cache/kv_cache.cpp
@@ -53,9 +53,14 @@ std::unique_ptr<KVCacheImpl> create_kv_cache_impl(
     int64_t layer_id) {
   CHECK_GE(layer_id, 0) << "KV cache layer_id must be non-negative.";
 
-#if !defined(USE_MLU)
+#if !defined(USE_MLU) && !defined(USE_NPU)
   CHECK(!create_options.enable_kv_cache_quant())
-      << "KV cache quantization is only supported on MLU backend.";
+      << "KV cache quantization is unsupported on this backend.";
+#elif defined(USE_NPU)
+  CHECK(!create_options.enable_kv_cache_quant() ||
+        (create_options.model_type() == "glm_moe_dsa" &&
+         create_options.kv_cache_dtype() == "fp8_e4m3"))
+      << "NPU quantized KV cache only supports PyTorch GLM-5.2.";
 #endif
 
   const bool is_linear_layer =

--- a/xllm/core/framework/kv_cache/kv_cache_capacity.h
+++ b/xllm/core/framework/kv_cache/kv_cache_capacity.h
@@ -32,6 +32,8 @@ class KVCacheCapacity final {
   PROPERTY(int64_t, index_slot_size) = 0;
   PROPERTY(int64_t, num_indexer_layers) = 0;
   PROPERTY(bool, enable_indexer_cache_quant) = false;
+  // Quantized index caches keep scales by default; raw FP8 needs none.
+  PROPERTY(bool, enable_indexer_cache_scale) = true;
 
   // for kv cache quantization scale cache
   PROPERTY(int64_t, scale_slot_size) = 0;

--- a/xllm/core/framework/kv_cache/kv_cache_estimation.cpp
+++ b/xllm/core/framework/kv_cache/kv_cache_estimation.cpp
@@ -73,7 +73,7 @@ int64_t kv_slot_size(const ModelArgs& model_args,
 }
 
 int64_t index_slot_size(const ModelArgs& model_args,
-                        bool enable_indexer_cache_quantization,
+                        const std::string& indexer_cache_dtype,
                         int64_t dtype_size) {
   if (model_args.index_n_heads() <= 0) {
     return 0;
@@ -85,9 +85,13 @@ int64_t index_slot_size(const ModelArgs& model_args,
       util::kv_split_size_effective() > 1) {
     split_factor = util::kv_split_size_effective();
   }
-  if (enable_indexer_cache_quantization) {
-    // int8 index cache: one byte per element, plus an independent per-token
-    // fp32 scale (kept separate from the main-KV scale_slot_size path).
+#if defined(USE_NPU)
+  if (indexer_cache_dtype == "fp8_e4m3") {
+    return split_factor * index_n_head * model_args.index_head_dim();
+  }
+#endif
+  if (indexer_cache_dtype == "int8") {
+    // The index scale is kept separate from the main-KV scale_slot_size path.
     return split_factor * (static_cast<int64_t>(sizeof(int8_t)) * index_n_head *
                                model_args.index_head_dim() +
                            static_cast<int64_t>(sizeof(float)));
@@ -100,6 +104,12 @@ int64_t scale_slot_size(const ModelArgs& model_args,
   if (options.kv_cache_dtype == "auto") {
     return 0;
   }
+#if defined(USE_NPU)
+  if (model_args.model_type() == "glm_moe_dsa" &&
+      options.kv_cache_dtype == "fp8_e4m3") {
+    return 0;
+  }
+#endif
   if (model_args.enable_mla()) {
     return sizeof(float);
   }
@@ -670,13 +680,21 @@ KVCacheCapacity estimate_kv_cache_capacity(
       torch::scalarTypeToTypeMeta(options.dtype).itemsize());
   const int64_t cache_dtype_size =
       kv_cache_dtype_size(options.kv_cache_dtype, dtype_size);
+#if defined(USE_NPU)
+  const bool enable_indexer_cache_quantization =
+      options.indexer_cache_dtype == "int8" ||
+      options.indexer_cache_dtype == "fp8_e4m3";
+#else
   const bool enable_indexer_cache_quantization =
       options.indexer_cache_dtype == "int8";
+#endif
+  const bool enable_indexer_cache_scale = options.indexer_cache_dtype == "int8";
 
   kv_cache_cap.slot_size(kv_slot_size(model_args, options, cache_dtype_size))
-      .index_slot_size(index_slot_size(
-          model_args, enable_indexer_cache_quantization, dtype_size))
+      .index_slot_size(
+          index_slot_size(model_args, options.indexer_cache_dtype, dtype_size))
       .enable_indexer_cache_quant(enable_indexer_cache_quantization)
+      .enable_indexer_cache_scale(enable_indexer_cache_scale)
       .scale_slot_size(scale_slot_size(model_args, options))
       .linear_slot_size(linear_slot_size(model_args, options, dtype_size))
       .n_layers(model_args.n_layers())

--- a/xllm/core/framework/kv_cache/kv_cache_shape.cpp
+++ b/xllm/core/framework/kv_cache/kv_cache_shape.cpp
@@ -91,7 +91,8 @@ KVCacheShape::KVCacheShape(const KVCacheCapacity& kv_cache_cap,
 
   apply_device_layout(model_args);
 
-  if (enable_lighting_indexer && kv_cache_cap.enable_indexer_cache_quant()) {
+  if (enable_lighting_indexer && kv_cache_cap.enable_indexer_cache_quant() &&
+      kv_cache_cap.enable_indexer_cache_scale()) {
     init_index_cache_scale_shape();
   }
 }

--- a/xllm/core/framework/kv_cache/kv_cache_utils.cpp
+++ b/xllm/core/framework/kv_cache/kv_cache_utils.cpp
@@ -225,8 +225,11 @@ IndexedKVCacheTensors create_indexed_kv_cache_tensors(
                                            create_options);
 #elif defined(USE_NPU)
   const torch::ScalarType index_dtype =
-      create_options.enable_indexer_cache_quant() ? torch::kChar
-                                                  : create_options.dtype();
+      create_options.indexer_cache_dtype() == "fp8_e4m3"
+          ? torch::kByte
+          : (create_options.enable_indexer_cache_quant()
+                 ? torch::kChar
+                 : create_options.dtype());
   const aclFormat npu_format_type =
       get_npu_kv_cache_format(create_options.model_type());
   if (create_options.enable_kv_cache_huge_page_allocator()) {
@@ -243,7 +246,8 @@ IndexedKVCacheTensors create_indexed_kv_cache_tensors(
       kv_cache_shape.index_cache_shape(),
       torch::dtype(create_options.dtype()).device(create_options.device()));
 #endif
-  if (create_options.enable_indexer_cache_quant()) {
+  if (create_options.enable_indexer_cache_quant() &&
+      create_options.indexer_cache_dtype() != "fp8_e4m3") {
 #if !defined(USE_MLU) && !defined(USE_NPU)
     CHECK(false) << "Indexer cache INT8 is unsupported on this backend.";
 #endif
@@ -285,6 +289,18 @@ IndexedKVCacheTensors create_indexed_kv_cache_tensors(
 QuantizedKVCacheTensors create_quantized_kv_cache_tensors(
     const KVCacheShape& kv_cache_shape,
     const KVCacheCreateOptions& create_options) {
+#if defined(USE_NPU)
+  CHECK_EQ(create_options.model_type(), "glm_moe_dsa")
+      << "NPU FP8 KV cache only supports PyTorch GLM-5.2.";
+  CHECK_EQ(create_options.kv_cache_dtype(), "fp8_e4m3")
+      << "NPU KV cache quantization only supports fp8_e4m3.";
+  KVCacheCreateOptions fp8_options = create_options;
+  fp8_options.dtype(torch::kByte);
+  QuantizedKVCacheTensors tensors;
+  tensors.kv_cache_tensors =
+      create_kv_cache_tensors(kv_cache_shape, fp8_options);
+  return tensors;
+#else
 #if !defined(USE_MLU)
   CHECK(!create_options.enable_kv_cache_quant())
       << "KV cache quantization is only supported on MLU backend.";
@@ -319,6 +335,7 @@ QuantizedKVCacheTensors create_quantized_kv_cache_tensors(
   }
 
   return tensors;
+#endif
 }
 
 LinearAttentionKVCacheTensors create_linear_attention_kv_cache_tensors(

--- a/xllm/core/framework/kv_cache/kv_cache_utils.h
+++ b/xllm/core/framework/kv_cache/kv_cache_utils.h
@@ -82,11 +82,13 @@ struct KVCacheCreateOptions {
   // whether that layer owns indexer cache tensors.
   PROPERTY(std::vector<bool>, indexer_cache_enabled_layers);
   PROPERTY(bool, enable_kv_cache_quant) = false;
+  PROPERTY(std::string, kv_cache_dtype) = "auto";
   PROPERTY(std::shared_ptr<KVCacheTensorAllocator>, tensor_allocator);
 #if defined(USE_NPU)
   PROPERTY(bool, enable_kv_cache_huge_page_allocator) = false;
 #endif
   PROPERTY(bool, enable_indexer_cache_quant) = false;
+  PROPERTY(std::string, indexer_cache_dtype) = "auto";
 
   // DeepSeek V4 cache allocation metadata.
   PROPERTY(int64_t, block_size) = 0;

--- a/xllm/core/framework/kv_cache/quantized_kv_cache_impl.h
+++ b/xllm/core/framework/kv_cache/quantized_kv_cache_impl.h
@@ -32,7 +32,7 @@ class QuantizedKVCacheImpl final : public KVCacheImpl {
                    torch::Tensor& dst_tensor) override;
 
  private:
-  // scale tensors for quantized KV cache (int8)
+  // Scale tensors are defined for INT8 cache formats and absent for FP8.
   torch::Tensor key_cache_scale_;
   torch::Tensor value_cache_scale_;
 };

--- a/xllm/core/kernels/npu/npu_ops_library.cpp
+++ b/xllm/core/kernels/npu/npu_ops_library.cpp
@@ -39,6 +39,51 @@ namespace xllm {
 
 namespace {
 
+void fp8_cache_write_npu(const torch::Tensor& slots,
+                         const torch::Tensor& values,
+                         torch::Tensor& cache) {
+  xllm::kernel::npu::tilelang::fp8_cache_write(slots, values, cache);
+}
+
+torch::Tensor glm52_fp8_sparse_mla_attention_out_npu(
+    const torch::Tensor& q_latent,
+    const torch::Tensor& q_rope,
+    const torch::Tensor& nope_cache,
+    const torch::Tensor& rope_cache,
+    const torch::Tensor& topk_indices,
+    const torch::Tensor& block_table,
+    const torch::Tensor& actual_seq_lengths_kv,
+    const torch::Tensor& e4m3_decode_table,
+    torch::Tensor& output,
+    torch::Tensor& workspace_k,
+    torch::Tensor& workspace_k_rope,
+    torch::Tensor& workspace_scores,
+    torch::Tensor& workspace_probs,
+    torch::Tensor& workspace_output,
+    torch::Tensor& workspace_q,
+    torch::Tensor& workspace_q_rope,
+    double softmax_scale) {
+  xllm::kernel::npu::tilelang::glm52_fp8_sparse_mla_attention(
+      q_latent,
+      q_rope,
+      nope_cache,
+      rope_cache,
+      topk_indices,
+      block_table,
+      actual_seq_lengths_kv,
+      e4m3_decode_table,
+      output,
+      workspace_k,
+      workspace_k_rope,
+      workspace_scores,
+      workspace_probs,
+      workspace_output,
+      workspace_q,
+      workspace_q_rope,
+      static_cast<float>(softmax_scale));
+  return output;
+}
+
 torch::Tensor rms_norm_npu(const torch::Tensor& input,
                            const torch::Tensor& weight,
                            double eps) {
@@ -481,6 +526,15 @@ void ensure_xllm_ops_registered() {
 // Schema declarations (device-agnostic). Identical to cuda_ops_library.cpp —
 // compiled only under USE_NPU (mutually exclusive with USE_CUDA).
 TORCH_LIBRARY(xllm_ops, m) {
+  m.def("fp8_cache_write(Tensor slots, Tensor values, Tensor(a!) cache) -> ()");
+  m.def(
+      "glm52_fp8_sparse_mla_attention_out(Tensor q_latent, Tensor q_rope, "
+      "Tensor nope_cache, Tensor rope_cache, Tensor topk_indices, Tensor "
+      "block_table, Tensor actual_seq_lengths_kv, Tensor e4m3_decode_table, "
+      "Tensor(a!) output, Tensor(b!) workspace_k, Tensor(c!) "
+      "workspace_k_rope, Tensor(d!) workspace_scores, Tensor(e!) "
+      "workspace_probs, Tensor(f!) workspace_output, Tensor(g!) workspace_q, "
+      "Tensor(h!) workspace_q_rope, float softmax_scale) -> Tensor(a!)");
   m.def("rms_norm(Tensor input, Tensor weight, float eps) -> Tensor");
   m.def(
       "rms_norm_gated(Tensor input, Tensor gate, Tensor weight, float eps) -> "
@@ -688,6 +742,9 @@ TORCH_LIBRARY(xllm_ops, m) {
 }
 
 TORCH_LIBRARY_IMPL(xllm_ops, PrivateUse1, m) {
+  m.impl("fp8_cache_write", TORCH_FN(xllm::fp8_cache_write_npu));
+  m.impl("glm52_fp8_sparse_mla_attention_out",
+         TORCH_FN(xllm::glm52_fp8_sparse_mla_attention_out_npu));
   m.impl("rms_norm", TORCH_FN(xllm::rms_norm_npu));
   m.impl("rms_norm_gated", TORCH_FN(xllm::rms_norm_gated_npu));
   m.impl("l2_norm", TORCH_FN(xllm::l2_norm_npu));

--- a/xllm/core/kernels/npu/tilelang/CMakeLists.txt
+++ b/xllm/core/kernels/npu/tilelang/CMakeLists.txt
@@ -133,6 +133,16 @@ tilelang_register_runtime_kernel(
 )
 
 tilelang_register_runtime_kernel(
+  NAME fp8_cache_write
+  WRAPPER_SRCS fp8_cache_write_wrapper.cpp
+)
+
+tilelang_register_runtime_kernel(
+  NAME glm52_fp8_sparse_mla_attention
+  WRAPPER_SRCS glm52_fp8_sparse_mla_attention_wrapper.cpp
+)
+
+tilelang_register_runtime_kernel(
   NAME spec_verify_attention_tiling_update
   WRAPPER_SRCS spec_verify_attention_tiling_update_wrapper.cpp
 )

--- a/xllm/core/kernels/npu/tilelang/fp8_cache_write_wrapper.cpp
+++ b/xllm/core/kernels/npu/tilelang/fp8_cache_write_wrapper.cpp
@@ -1,0 +1,72 @@
+/* Copyright 2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <glog/logging.h>
+#include <torch_npu/csrc/core/npu/NPUStream.h>
+
+#include <cstdint>
+#include <limits>
+
+#include "core/kernels/npu/tilelang/dispatch_registry.h"
+#include "core/kernels/npu/tilelang/tilelang_ops_api.h"
+
+#ifndef XLLM_TL_FP8_CACHE_WRITE_REGISTRY_INC
+#error "XLLM_TL_FP8_CACHE_WRITE_REGISTRY_INC is not defined"
+#endif
+
+namespace xllm::kernel::npu::tilelang {
+namespace {
+#include XLLM_TL_FP8_CACHE_WRITE_REGISTRY_INC
+}  // namespace
+
+void fp8_cache_write(const torch::Tensor& slots,
+                     const torch::Tensor& values,
+                     torch::Tensor& cache) {
+  CHECK(slots.defined() && values.defined() && cache.defined());
+  CHECK(cache.device().type() == torch::kPrivateUse1);
+  CHECK(slots.device() == cache.device() && values.device() == cache.device());
+  CHECK(slots.is_contiguous() && values.is_contiguous() &&
+        cache.is_contiguous());
+  CHECK_EQ(slots.scalar_type(), torch::kInt64);
+  CHECK_EQ(values.scalar_type(), torch::kUInt8);
+  CHECK_EQ(cache.scalar_type(), torch::kUInt8);
+  CHECK_EQ(slots.dim(), 1);
+  CHECK_EQ(values.dim(), 2);
+  CHECK_EQ(cache.dim(), 2);
+  CHECK_EQ(values.size(0), slots.numel());
+  CHECK_EQ(values.size(1), cache.size(1));
+  CHECK(cache.size(1) == 64 || cache.size(1) == 128 || cache.size(1) == 512);
+  if (slots.numel() == 0) {
+    return;
+  }
+  CHECK_GT(cache.size(0), 0);
+  CHECK_LE(cache.size(0),
+           static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+  const auto specialization = make_fp8_cache_write_specialization(
+      Fp8CacheWriteHeadDim{static_cast<int32_t>(cache.size(1))});
+  const auto* entry = find_fp8_cache_write_kernel_entry(specialization);
+  CHECK(entry != nullptr) << "No compiled FP8 cache writer for head_dim="
+                          << cache.size(1);
+  aclrtStream stream =
+      c10_npu::getCurrentNPUStream(cache.device().index()).stream();
+  entry->fn(static_cast<uint8_t*>(slots.data_ptr()),
+            static_cast<uint8_t*>(values.data_ptr()),
+            static_cast<uint8_t*>(cache.data_ptr()),
+            slots.numel(),
+            cache.size(0),
+            stream);
+}
+
+}  // namespace xllm::kernel::npu::tilelang

--- a/xllm/core/kernels/npu/tilelang/glm52_fp8_sparse_mla_attention_wrapper.cpp
+++ b/xllm/core/kernels/npu/tilelang/glm52_fp8_sparse_mla_attention_wrapper.cpp
@@ -1,0 +1,387 @@
+/* Copyright 2026 The xLLM Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/xLLM-AI/xllm/blob/main/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <glog/logging.h>
+#include <torch_npu/csrc/core/npu/NPUStream.h>
+#include <torch_npu/torch_npu.h>
+
+#include <cstdint>
+#include <limits>
+#include <string_view>
+
+#include "acl/acl.h"
+#include "core/kernels/npu/tilelang/dispatch_registry.h"
+#include "core/kernels/npu/tilelang/tilelang_ops_api.h"
+
+#ifndef XLLM_TL_GLM52_FP8_SPARSE_MLA_ATTENTION_REGISTRY_INC
+#error "XLLM_TL_GLM52_FP8_SPARSE_MLA_ATTENTION_REGISTRY_INC is not defined"
+#endif
+
+namespace xllm::kernel::npu::tilelang {
+namespace {
+
+constexpr int64_t kLatentDim = 512;
+constexpr int64_t kRopeDim = 64;
+constexpr int64_t kTopk = 2048;
+constexpr int64_t kBlockSize = 128;
+constexpr int64_t kCoreNum = 24;
+constexpr int64_t kHeadTile = 16;
+constexpr int64_t kKvTile = 64;
+constexpr int64_t kMaxNumQueries = 1024;
+constexpr int64_t kMaxCacheBlocks = 32768;
+constexpr int64_t kMaxBlockTableLen = 32768;
+
+#include XLLM_TL_GLM52_FP8_SPARSE_MLA_ATTENTION_REGISTRY_INC
+
+void check_npu(const torch::Tensor& tensor, std::string_view name) {
+  CHECK(tensor.defined()) << name << " must be defined";
+  CHECK_EQ(tensor.device().type(), torch::kPrivateUse1)
+      << name << " must be on NPU";
+}
+
+void check_npu_contiguous(const torch::Tensor& tensor, std::string_view name) {
+  check_npu(tensor, name);
+  CHECK(tensor.is_contiguous()) << name << " must be contiguous";
+}
+
+void check_same_device(const torch::Tensor& tensor,
+                       const torch::Tensor& reference,
+                       std::string_view name) {
+  CHECK(tensor.device() == reference.device())
+      << name << " must be on the same NPU device as q_latent";
+}
+
+void check_workspace(const torch::Tensor& workspace,
+                     std::string_view name,
+                     torch::ScalarType dtype,
+                     int64_t core_slots,
+                     int64_t dim_1,
+                     int64_t dim_2) {
+  check_npu_contiguous(workspace, name);
+  CHECK_EQ(workspace.dtype(), dtype) << name << " dtype mismatch";
+  CHECK_EQ(workspace.dim(), 3) << name << " must be 3D";
+  CHECK_EQ(workspace.size(0), core_slots)
+      << name << " core slot dimension mismatch";
+  CHECK_EQ(workspace.size(1), dim_1) << name << " tile dimension mismatch";
+  CHECK_EQ(workspace.size(2), dim_2) << name << " feature dimension mismatch";
+}
+
+void check_supported(const torch::Tensor& q_latent,
+                     const torch::Tensor& q_rope,
+                     const torch::Tensor& nope_cache,
+                     const torch::Tensor& rope_cache,
+                     const torch::Tensor& topk_indices,
+                     const torch::Tensor& block_table,
+                     const torch::Tensor& actual_seq_lengths_kv,
+                     const torch::Tensor& e4m3_decode_table,
+                     const torch::Tensor& output,
+                     const torch::Tensor& workspace_k,
+                     const torch::Tensor& workspace_k_rope,
+                     const torch::Tensor& workspace_scores,
+                     const torch::Tensor& workspace_probs,
+                     const torch::Tensor& workspace_output,
+                     const torch::Tensor& workspace_q,
+                     const torch::Tensor& workspace_q_rope) {
+  check_npu(q_latent, "TileLang GLM-5.2 FP8 MLA: q_latent");
+  check_npu(q_rope, "TileLang GLM-5.2 FP8 MLA: q_rope");
+  check_npu_contiguous(nope_cache, "TileLang GLM-5.2 FP8 MLA: nope_cache");
+  check_npu_contiguous(rope_cache, "TileLang GLM-5.2 FP8 MLA: rope_cache");
+  check_npu_contiguous(topk_indices, "TileLang GLM-5.2 FP8 MLA: topk_indices");
+  check_npu_contiguous(block_table, "TileLang GLM-5.2 FP8 MLA: block_table");
+  check_npu_contiguous(actual_seq_lengths_kv,
+                       "TileLang GLM-5.2 FP8 MLA: actual_seq_lengths_kv");
+  check_npu_contiguous(e4m3_decode_table,
+                       "TileLang GLM-5.2 FP8 MLA: e4m3_decode_table");
+  check_npu_contiguous(output, "TileLang GLM-5.2 FP8 MLA: output");
+
+  CHECK_EQ(q_latent.dtype(), torch::kBFloat16)
+      << "TileLang GLM-5.2 FP8 MLA: q_latent must be bfloat16";
+  CHECK_EQ(q_rope.dtype(), q_latent.dtype())
+      << "TileLang GLM-5.2 FP8 MLA: q_rope dtype mismatch";
+  CHECK_EQ(nope_cache.dtype(), torch::kUInt8)
+      << "TileLang GLM-5.2 FP8 MLA: nope_cache must contain raw uint8 E4M3 "
+         "bytes";
+  CHECK_EQ(rope_cache.dtype(), torch::kUInt8)
+      << "TileLang GLM-5.2 FP8 MLA: rope_cache must contain raw uint8 E4M3 "
+         "bytes";
+  CHECK_EQ(topk_indices.dtype(), torch::kInt32)
+      << "TileLang GLM-5.2 FP8 MLA: topk_indices must be int32";
+  CHECK_EQ(block_table.dtype(), torch::kInt32)
+      << "TileLang GLM-5.2 FP8 MLA: block_table must be int32";
+  CHECK_EQ(actual_seq_lengths_kv.dtype(), torch::kInt32)
+      << "TileLang GLM-5.2 FP8 MLA: actual_seq_lengths_kv must be int32";
+  CHECK_EQ(e4m3_decode_table.dtype(), torch::kFloat32)
+      << "TileLang GLM-5.2 FP8 MLA: E4M3 decode table must be float32";
+  CHECK_EQ(output.dtype(), q_latent.dtype())
+      << "TileLang GLM-5.2 FP8 MLA: output dtype mismatch";
+
+  CHECK_EQ(q_latent.dim(), 3)
+      << "TileLang GLM-5.2 FP8 MLA: q_latent must be [T, H, 512]";
+  CHECK_EQ(q_rope.dim(), 3)
+      << "TileLang GLM-5.2 FP8 MLA: q_rope must be [T, H, 64]";
+  CHECK_EQ(q_latent.size(2), kLatentDim)
+      << "TileLang GLM-5.2 FP8 MLA: latent dimension must be 512";
+  CHECK_EQ(q_rope.size(2), kRopeDim)
+      << "TileLang GLM-5.2 FP8 MLA: rope dimension must be 64";
+  CHECK_EQ(q_rope.size(0), q_latent.size(0))
+      << "TileLang GLM-5.2 FP8 MLA: query token mismatch";
+  CHECK_EQ(q_rope.size(1), q_latent.size(1))
+      << "TileLang GLM-5.2 FP8 MLA: query head mismatch";
+  CHECK_EQ(q_latent.stride(2), 1)
+      << "TileLang GLM-5.2 FP8 MLA: q_latent last dimension must be contiguous";
+  CHECK_EQ(q_rope.stride(2), 1)
+      << "TileLang GLM-5.2 FP8 MLA: q_rope last dimension must be contiguous";
+  CHECK_GT(q_latent.stride(0), 0)
+      << "TileLang GLM-5.2 FP8 MLA: q_latent token stride must be positive";
+  CHECK_GT(q_latent.stride(1), 0)
+      << "TileLang GLM-5.2 FP8 MLA: q_latent head stride must be positive";
+  CHECK_GT(q_rope.stride(0), 0)
+      << "TileLang GLM-5.2 FP8 MLA: q_rope token stride must be positive";
+  CHECK_GT(q_rope.stride(1), 0)
+      << "TileLang GLM-5.2 FP8 MLA: q_rope head stride must be positive";
+  CHECK(q_latent.size(1) == 4 || q_latent.size(1) == 8 ||
+        q_latent.size(1) == 16)
+      << "TileLang GLM-5.2 FP8 MLA: supported local head counts are 4, 8, 16";
+  CHECK_LE(q_latent.size(0), kMaxNumQueries)
+      << "TileLang GLM-5.2 FP8 MLA: query count exceeds compile limit";
+
+  CHECK_EQ(nope_cache.dim(), 4)
+      << "TileLang GLM-5.2 FP8 MLA: nope_cache must be [B, 128, 1, 512]";
+  CHECK_EQ(rope_cache.dim(), 4)
+      << "TileLang GLM-5.2 FP8 MLA: rope_cache must be [B, 128, 1, 64]";
+  CHECK_EQ(nope_cache.size(0), rope_cache.size(0))
+      << "TileLang GLM-5.2 FP8 MLA: cache block count mismatch";
+  CHECK_GT(nope_cache.size(0), 0)
+      << "TileLang GLM-5.2 FP8 MLA: cache must contain at least one block";
+  CHECK_LE(nope_cache.size(0), kMaxCacheBlocks)
+      << "TileLang GLM-5.2 FP8 MLA: cache block count exceeds compile limit";
+  CHECK_EQ(nope_cache.size(1), kBlockSize)
+      << "TileLang GLM-5.2 FP8 MLA: cache block size must be 128";
+  CHECK_EQ(rope_cache.size(1), kBlockSize)
+      << "TileLang GLM-5.2 FP8 MLA: rope cache block size must be 128";
+  CHECK_EQ(nope_cache.size(2), 1)
+      << "TileLang GLM-5.2 FP8 MLA: nope_cache must have one KV head";
+  CHECK_EQ(rope_cache.size(2), 1)
+      << "TileLang GLM-5.2 FP8 MLA: rope_cache must have one KV head";
+  CHECK_EQ(nope_cache.size(3), kLatentDim)
+      << "TileLang GLM-5.2 FP8 MLA: nope_cache dimension must be 512";
+  CHECK_EQ(rope_cache.size(3), kRopeDim)
+      << "TileLang GLM-5.2 FP8 MLA: rope_cache dimension must be 64";
+
+  CHECK_EQ(topk_indices.dim(), 3)
+      << "TileLang GLM-5.2 FP8 MLA: topk_indices must be [T, 1, 2048]";
+  CHECK_EQ(topk_indices.size(0), q_latent.size(0))
+      << "TileLang GLM-5.2 FP8 MLA: topk query count mismatch";
+  CHECK_EQ(topk_indices.size(1), 1)
+      << "TileLang GLM-5.2 FP8 MLA: topk_indices must have one KV head";
+  CHECK_EQ(topk_indices.size(2), kTopk)
+      << "TileLang GLM-5.2 FP8 MLA: topk count must be 2048";
+
+  CHECK_EQ(block_table.dim(), 2)
+      << "TileLang GLM-5.2 FP8 MLA: block_table must be 2D";
+  CHECK_EQ(block_table.size(0), q_latent.size(0))
+      << "TileLang GLM-5.2 FP8 MLA: block_table batch mismatch";
+  CHECK_GT(block_table.size(1), 0) << "TileLang GLM-5.2 FP8 MLA: block_table "
+                                      "must contain at least one block";
+  CHECK_LE(block_table.size(1), kMaxBlockTableLen)
+      << "TileLang GLM-5.2 FP8 MLA: block_table stride exceeds compile limit";
+  CHECK_EQ(actual_seq_lengths_kv.dim(), 1)
+      << "TileLang GLM-5.2 FP8 MLA: actual_seq_lengths_kv must be 1D";
+  CHECK_EQ(actual_seq_lengths_kv.size(0), q_latent.size(0))
+      << "TileLang GLM-5.2 FP8 MLA: sequence length batch mismatch";
+  CHECK_EQ(e4m3_decode_table.dim(), 1)
+      << "TileLang GLM-5.2 FP8 MLA: E4M3 decode table must be 1D";
+  CHECK_EQ(e4m3_decode_table.size(0), 256)
+      << "TileLang GLM-5.2 FP8 MLA: E4M3 decode table must have 256 entries";
+  CHECK_EQ(output.sizes(), q_latent.sizes())
+      << "TileLang GLM-5.2 FP8 MLA: output shape mismatch";
+
+  check_workspace(workspace_k,
+                  "TileLang GLM-5.2 FP8 MLA: workspace_k",
+                  torch::kBFloat16,
+                  kCoreNum,
+                  kKvTile,
+                  kLatentDim);
+  check_workspace(workspace_k_rope,
+                  "TileLang GLM-5.2 FP8 MLA: workspace_k_rope",
+                  torch::kBFloat16,
+                  kCoreNum,
+                  kKvTile,
+                  kRopeDim);
+  check_workspace(workspace_scores,
+                  "TileLang GLM-5.2 FP8 MLA: workspace_scores",
+                  torch::kFloat32,
+                  kCoreNum,
+                  kHeadTile,
+                  kKvTile);
+  check_workspace(workspace_probs,
+                  "TileLang GLM-5.2 FP8 MLA: workspace_probs",
+                  torch::kBFloat16,
+                  kCoreNum,
+                  kHeadTile,
+                  kKvTile);
+  check_workspace(workspace_output,
+                  "TileLang GLM-5.2 FP8 MLA: workspace_output",
+                  torch::kFloat32,
+                  kCoreNum,
+                  kHeadTile,
+                  kLatentDim);
+  check_workspace(workspace_q,
+                  "TileLang GLM-5.2 FP8 MLA: workspace_q",
+                  torch::kBFloat16,
+                  kCoreNum,
+                  kHeadTile,
+                  kLatentDim);
+  check_workspace(workspace_q_rope,
+                  "TileLang GLM-5.2 FP8 MLA: workspace_q_rope",
+                  torch::kBFloat16,
+                  kCoreNum,
+                  kHeadTile,
+                  kRopeDim);
+
+  check_same_device(q_rope, q_latent, "TileLang GLM-5.2 FP8 MLA: q_rope");
+  check_same_device(
+      nope_cache, q_latent, "TileLang GLM-5.2 FP8 MLA: nope_cache");
+  check_same_device(
+      rope_cache, q_latent, "TileLang GLM-5.2 FP8 MLA: rope_cache");
+  check_same_device(
+      topk_indices, q_latent, "TileLang GLM-5.2 FP8 MLA: topk_indices");
+  check_same_device(
+      block_table, q_latent, "TileLang GLM-5.2 FP8 MLA: block_table");
+  check_same_device(actual_seq_lengths_kv,
+                    q_latent,
+                    "TileLang GLM-5.2 FP8 MLA: actual_seq_lengths_kv");
+  check_same_device(e4m3_decode_table,
+                    q_latent,
+                    "TileLang GLM-5.2 FP8 MLA: e4m3_decode_table");
+  check_same_device(output, q_latent, "TileLang GLM-5.2 FP8 MLA: output");
+  check_same_device(
+      workspace_k, q_latent, "TileLang GLM-5.2 FP8 MLA: workspace_k");
+  check_same_device(
+      workspace_k_rope, q_latent, "TileLang GLM-5.2 FP8 MLA: workspace_k_rope");
+  check_same_device(
+      workspace_scores, q_latent, "TileLang GLM-5.2 FP8 MLA: workspace_scores");
+  check_same_device(
+      workspace_probs, q_latent, "TileLang GLM-5.2 FP8 MLA: workspace_probs");
+  check_same_device(
+      workspace_output, q_latent, "TileLang GLM-5.2 FP8 MLA: workspace_output");
+  check_same_device(
+      workspace_q, q_latent, "TileLang GLM-5.2 FP8 MLA: workspace_q");
+  check_same_device(
+      workspace_q_rope, q_latent, "TileLang GLM-5.2 FP8 MLA: workspace_q_rope");
+}
+
+}  // namespace
+
+void glm52_fp8_sparse_mla_attention(const torch::Tensor& q_latent,
+                                    const torch::Tensor& q_rope,
+                                    const torch::Tensor& nope_cache,
+                                    const torch::Tensor& rope_cache,
+                                    const torch::Tensor& topk_indices,
+                                    const torch::Tensor& block_table,
+                                    const torch::Tensor& actual_seq_lengths_kv,
+                                    const torch::Tensor& e4m3_decode_table,
+                                    torch::Tensor& output,
+                                    torch::Tensor& workspace_k,
+                                    torch::Tensor& workspace_k_rope,
+                                    torch::Tensor& workspace_scores,
+                                    torch::Tensor& workspace_probs,
+                                    torch::Tensor& workspace_output,
+                                    torch::Tensor& workspace_q,
+                                    torch::Tensor& workspace_q_rope,
+                                    float softmax_scale) {
+  check_supported(q_latent,
+                  q_rope,
+                  nope_cache,
+                  rope_cache,
+                  topk_indices,
+                  block_table,
+                  actual_seq_lengths_kv,
+                  e4m3_decode_table,
+                  output,
+                  workspace_k,
+                  workspace_k_rope,
+                  workspace_scores,
+                  workspace_probs,
+                  workspace_output,
+                  workspace_q,
+                  workspace_q_rope);
+  if (q_latent.size(0) == 0) {
+    return;
+  }
+
+  CHECK_LE(q_latent.size(0),
+           static_cast<int64_t>(std::numeric_limits<int32_t>::max()))
+      << "TileLang GLM-5.2 FP8 MLA: query count exceeds int32 range";
+  CHECK_LE(block_table.size(1),
+           static_cast<int64_t>(std::numeric_limits<int32_t>::max()))
+      << "TileLang GLM-5.2 FP8 MLA: block_table stride exceeds int32 range";
+  CHECK_LE(q_latent.stride(0),
+           static_cast<int64_t>(std::numeric_limits<int32_t>::max()))
+      << "TileLang GLM-5.2 FP8 MLA: q_latent token stride exceeds int32 range";
+  CHECK_LE(q_latent.stride(1),
+           static_cast<int64_t>(std::numeric_limits<int32_t>::max()))
+      << "TileLang GLM-5.2 FP8 MLA: q_latent head stride exceeds int32 range";
+  CHECK_LE(q_rope.stride(0),
+           static_cast<int64_t>(std::numeric_limits<int32_t>::max()))
+      << "TileLang GLM-5.2 FP8 MLA: q_rope token stride exceeds int32 range";
+  CHECK_LE(q_rope.stride(1),
+           static_cast<int64_t>(std::numeric_limits<int32_t>::max()))
+      << "TileLang GLM-5.2 FP8 MLA: q_rope head stride exceeds int32 range";
+
+  const auto specialization =
+      make_glm52_fp8_sparse_mla_attention_specialization(
+          Glm52Fp8SparseMlaAttentionNumHeads{
+              static_cast<int32_t>(q_latent.size(1))},
+          Glm52Fp8SparseMlaAttentionDType{
+              to_tilelang_dtype(q_latent.scalar_type())});
+  const auto* entry =
+      find_glm52_fp8_sparse_mla_attention_kernel_entry(specialization);
+  CHECK(entry != nullptr)
+      << "TileLang GLM-5.2 FP8 MLA: no compiled variant. Available variants: "
+      << available_glm52_fp8_sparse_mla_attention_variant_keys();
+
+  const int32_t device_id = q_latent.device().index();
+  aclrtStream stream = c10_npu::getCurrentNPUStream(device_id).stream();
+  entry->fn(
+      reinterpret_cast<uint8_t*>(const_cast<void*>(q_latent.data_ptr())),
+      reinterpret_cast<uint8_t*>(const_cast<void*>(q_rope.data_ptr())),
+      reinterpret_cast<uint8_t*>(const_cast<void*>(nope_cache.data_ptr())),
+      reinterpret_cast<uint8_t*>(const_cast<void*>(rope_cache.data_ptr())),
+      reinterpret_cast<uint8_t*>(const_cast<void*>(topk_indices.data_ptr())),
+      reinterpret_cast<uint8_t*>(const_cast<void*>(block_table.data_ptr())),
+      reinterpret_cast<uint8_t*>(
+          const_cast<void*>(actual_seq_lengths_kv.data_ptr())),
+      reinterpret_cast<uint8_t*>(
+          const_cast<void*>(e4m3_decode_table.data_ptr())),
+      reinterpret_cast<uint8_t*>(output.data_ptr()),
+      reinterpret_cast<uint8_t*>(workspace_k.data_ptr()),
+      reinterpret_cast<uint8_t*>(workspace_k_rope.data_ptr()),
+      reinterpret_cast<uint8_t*>(workspace_scores.data_ptr()),
+      reinterpret_cast<uint8_t*>(workspace_probs.data_ptr()),
+      reinterpret_cast<uint8_t*>(workspace_output.data_ptr()),
+      reinterpret_cast<uint8_t*>(workspace_q.data_ptr()),
+      reinterpret_cast<uint8_t*>(workspace_q_rope.data_ptr()),
+      static_cast<int32_t>(q_latent.stride(0)),
+      static_cast<int32_t>(q_latent.stride(1)),
+      static_cast<int32_t>(q_rope.stride(0)),
+      static_cast<int32_t>(q_rope.stride(1)),
+      static_cast<int32_t>(q_latent.size(0)),
+      static_cast<int32_t>(block_table.size(1)),
+      softmax_scale,
+      stream);
+}
+
+}  // namespace xllm::kernel::npu::tilelang

--- a/xllm/core/kernels/npu/tilelang/tilelang_ops_api.h
+++ b/xllm/core/kernels/npu/tilelang/tilelang_ops_api.h
@@ -28,6 +28,32 @@ namespace xllm::kernel::npu::tilelang {
 
 // Public TileLang kernel APIs exported to the xLLM NPU runtime.
 
+// Copy contiguous byte rows to paged cache slots; negative slots are padding.
+void fp8_cache_write(const torch::Tensor& slots,
+                     const torch::Tensor& values,
+                     torch::Tensor& cache);
+
+// Compute GLM-5.2 decode-only sparse MLA attention directly from raw E4M3
+// paged latent and RoPE caches. All output and workspace tensors are caller
+// owned to keep graph capture allocation-free.
+void glm52_fp8_sparse_mla_attention(const torch::Tensor& q_latent,
+                                    const torch::Tensor& q_rope,
+                                    const torch::Tensor& nope_cache,
+                                    const torch::Tensor& rope_cache,
+                                    const torch::Tensor& topk_indices,
+                                    const torch::Tensor& block_table,
+                                    const torch::Tensor& actual_seq_lengths_kv,
+                                    const torch::Tensor& e4m3_decode_table,
+                                    torch::Tensor& output,
+                                    torch::Tensor& workspace_k,
+                                    torch::Tensor& workspace_k_rope,
+                                    torch::Tensor& workspace_scores,
+                                    torch::Tensor& workspace_probs,
+                                    torch::Tensor& workspace_output,
+                                    torch::Tensor& workspace_q,
+                                    torch::Tensor& workspace_q_rope,
+                                    float softmax_scale);
+
 // Take the first token from each row of an existing row-major int32 verify
 // buffer and pack it with `spec_width - 1` proposer columns into graph-owned
 // row-major int32 storage on the current NPU stream. `spec_width` equals

--- a/xllm/core/runtime/options.h
+++ b/xllm/core/runtime/options.h
@@ -283,6 +283,7 @@ struct Options {
   // KV cache data type for quantization.
   // "auto" (default): KV cache dtype aligns with model dtype (no quantization).
   // "int8": Enables INT8 quantization. Only supported on MLU backend.
+  // "fp8_e4m3": Enables raw E4M3 cache storage for PyTorch GLM-5.2 on NPU.
   PROPERTY(std::string, kv_cache_dtype) = "auto";
 
   // max concurrency for rec worker

--- a/xllm/core/runtime/worker_impl.cpp
+++ b/xllm/core/runtime/worker_impl.cpp
@@ -55,6 +55,7 @@ limitations under the License.
 #include "core/framework/config/kernel_config.h"
 #include "core/framework/config/kv_cache_config.h"
 #include "core/framework/config/load_config.h"
+#include "core/framework/config/model_config.h"
 #include "core/framework/config/profile_config.h"
 #include "core/framework/config/scheduler_config.h"
 #include "core/framework/config/speculative_config.h"
@@ -511,23 +512,38 @@ bool WorkerImpl::allocate_kv_cache_storage(
   std::vector<bool> indexer_cache_enabled_layers =
       resolve_indexer_cache_enabled_layers(args, num_layers);
 
-  // Check if KV cache quantization is enabled
-  // "auto" (default): cache dtype aligns with model dtype (no quantization)
-  // "int8": enables INT8 quantization
-  const bool enable_kv_cache_quant = options_.kv_cache_dtype() == "int8";
-
+  const std::string& kv_cache_dtype = options_.kv_cache_dtype();
+  const std::string& indexer_cache_dtype =
+      ::xllm::KVCacheConfig::get_instance().indexer_cache_dtype();
+#if defined(USE_NPU)
+  const bool enable_kv_cache_quant =
+      kv_cache_dtype == "int8" || kv_cache_dtype == "fp8_e4m3";
   const bool enable_indexer_cache_quant =
-      ::xllm::KVCacheConfig::get_instance().indexer_cache_dtype() == "int8";
+      indexer_cache_dtype == "int8" || indexer_cache_dtype == "fp8_e4m3";
+#else
+  const bool enable_kv_cache_quant = kv_cache_dtype == "int8";
+  const bool enable_indexer_cache_quant = indexer_cache_dtype == "int8";
+#endif
+#if defined(USE_NPU)
+  const bool supports_npu_python_glm52_cache_quant =
+      args.model_type() == "glm_moe_dsa" &&
+      ModelConfig::is_python_model_impl(context_.get_model_impl());
+  CHECK(!enable_kv_cache_quant ||
+        (kv_cache_dtype == "fp8_e4m3" && supports_npu_python_glm52_cache_quant))
+      << "NPU quantized KV cache only supports PyTorch GLM-5.2.";
+  CHECK(indexer_cache_dtype != "fp8_e4m3" ||
+        supports_npu_python_glm52_cache_quant)
+      << "NPU quantized indexer cache only supports PyTorch GLM-5.2.";
+#endif
   if (enable_lighting_indexer) {
     CHECK_EQ(kv_cache_shape.has_index_cache_scale_shape(),
-             enable_indexer_cache_quant)
+             indexer_cache_dtype == "int8")
         << "Indexer cache shape and worker quantization config must agree.";
   }
 
   if (enable_kv_cache_quant) {
-#if !defined(USE_MLU)
-    LOG(FATAL) << "KV Cache quantization is only supported on MLU backend. "
-               << "Current backend does not support this feature.";
+#if !defined(USE_MLU) && !defined(USE_NPU)
+    LOG(FATAL) << "KV Cache quantization is unsupported on this backend.";
 #endif
     // Check for unsupported scenarios
     if (options_.backend() == "vlm") {
@@ -561,7 +577,9 @@ bool WorkerImpl::allocate_kv_cache_storage(
       .layer_cache_owned(std::move(layer_cache_owned))
       .indexer_cache_enabled_layers(std::move(indexer_cache_enabled_layers))
       .enable_kv_cache_quant(enable_kv_cache_quant)
+      .kv_cache_dtype(kv_cache_dtype)
       .enable_indexer_cache_quant(enable_indexer_cache_quant)
+      .indexer_cache_dtype(indexer_cache_dtype)
       .tensor_allocator(std::move(tensor_allocator))
       .block_size(options_.block_size())
       .head_dim(args.head_dim())

--- a/xllm/pybind/args.py
+++ b/xllm/pybind/args.py
@@ -213,7 +213,10 @@ class ArgumentParser:
             "--kv_cache_dtype",
             type=str,
             default="auto",
-            help='KV cache data type. "auto" (default) aligns with model dtype, "int8" enables INT8 quantization (MLU only).',
+            help=(
+                'KV cache data type. "auto" aligns with model dtype, "int8" enables INT8 quantization on MLU, '
+                'and "fp8_e4m3" enables E4M3 cache storage for PyTorch GLM-5.2 on NPU.'
+            ),
         )
         self.parser.add_argument(
             "--use_cpp_chat_template",

--- a/xllm/python/attention/fp8_cache.py
+++ b/xllm/python/attention/fp8_cache.py
@@ -1,0 +1,97 @@
+# Copyright 2026 The xLLM Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://github.com/xLLM-AI/xllm/blob/main/LICENSE
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Software E4M3 encoding for NPU caches.
+
+The current NPU cast operator cannot consume or produce native PyTorch FP8
+tensors. Cache tensors therefore store the IEEE-like E4M3FN bit pattern in a
+``torch.uint8`` tensor. These helpers encode floating-point values on cache
+writes and explicitly decode them before attention computation.
+"""
+
+from __future__ import annotations
+
+from functools import cache
+
+import torch
+
+_E4M3_MAX = 448.0
+_E4M3_MIN_NORMAL = 2.0**-6
+_E4M3_SUBNORMAL_SCALE = 2.0**9
+
+
+def quantize_e4m3(value: torch.Tensor) -> torch.Tensor:
+    """Encode a floating-point tensor as saturated E4M3FN bytes."""
+    if not value.is_floating_point():
+        raise TypeError("E4M3 cache quantization requires a floating-point tensor")
+
+    working = value.to(torch.float32)
+    absolute = torch.nan_to_num(
+        working.abs(),
+        nan=0.0,
+        posinf=_E4M3_MAX,
+        neginf=_E4M3_MAX,
+    ).clamp(max=_E4M3_MAX)
+    sign_bits = (working < 0).to(torch.int32) * 128
+
+    is_normal = absolute >= _E4M3_MIN_NORMAL
+    exponent = torch.floor(torch.log2(absolute.clamp_min(_E4M3_MIN_NORMAL))).to(torch.int32)
+    exponent_value = torch.exp2(exponent.to(torch.float32))
+    mantissa = torch.round((absolute / exponent_value - 1.0) * 8.0).to(torch.int32)
+    carry = mantissa == 8
+    exponent = exponent + carry.to(torch.int32)
+    mantissa = torch.where(carry, torch.zeros_like(mantissa), mantissa)
+    normal_bits = (exponent + 7) * 8 + mantissa
+
+    subnormal_bits = torch.round(absolute * _E4M3_SUBNORMAL_SCALE).to(torch.int32)
+    magnitude_bits = torch.where(is_normal, normal_bits, subnormal_bits).clamp(0, 126)
+    return (sign_bits + magnitude_bits).to(torch.uint8)
+
+
+def dequantize_e4m3(value: torch.Tensor, dtype: torch.dtype = torch.bfloat16) -> torch.Tensor:
+    """Decode E4M3FN bytes to ``dtype`` for attention computation."""
+    if value.dtype != torch.uint8:
+        raise TypeError("E4M3 cache dequantization requires a torch.uint8 tensor")
+
+    if value.device.type == "npu":
+        # Avoid cache-sized arithmetic intermediates retained by ACL graphs.
+        table = _get_e4m3_decode_table(value.device, dtype)
+        indices = value.reshape(-1).to(torch.int32)
+        return torch.index_select(table, 0, indices).reshape(value.shape)
+
+    bits = value.to(torch.int32)
+    is_negative = bits >= 128
+    magnitude_bits = (bits & 127).clamp_max(126)
+    exponent = magnitude_bits >> 3
+    mantissa = magnitude_bits & 7
+
+    subnormal = mantissa.to(torch.float32) * (2.0**-9)
+    normal = (8 + mantissa).to(torch.float32) * torch.exp2((exponent - 10).to(torch.float32))
+    decoded = torch.where(exponent == 0, subnormal, normal)
+    decoded = torch.where(is_negative, -decoded, decoded)
+    return decoded.to(dtype)
+
+
+def create_e4m3_decode_table(device: torch.device) -> torch.Tensor:
+    """Create the 256-entry FP32 lookup table consumed by fused NPU kernels."""
+    encoded = torch.arange(256, dtype=torch.int32).to(torch.uint8)
+    return dequantize_e4m3(encoded, torch.float32).to(device)
+
+
+@cache
+def _get_e4m3_decode_table(device: torch.device, dtype: torch.dtype) -> torch.Tensor:
+    return create_e4m3_decode_table(device).to(dtype)
+
+
+__all__ = ["create_e4m3_decode_table", "dequantize_e4m3", "quantize_e4m3"]

--- a/xllm/python/attention/npu_paged_attention.py
+++ b/xllm/python/attention/npu_paged_attention.py
@@ -37,6 +37,11 @@ from xllm.python.attention.backend import (
 from xllm.python.attention.expanded_decode_metadata import (
     resolve_expanded_decode_metadata,
 )
+from xllm.python.attention.fp8_cache import (
+    create_e4m3_decode_table,
+    dequantize_e4m3,
+    quantize_e4m3,
+)
 from xllm.python.model_executor.cp_utils import cp_gather_kv
 from xllm.python.model_executor.forward_context import (
     AclGraphTask,
@@ -57,6 +62,18 @@ if TYPE_CHECKING:
 #    only aligns when q_len == kv_len and would misalign on a cache hit).
 _SPARSE_MODE_NONE = 0
 _SPARSE_MODE_RIGHT_DOWN_CAUSAL = 3
+
+_GLM52_FP8_ATTN_CORE_NUM = 24
+_GLM52_FP8_ATTN_HEAD_TILE = 16
+_GLM52_FP8_ATTN_KV_TILE = 64
+_GLM52_FP8_ATTN_LATENT_DIM = 512
+_GLM52_FP8_ATTN_ROPE_DIM = 64
+_GLM52_FP8_ATTN_TOPK = 2048
+_GLM52_FP8_ATTN_BLOCK_SIZE = 128
+_GLM52_FP8_ATTN_MAX_QUERIES = 1024
+_GLM52_FP8_ATTN_MAX_CACHE_BLOCKS = 32768
+_GLM52_FP8_ATTN_MAX_BLOCK_TABLE_LEN = 32768
+_GLM52_FP8_ATTN_HEAD_COUNTS = (4, 8, 16)
 
 _HAS_FIA_V2 = hasattr(torch.ops.npu, "npu_fused_infer_attention_score_v2") and hasattr(
     torch_npu, "_npu_fused_infer_attention_score_v2_get_max_workspace"
@@ -560,7 +577,7 @@ class NpuPagedAttentionBackend(AttentionBackend):
             if not cache_is_preprocessed:
                 if k_latent_3d is None or k_pe_3d is None:
                     raise RuntimeError("MLA cache inputs are required")
-                torch.ops.xllm_ops.reshape_paged_cache(
+                self._update_mla_cache(
                     metadata.slot_mapping,
                     k_latent_3d,
                     k_pe_3d,
@@ -598,7 +615,7 @@ class NpuPagedAttentionBackend(AttentionBackend):
         global_rope = cp_gather_kv(k_pe_3d, cp_context).contiguous()
         cache_slots = metadata.local_slot_mapping if metadata.has_kv_shard else metadata.slot_mapping
         assert cache_slots is not None
-        torch.ops.xllm_ops.reshape_paged_cache(
+        self._update_mla_cache(
             cache_slots,
             global_latent,
             global_rope,
@@ -648,6 +665,8 @@ class NpuPagedAttentionBackend(AttentionBackend):
         kv_cache, rope_cache = layer_cache.key, layer_cache.value
         if kv_cache is None or rope_cache is None:
             raise RuntimeError(f"MLA latent cache is missing for layer {layer.layer_id}")
+        if kv_cache.dtype == torch.uint8:
+            return None
         return MlaPreprocessContext(
             kv_cache=kv_cache,
             rope_cache=rope_cache,
@@ -729,6 +748,46 @@ class NpuPagedAttentionBackend(AttentionBackend):
         return metadata
 
     @staticmethod
+    def _update_paged_cache(
+        cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        values: torch.Tensor,
+    ) -> None:
+        """Write raw E4M3 bytes, skipping CP and graph padding slots."""
+        slots = slot_mapping.reshape(-1)
+        if cache.device.type != "cpu":
+            kernels.fp8_cache_write(
+                slots.to(torch.int64).contiguous(),
+                values.reshape(slots.numel(), cache.size(-1)).contiguous(),
+                cache.view(-1, cache.size(-1)),
+            )
+            return
+        valid_rows = torch.nonzero(slots >= 0, as_tuple=False).flatten()
+        if valid_rows.numel() == 0:
+            return
+        # ScatterNdUpdateV2 has no uint8 specialization. index_copy_ preserves
+        # every encoded bit, including bytes with the high bit set.
+        cache.view(-1, cache.size(-1)).index_copy_(
+            0,
+            slots.index_select(0, valid_rows).to(torch.int64),
+            values.reshape(slots.numel(), cache.size(-1)).index_select(0, valid_rows),
+        )
+
+    @staticmethod
+    def _update_mla_cache(
+        slot_mapping: torch.Tensor,
+        k_latent: torch.Tensor,
+        k_rope: torch.Tensor,
+        nope_cache: torch.Tensor,
+        rope_cache: torch.Tensor,
+    ) -> None:
+        if nope_cache.dtype == torch.uint8:
+            NpuPagedAttentionBackend._update_paged_cache(nope_cache, slot_mapping, quantize_e4m3(k_latent))
+            NpuPagedAttentionBackend._update_paged_cache(rope_cache, slot_mapping, quantize_e4m3(k_rope))
+            return
+        torch.ops.xllm_ops.reshape_paged_cache(slot_mapping, k_latent, k_rope, nope_cache, rope_cache)
+
+    @staticmethod
     def _update_mla_index_cache(
         index_cache: torch.Tensor,
         index_cache_scale: torch.Tensor | None,
@@ -736,6 +795,9 @@ class NpuPagedAttentionBackend(AttentionBackend):
         values: torch.Tensor,
         scales: torch.Tensor | None,
     ) -> None:
+        if index_cache.dtype == torch.uint8:
+            NpuPagedAttentionBackend._update_paged_cache(index_cache, slot_mapping, values)
+            return
         if slot_mapping.numel() == 0:
             return
         cache_view = index_cache.view(-1, index_cache.size(-1))
@@ -835,6 +897,28 @@ class NpuPagedAttentionBackend(AttentionBackend):
             actual_seq_q = self._mla_actual_seq_q
         if actual_seq_kv is None:
             actual_seq_kv = self._mla_actual_seq_kv
+        if nope_cache.dtype == torch.uint8 and self._can_use_glm52_fp8_sparse_mla(
+            q_latent,
+            q_pe,
+            nope_cache,
+            rope_cache,
+            topk,
+            block_table,
+            actual_seq_kv,
+        ):
+            return self._glm52_fp8_sparse_mla(
+                q_latent,
+                q_pe,
+                nope_cache,
+                rope_cache,
+                topk,
+                block_table,
+                actual_seq_kv,
+                layer_id,
+            )
+        if nope_cache.dtype == torch.uint8:
+            nope_cache = dequantize_e4m3(nope_cache, torch.bfloat16)
+            rope_cache = dequantize_e4m3(rope_cache, torch.bfloat16)
         out = get_execution_buffer(
             ("SFA_OUTPUT", layer_id) + tuple(q_latent.shape),
             lambda: torch.empty_like(q_latent),
@@ -856,6 +940,168 @@ class NpuPagedAttentionBackend(AttentionBackend):
             3,
             out,
         )  # [T, H, kv_lora]
+
+    def _can_use_glm52_fp8_sparse_mla(
+        self,
+        q_latent: torch.Tensor,
+        q_pe: torch.Tensor,
+        nope_cache: torch.Tensor,
+        rope_cache: torch.Tensor,
+        topk: torch.Tensor,
+        block_table: torch.Tensor,
+        actual_seq_kv: torch.Tensor,
+    ) -> bool:
+        metadata = getattr(self, "_metadata", None)
+        num_queries = q_latent.size(0)
+        return (
+            metadata is not None
+            and not metadata.is_prefill
+            and not metadata.is_chunked_prefill
+            and not metadata.is_mixed
+            and not metadata.is_spec_verify
+            and nope_cache.dtype == torch.uint8
+            and rope_cache.dtype == torch.uint8
+            and 0 < num_queries <= _GLM52_FP8_ATTN_MAX_QUERIES
+            and q_latent.dim() == 3
+            and q_latent.dtype == torch.bfloat16
+            and q_latent.size(1) in _GLM52_FP8_ATTN_HEAD_COUNTS
+            and q_latent.size(2) == _GLM52_FP8_ATTN_LATENT_DIM
+            and q_latent.stride(2) == 1
+            and q_pe.shape
+            == (
+                num_queries,
+                q_latent.size(1),
+                _GLM52_FP8_ATTN_ROPE_DIM,
+            )
+            and q_pe.dtype == torch.bfloat16
+            and q_pe.stride(2) == 1
+            and nope_cache.dim() == 4
+            and nope_cache.is_contiguous()
+            and nope_cache.size(0) <= _GLM52_FP8_ATTN_MAX_CACHE_BLOCKS
+            and nope_cache.shape[1:]
+            == (
+                _GLM52_FP8_ATTN_BLOCK_SIZE,
+                1,
+                _GLM52_FP8_ATTN_LATENT_DIM,
+            )
+            and rope_cache.dim() == 4
+            and rope_cache.is_contiguous()
+            and rope_cache.shape
+            == (
+                nope_cache.size(0),
+                _GLM52_FP8_ATTN_BLOCK_SIZE,
+                1,
+                _GLM52_FP8_ATTN_ROPE_DIM,
+            )
+            and topk.is_contiguous()
+            and topk.dtype == torch.int32
+            and topk.shape == (num_queries, 1, _GLM52_FP8_ATTN_TOPK)
+            and block_table.is_contiguous()
+            and block_table.dtype == torch.int32
+            and block_table.dim() == 2
+            and block_table.size(0) == num_queries
+            and block_table.size(1) <= _GLM52_FP8_ATTN_MAX_BLOCK_TABLE_LEN
+            and actual_seq_kv is not None
+            and actual_seq_kv.is_contiguous()
+            and actual_seq_kv.dtype == torch.int32
+            and actual_seq_kv.shape == (num_queries,)
+        )
+
+    def _glm52_fp8_sparse_mla(
+        self,
+        q_latent: torch.Tensor,
+        q_pe: torch.Tensor,
+        nope_cache: torch.Tensor,
+        rope_cache: torch.Tensor,
+        topk: torch.Tensor,
+        block_table: torch.Tensor,
+        actual_seq_kv: torch.Tensor,
+        layer_id: int,
+    ) -> torch.Tensor:
+        decode_table = getattr(self, "_fp8_e4m3_decode_table", None)
+        if decode_table is None or decode_table.device != q_latent.device:
+            decode_table = create_e4m3_decode_table(q_latent.device)
+            self._fp8_e4m3_decode_table = decode_table
+
+        workspaces = getattr(self, "_fp8_mla_workspaces", None)
+        if workspaces is None or workspaces[0].device != q_latent.device:
+            bf16 = torch.bfloat16
+            fp32 = torch.float32
+            device = q_latent.device
+            workspaces = (
+                torch.empty(
+                    _GLM52_FP8_ATTN_CORE_NUM,
+                    _GLM52_FP8_ATTN_KV_TILE,
+                    _GLM52_FP8_ATTN_LATENT_DIM,
+                    dtype=bf16,
+                    device=device,
+                ),
+                torch.empty(
+                    _GLM52_FP8_ATTN_CORE_NUM,
+                    _GLM52_FP8_ATTN_KV_TILE,
+                    _GLM52_FP8_ATTN_ROPE_DIM,
+                    dtype=bf16,
+                    device=device,
+                ),
+                torch.empty(
+                    _GLM52_FP8_ATTN_CORE_NUM,
+                    _GLM52_FP8_ATTN_HEAD_TILE,
+                    _GLM52_FP8_ATTN_KV_TILE,
+                    dtype=fp32,
+                    device=device,
+                ),
+                torch.empty(
+                    _GLM52_FP8_ATTN_CORE_NUM,
+                    _GLM52_FP8_ATTN_HEAD_TILE,
+                    _GLM52_FP8_ATTN_KV_TILE,
+                    dtype=bf16,
+                    device=device,
+                ),
+                torch.empty(
+                    _GLM52_FP8_ATTN_CORE_NUM,
+                    _GLM52_FP8_ATTN_HEAD_TILE,
+                    _GLM52_FP8_ATTN_LATENT_DIM,
+                    dtype=fp32,
+                    device=device,
+                ),
+                torch.empty(
+                    _GLM52_FP8_ATTN_CORE_NUM,
+                    _GLM52_FP8_ATTN_HEAD_TILE,
+                    _GLM52_FP8_ATTN_LATENT_DIM,
+                    dtype=bf16,
+                    device=device,
+                ),
+                torch.empty(
+                    _GLM52_FP8_ATTN_CORE_NUM,
+                    _GLM52_FP8_ATTN_HEAD_TILE,
+                    _GLM52_FP8_ATTN_ROPE_DIM,
+                    dtype=bf16,
+                    device=device,
+                ),
+            )
+            self._fp8_mla_workspaces = workspaces
+
+        output = get_execution_buffer(
+            ("GLM52_FP8_SFA_OUTPUT", layer_id) + tuple(q_latent.shape),
+            lambda: torch.empty(
+                q_latent.shape,
+                dtype=q_latent.dtype,
+                device=q_latent.device,
+            ),
+        )
+        return kernels.glm52_fp8_sparse_mla_attention_out(
+            q_latent,
+            q_pe,
+            nope_cache,
+            rope_cache,
+            topk,
+            block_table,
+            actual_seq_kv,
+            decode_table,
+            output,
+            *workspaces,
+            self.scale,
+        )
 
     def _mla_dense_fia_v2_out(
         self,
@@ -910,6 +1156,9 @@ class NpuPagedAttentionBackend(AttentionBackend):
         layer_id: int,
     ) -> torch.Tensor:
         """Run dense absorbed MLA with FIA v2 and separate RoPE caches."""
+        if nope_cache.dtype == torch.uint8:
+            nope_cache = dequantize_e4m3(nope_cache, torch.bfloat16)
+            rope_cache = dequantize_e4m3(rope_cache, torch.bfloat16)
         if not self._use_fia_v2:
             raise RuntimeError("dense MLA requires FIA v2 support")
         if self._mla_actual_seq_q_host is None:

--- a/xllm/python/kernels_npu/__init__.py
+++ b/xllm/python/kernels_npu/__init__.py
@@ -84,6 +84,8 @@ _EXPORTS = {
         "vision_rotary_mul",
     ),
     "sparse_attention": (
+        "fp8_cache_write",
+        "glm52_fp8_sparse_mla_attention_out",
         "lightning_indexer",
         "lightning_indexer_out",
         "quant_lightning_indexer",
@@ -103,6 +105,8 @@ _EXPORTS = {
 }
 
 __all__ = [
+    "fp8_cache_write",
+    "glm52_fp8_sparse_mla_attention_out",
     "rms_norm",
     "gemma_rms_norm",
     "fused_add_rms_norm",

--- a/xllm/python/kernels_npu/_custom_op.py
+++ b/xllm/python/kernels_npu/_custom_op.py
@@ -1032,6 +1032,50 @@ def _sfa_dcp_remap_out_fake(
     return out
 
 
+def _glm52_fp8_sparse_mla_attention_out_fake(
+    q_latent: torch.Tensor,
+    q_rope: torch.Tensor,
+    nope_cache: torch.Tensor,
+    rope_cache: torch.Tensor,
+    topk_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    actual_seq_lengths_kv: torch.Tensor,
+    e4m3_decode_table: torch.Tensor,
+    output: torch.Tensor,
+    workspace_k: torch.Tensor,
+    workspace_k_rope: torch.Tensor,
+    workspace_scores: torch.Tensor,
+    workspace_probs: torch.Tensor,
+    workspace_output: torch.Tensor,
+    workspace_q: torch.Tensor,
+    workspace_q_rope: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor:
+    del (
+        q_latent,
+        q_rope,
+        nope_cache,
+        rope_cache,
+        topk_indices,
+        block_table,
+        actual_seq_lengths_kv,
+        e4m3_decode_table,
+        workspace_k,
+        workspace_k_rope,
+        workspace_scores,
+        workspace_probs,
+        workspace_output,
+        workspace_q,
+        workspace_q_rope,
+        softmax_scale,
+    )
+    return output
+
+
+def _fp8_cache_write_fake(slots: torch.Tensor, values: torch.Tensor, cache: torch.Tensor) -> None:
+    del slots, values, cache
+
+
 register_fake("xllm_ops::rms_norm", _rms_norm_fake)
 register_fake("xllm_ops::rms_norm_gated", _rms_norm_gated_fake)
 register_fake("xllm_ops::l2_norm", _l2_norm_fake)
@@ -1080,3 +1124,8 @@ register_fake("xllm_ops::sparse_attn_sharedkv", _sparse_attn_sharedkv_fake)
 register_fake("xllm_ops::sparse_attn_sharedkv_metadata", _sparse_attn_sharedkv_metadata_fake)
 register_fake("xllm_ops::sparse_flash_attention_lse", _sparse_flash_attention_lse_fake)
 register_fake("xllm_ops::sfa_dcp_remap_out", _sfa_dcp_remap_out_fake)
+
+
+register_fake("xllm_ops::glm52_fp8_sparse_mla_attention_out", _glm52_fp8_sparse_mla_attention_out_fake)
+
+register_fake("xllm_ops::fp8_cache_write", _fp8_cache_write_fake)

--- a/xllm/python/kernels_npu/sparse_attention.py
+++ b/xllm/python/kernels_npu/sparse_attention.py
@@ -331,7 +331,55 @@ def sparse_flash_attention_lse(
     )
 
 
+def fp8_cache_write(slots: torch.Tensor, values: torch.Tensor, cache: torch.Tensor) -> None:
+    """Write raw FP8 rows without synchronizing or overwriting padding slots."""
+    torch.ops.xllm_ops.fp8_cache_write(slots, values, cache)
+
+
+def glm52_fp8_sparse_mla_attention_out(
+    q_latent: torch.Tensor,
+    q_rope: torch.Tensor,
+    nope_cache: torch.Tensor,
+    rope_cache: torch.Tensor,
+    topk_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    actual_seq_lengths_kv: torch.Tensor,
+    e4m3_decode_table: torch.Tensor,
+    output: torch.Tensor,
+    workspace_k: torch.Tensor,
+    workspace_k_rope: torch.Tensor,
+    workspace_scores: torch.Tensor,
+    workspace_probs: torch.Tensor,
+    workspace_output: torch.Tensor,
+    workspace_q: torch.Tensor,
+    workspace_q_rope: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor:
+    """Run decode-only GLM-5.2 sparse MLA on raw E4M3 paged caches."""
+    return torch.ops.xllm_ops.glm52_fp8_sparse_mla_attention_out(
+        q_latent,
+        q_rope,
+        nope_cache,
+        rope_cache,
+        topk_indices,
+        block_table,
+        actual_seq_lengths_kv,
+        e4m3_decode_table,
+        output,
+        workspace_k,
+        workspace_k_rope,
+        workspace_scores,
+        workspace_probs,
+        workspace_output,
+        workspace_q,
+        workspace_q_rope,
+        softmax_scale,
+    )
+
+
 __all__ = [
+    "fp8_cache_write",
+    "glm52_fp8_sparse_mla_attention_out",
     "lightning_indexer",
     "lightning_indexer_out",
     "quant_lightning_indexer",

--- a/xllm/python/kernels_npu/tilelang/fp8_cache_write.py
+++ b/xllm/python/kernels_npu/tilelang/fp8_cache_write.py
@@ -1,0 +1,54 @@
+# Copyright 2026 The xLLM Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://github.com/xLLM-AI/xllm/blob/main/LICENSE
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Copy FP8 cache rows while ignoring negative padding slots on device."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import tilelang.language as T
+
+if TYPE_CHECKING:
+    from tvm.tir import PrimFunc
+
+NUM_ROWS = T.symbolic("num_rows")
+CACHE_ROWS = T.symbolic("cache_rows")
+SUPPORTED_HEAD_DIMS = (64, 128, 512)
+
+
+def build_fp8_cache_write_kernel(head_dim: int) -> PrimFunc:
+    if head_dim not in SUPPORTED_HEAD_DIMS:
+        raise ValueError(f"unsupported FP8 cache head dimension: {head_dim}")
+
+    @T.prim_func
+    def fp8_cache_write(
+        slots: T.Tensor((NUM_ROWS,), "int64"),
+        values: T.Tensor((NUM_ROWS, head_dim), "uint8"),
+        cache: T.Tensor((CACHE_ROWS, head_dim), "uint8"),
+    ):
+        with T.Kernel(24, is_npu=True) as (cid, vid):
+            task_id = cid * 2 + vid
+            rows_per_task = (NUM_ROWS + 47) // 48
+            row_start = task_id * rows_per_task
+            row_end = T.min(row_start + rows_per_task, NUM_ROWS)
+            with T.Scope("V"):
+                row_ub = T.alloc_ub((head_dim,), "uint8")
+                for row in T.serial(row_start, row_end):
+                    slot = T.Cast("int32", slots[row])
+                    if slot >= 0:
+                        T.copy(values[row, :], row_ub)
+                        T.copy(row_ub, cache[slot, :])
+
+    return fp8_cache_write

--- a/xllm/python/kernels_npu/tilelang/glm52_fp8_sparse_mla_attention.py
+++ b/xllm/python/kernels_npu/tilelang/glm52_fp8_sparse_mla_attention.py
@@ -1,0 +1,573 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 The xLLM Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import tilelang.language as T
+
+if TYPE_CHECKING:
+    from tvm.tir import PrimFunc
+
+from xllm.python.kernels_npu.tilelang.utils import DEFAULT_ASCEND_PASS_CONFIGS
+
+LATENT_DIM = 512
+ROPE_DIM = 64
+TOPK = 2048
+BLOCK_SIZE = 128
+CORE_NUM = 24
+HEAD_TILE = 16
+KV_TILE = 64
+VEC_NUM = 2
+VEC_HEAD_TILE = HEAD_TILE // VEC_NUM
+VEC_KV_TILE = KV_TILE // VEC_NUM
+KV_COPY_ROWS = 32
+MAX_NUM_QUERIES = 1024
+MAX_CACHE_BLOCKS = 32768
+MAX_BLOCK_TABLE_LEN = 32768
+DEFAULT_DTYPE = "bf16"
+SUPPORTED_NUM_HEADS = (4, 8, 16)
+
+
+def build_glm52_fp8_sparse_mla_attention_kernel(num_heads: int) -> PrimFunc:
+    if num_heads not in SUPPORTED_NUM_HEADS:
+        raise ValueError(
+            f"GLM-5.2 FP8 sparse MLA attention only supports num_heads in {SUPPORTED_NUM_HEADS}, got {num_heads}"
+        )
+
+    num_kv_tiles = TOPK // KV_TILE
+    input_dtype = "bfloat16"
+    accum_dtype = "float32"
+    index_dtype = "int32"
+
+    @T.prim_func
+    def glm52_fp8_sparse_mla_attention_kernel(
+        q_latent: T.Tensor((1, MAX_NUM_QUERIES * num_heads * LATENT_DIM), input_dtype),
+        q_rope: T.Tensor((1, MAX_NUM_QUERIES * num_heads * ROPE_DIM), input_dtype),
+        nope_cache: T.Tensor((MAX_CACHE_BLOCKS, BLOCK_SIZE, LATENT_DIM), "uint8"),
+        rope_cache: T.Tensor((MAX_CACHE_BLOCKS, BLOCK_SIZE, ROPE_DIM), "uint8"),
+        topk_indices: T.Tensor((MAX_NUM_QUERIES, TOPK), index_dtype),
+        block_table: T.Tensor((1, MAX_NUM_QUERIES * MAX_BLOCK_TABLE_LEN), index_dtype),
+        actual_seq_lengths_kv: T.Tensor((MAX_NUM_QUERIES,), index_dtype),
+        e4m3_decode_table: T.Tensor((256,), accum_dtype),
+        output: T.Tensor((MAX_NUM_QUERIES, num_heads, LATENT_DIM), input_dtype),
+        workspace_k: T.Tensor((CORE_NUM, KV_TILE, LATENT_DIM), input_dtype),
+        workspace_k_rope: T.Tensor((CORE_NUM, KV_TILE, ROPE_DIM), input_dtype),
+        workspace_scores: T.Tensor((CORE_NUM, HEAD_TILE, KV_TILE), accum_dtype),
+        workspace_probs: T.Tensor((CORE_NUM, HEAD_TILE, KV_TILE), input_dtype),
+        workspace_output: T.Tensor((CORE_NUM, HEAD_TILE, LATENT_DIM), accum_dtype),
+        workspace_q: T.Tensor((CORE_NUM, HEAD_TILE, LATENT_DIM), input_dtype),
+        workspace_q_rope: T.Tensor((CORE_NUM, HEAD_TILE, ROPE_DIM), input_dtype),
+        q_token_stride: T.int32,
+        q_head_stride: T.int32,
+        q_rope_token_stride: T.int32,
+        q_rope_head_stride: T.int32,
+        num_queries: T.int32,
+        block_table_stride: T.int32,
+        softmax_scale: T.float32,
+    ):
+        with T.Kernel(CORE_NUM, is_npu=True) as (cid, vid):
+            q_l1 = T.alloc_L1((HEAD_TILE, LATENT_DIM), input_dtype)
+            q_rope_l1 = T.alloc_L1((HEAD_TILE, ROPE_DIM), input_dtype)
+            k_l1 = T.alloc_L1((KV_TILE, LATENT_DIM), input_dtype)
+            k_rope_l1 = T.alloc_L1((KV_TILE, ROPE_DIM), input_dtype)
+            probs_l1 = T.alloc_L1((HEAD_TILE, KV_TILE), input_dtype)
+            scores_l0c = T.alloc_L0C((HEAD_TILE, KV_TILE), accum_dtype)
+            output_l0c = T.alloc_L0C((HEAD_TILE, LATENT_DIM), accum_dtype)
+
+            indices_ub = T.alloc_ub((KV_TILE,), index_dtype)
+            indices_fp32_ub = T.alloc_ub((KV_TILE,), accum_dtype)
+            valid_mask_ub = T.alloc_ub((32,), "uint8")
+            nonnegative_mask_ub = T.alloc_ub((32,), "uint8")
+            decode_table_ub = T.alloc_ub((256,), accum_dtype)
+            raw_cache_ub = T.alloc_ub((LATENT_DIM,), "uint8")
+            raw_cache_fp16_ub = T.alloc_ub((LATENT_DIM,), "float16")
+            decode_offsets_i32_ub = T.alloc_ub((LATENT_DIM,), index_dtype)
+            decode_offsets_u32_ub = T.alloc_ub((LATENT_DIM,), "uint32")
+            decoded_fp32_ub = T.alloc_ub((LATENT_DIM,), accum_dtype)
+            decoded_bf16_ub = T.alloc_ub((LATENT_DIM,), input_dtype)
+            raw_rope_cache_ub = T.alloc_ub((ROPE_DIM,), "uint8")
+            raw_rope_cache_fp16_ub = T.alloc_ub((ROPE_DIM,), "float16")
+            rope_decode_offsets_i32_ub = T.alloc_ub((ROPE_DIM,), index_dtype)
+            rope_decode_offsets_u32_ub = T.alloc_ub((ROPE_DIM,), "uint32")
+            decoded_rope_fp32_ub = T.alloc_ub((ROPE_DIM,), accum_dtype)
+            decoded_rope_bf16_ub = T.alloc_ub((ROPE_DIM,), input_dtype)
+            k_gather_ub = T.alloc_ub((2, KV_COPY_ROWS, LATENT_DIM), input_dtype)
+            k_rope_gather_ub = T.alloc_ub((2, KV_COPY_ROWS, ROPE_DIM), input_dtype)
+            q_gather_ub = T.alloc_ub((VEC_HEAD_TILE, LATENT_DIM), input_dtype)
+            q_rope_gather_ub = T.alloc_ub((VEC_HEAD_TILE, ROPE_DIM), input_dtype)
+
+            score_max_ub = T.alloc_ub((VEC_HEAD_TILE, 1), accum_dtype)
+            previous_score_max_ub = T.alloc_ub((VEC_HEAD_TILE, 1), accum_dtype)
+            scores_ub = T.alloc_ub((VEC_HEAD_TILE, KV_TILE), accum_dtype)
+            score_max_broadcast_ub = T.alloc_ub((VEC_HEAD_TILE, KV_TILE), accum_dtype)
+            output_scale_broadcast_ub = T.alloc_ub((VEC_HEAD_TILE, LATENT_DIM), accum_dtype)
+            score_sum_ub = T.alloc_ub((VEC_HEAD_TILE, 1), accum_dtype)
+            normalizer_ub = T.alloc_ub((VEC_HEAD_TILE, 1), accum_dtype)
+            probs_bf16_ub = T.alloc_ub((VEC_HEAD_TILE, KV_TILE), input_dtype)
+            partial_output_ub = T.alloc_ub((VEC_HEAD_TILE, LATENT_DIM), accum_dtype)
+            accumulated_output_ub = T.alloc_ub((VEC_HEAD_TILE, LATENT_DIM), accum_dtype)
+            normalizer_broadcast_ub = T.alloc_ub((VEC_HEAD_TILE, LATENT_DIM), accum_dtype)
+            output_bf16_ub = T.alloc_ub((VEC_HEAD_TILE, LATENT_DIM), input_dtype)
+
+            queries_per_core = (num_queries + CORE_NUM - 1) // CORE_NUM
+            query_start = cid * queries_per_core
+            query_end = T.if_then_else(
+                query_start + queries_per_core < num_queries,
+                query_start + queries_per_core,
+                num_queries,
+            )
+
+            if cid < num_queries:
+                T.copy(e4m3_decode_table, decode_table_ub)
+                T.set_flag("mte2", "v", 4)
+                T.wait_flag("mte2", "v", 4)
+                for query_idx in T.serial(query_start, query_end):
+                    T.tile.fill(q_gather_ub, 0.0)
+                    T.tile.fill(q_rope_gather_ub, 0.0)
+                    T.set_flag("v", "mte2", 8)
+                    T.wait_flag("v", "mte2", 8)
+                    if num_heads <= VEC_HEAD_TILE:
+                        if vid == 0:
+                            for head_idx in range(num_heads):
+                                T.copy(
+                                    q_latent[
+                                        0,
+                                        query_idx * q_token_stride + head_idx * q_head_stride : query_idx
+                                        * q_token_stride
+                                        + head_idx * q_head_stride
+                                        + LATENT_DIM,
+                                    ],
+                                    q_gather_ub[head_idx, :],
+                                )
+                                T.copy(
+                                    q_rope[
+                                        0,
+                                        query_idx * q_rope_token_stride + head_idx * q_rope_head_stride : query_idx
+                                        * q_rope_token_stride
+                                        + head_idx * q_rope_head_stride
+                                        + ROPE_DIM,
+                                    ],
+                                    q_rope_gather_ub[head_idx, :],
+                                )
+                    else:
+                        for head_idx in range(VEC_HEAD_TILE):
+                            global_head_idx = vid * VEC_HEAD_TILE + head_idx
+                            T.copy(
+                                q_latent[
+                                    0,
+                                    query_idx * q_token_stride + global_head_idx * q_head_stride : query_idx
+                                    * q_token_stride
+                                    + global_head_idx * q_head_stride
+                                    + LATENT_DIM,
+                                ],
+                                q_gather_ub[head_idx, :],
+                            )
+                            T.copy(
+                                q_rope[
+                                    0,
+                                    query_idx * q_rope_token_stride + global_head_idx * q_rope_head_stride : query_idx
+                                    * q_rope_token_stride
+                                    + global_head_idx * q_rope_head_stride
+                                    + ROPE_DIM,
+                                ],
+                                q_rope_gather_ub[head_idx, :],
+                            )
+                    T.set_flag("mte2", "mte3", 6)
+                    T.wait_flag("mte2", "mte3", 6)
+                    T.copy(
+                        q_gather_ub,
+                        workspace_q[
+                            cid,
+                            vid * VEC_HEAD_TILE : (vid + 1) * VEC_HEAD_TILE,
+                            :,
+                        ],
+                    )
+                    T.copy(
+                        q_rope_gather_ub,
+                        workspace_q_rope[
+                            cid,
+                            vid * VEC_HEAD_TILE : (vid + 1) * VEC_HEAD_TILE,
+                            :,
+                        ],
+                    )
+
+                    T.copy(workspace_q[cid, :, :], q_l1)
+                    T.copy(workspace_q_rope[cid, :, :], q_rope_l1)
+                    T.set_flag("mte2", "mte1", 7)
+                    T.wait_flag("mte2", "mte1", 7)
+
+                    actual_kv_len = actual_seq_lengths_kv[query_idx]
+                    T.tile.fill(accumulated_output_ub, 0.0)
+                    T.tile.fill(normalizer_ub, 0.0)
+                    T.tile.fill(score_max_ub, 2.0**30)
+
+                    for tile_idx in T.serial(num_kv_tiles):
+                        T.copy(
+                            topk_indices[
+                                query_idx,
+                                tile_idx * KV_TILE : (tile_idx + 1) * KV_TILE,
+                            ],
+                            indices_ub,
+                        )
+                        T.set_flag("mte2", "v", 5)
+                        T.wait_flag("mte2", "v", 5)
+                        T.copy(indices_ub, indices_fp32_ub)
+                        T.pipe_barrier("v")
+                        T.tile.compare(
+                            valid_mask_ub,
+                            indices_fp32_ub,
+                            T.float32(actual_kv_len - 1),
+                            "LE",
+                        )
+                        T.tile.compare(
+                            nonnegative_mask_ub,
+                            indices_fp32_ub,
+                            T.float32(0.0),
+                            "GE",
+                        )
+                        T.tile.bitwise_and(
+                            valid_mask_ub,
+                            valid_mask_ub,
+                            nonnegative_mask_ub,
+                        )
+
+                        for row_idx in range(VEC_KV_TILE):
+                            copy_group = row_idx // KV_COPY_ROWS
+                            copy_row = row_idx % KV_COPY_ROWS
+                            global_copy_group = tile_idx * (VEC_KV_TILE // KV_COPY_ROWS) + copy_group
+                            ping_pong = global_copy_group % 2
+                            index_in_tile = row_idx + vid * VEC_KV_TILE
+                            sparse_index = indices_ub[index_in_tile]
+                            safe_sparse_index = T.if_then_else(
+                                sparse_index >= 0,
+                                T.if_then_else(
+                                    sparse_index < actual_kv_len,
+                                    sparse_index,
+                                    0,
+                                ),
+                                0,
+                            )
+                            logical_block = safe_sparse_index // BLOCK_SIZE
+                            physical_block = block_table[
+                                0,
+                                query_idx * block_table_stride + logical_block,
+                            ]
+                            physical_block = T.if_then_else(
+                                physical_block >= 0,
+                                physical_block,
+                                0,
+                            )
+                            block_offset = safe_sparse_index % BLOCK_SIZE
+
+                            T.copy(
+                                nope_cache[physical_block, block_offset, :],
+                                raw_cache_ub,
+                            )
+                            T.set_flag("mte2", "v", 6)
+                            T.wait_flag("mte2", "v", 6)
+                            T.tile.cast(
+                                raw_cache_fp16_ub,
+                                raw_cache_ub,
+                                "CAST_NONE",
+                                LATENT_DIM,
+                            )
+                            T.tile.cast(
+                                decode_offsets_i32_ub,
+                                raw_cache_fp16_ub,
+                                "CAST_RINT",
+                                LATENT_DIM,
+                            )
+                            T.pipe_barrier("v")
+                            T.tile.mul(
+                                decode_offsets_i32_ub,
+                                decode_offsets_i32_ub,
+                                4,
+                            )
+                            T.pipe_barrier("v")
+                            T.reinterpretcast(
+                                decode_offsets_u32_ub,
+                                decode_offsets_i32_ub,
+                                "uint32_t",
+                            )
+                            # Gather derives its vector length from the source
+                            # view. Decode 512 values as two bounded 256-value
+                            # operations to avoid UB overrun.
+                            T.tile.gather(
+                                decoded_fp32_ub[:256],
+                                decode_table_ub,
+                                decode_offsets_u32_ub[:256],
+                                0,
+                            )
+                            T.tile.gather(
+                                decoded_fp32_ub[256:],
+                                decode_table_ub,
+                                decode_offsets_u32_ub[256:],
+                                0,
+                            )
+                            T.pipe_barrier("v")
+                            T.tile.cast(
+                                decoded_bf16_ub,
+                                decoded_fp32_ub,
+                                "CAST_RINT",
+                                LATENT_DIM,
+                            )
+                            T.copy(
+                                decoded_bf16_ub,
+                                k_gather_ub[ping_pong, copy_row, :],
+                            )
+
+                            T.copy(
+                                rope_cache[physical_block, block_offset, :],
+                                raw_rope_cache_ub,
+                            )
+                            T.set_flag("mte2", "v", 7)
+                            T.wait_flag("mte2", "v", 7)
+                            T.tile.cast(
+                                raw_rope_cache_fp16_ub,
+                                raw_rope_cache_ub,
+                                "CAST_NONE",
+                                ROPE_DIM,
+                            )
+                            T.tile.cast(
+                                rope_decode_offsets_i32_ub,
+                                raw_rope_cache_fp16_ub,
+                                "CAST_RINT",
+                                ROPE_DIM,
+                            )
+                            T.pipe_barrier("v")
+                            T.tile.mul(
+                                rope_decode_offsets_i32_ub,
+                                rope_decode_offsets_i32_ub,
+                                4,
+                            )
+                            T.pipe_barrier("v")
+                            T.reinterpretcast(
+                                rope_decode_offsets_u32_ub,
+                                rope_decode_offsets_i32_ub,
+                                "uint32_t",
+                            )
+                            # Limit the source view so Gather writes exactly 64
+                            # RoPE values while byte offsets still address the
+                            # complete 256-entry decode table allocation.
+                            T.tile.gather(
+                                decoded_rope_fp32_ub,
+                                decode_table_ub[:ROPE_DIM],
+                                rope_decode_offsets_u32_ub,
+                                0,
+                            )
+                            T.pipe_barrier("v")
+                            T.tile.cast(
+                                decoded_rope_bf16_ub,
+                                decoded_rope_fp32_ub,
+                                "CAST_RINT",
+                                ROPE_DIM,
+                            )
+                            T.copy(
+                                decoded_rope_bf16_ub,
+                                k_rope_gather_ub[ping_pong, copy_row, :],
+                            )
+
+                            if (row_idx + 1) % KV_COPY_ROWS == 0:
+                                if global_copy_group > 1:
+                                    T.wait_flag("mte3", "v", ping_pong)
+                                T.set_flag("v", "mte3", ping_pong)
+                                T.wait_flag("v", "mte3", ping_pong)
+                                T.copy(
+                                    k_gather_ub[ping_pong, :, :],
+                                    workspace_k[
+                                        cid,
+                                        vid * VEC_KV_TILE + copy_group * KV_COPY_ROWS : vid * VEC_KV_TILE
+                                        + (copy_group + 1) * KV_COPY_ROWS,
+                                        :,
+                                    ],
+                                )
+                                T.copy(
+                                    k_rope_gather_ub[ping_pong, :, :],
+                                    workspace_k_rope[
+                                        cid,
+                                        vid * VEC_KV_TILE + copy_group * KV_COPY_ROWS : vid * VEC_KV_TILE
+                                        + (copy_group + 1) * KV_COPY_ROWS,
+                                        :,
+                                    ],
+                                )
+                                if global_copy_group < num_kv_tiles - 2:
+                                    T.set_flag("mte3", "v", ping_pong)
+
+                        T.copy(workspace_k[cid, :, :], k_l1)
+                        T.copy(workspace_k_rope[cid, :, :], k_rope_l1)
+                        T.set_flag("mte2", "mte1", 1)
+                        T.wait_flag("mte2", "mte1", 1)
+                        T.gemm_v0(
+                            q_l1,
+                            k_l1,
+                            scores_l0c,
+                            transpose_B=True,
+                            init=True,
+                        )
+                        T.gemm_v0(
+                            q_rope_l1,
+                            k_rope_l1,
+                            scores_l0c,
+                            transpose_B=True,
+                        )
+                        T.set_flag("m", "fix", 2)
+                        T.wait_flag("m", "fix", 2)
+                        T.copy(scores_l0c, workspace_scores[cid, :, :])
+
+                        T.copy(score_max_ub, previous_score_max_ub)
+                        T.copy(
+                            workspace_scores[
+                                cid,
+                                vid * VEC_HEAD_TILE : (vid + 1) * VEC_HEAD_TILE,
+                                :,
+                            ],
+                            scores_ub,
+                        )
+                        T.set_flag("mte2", "v", 0)
+                        T.wait_flag("mte2", "v", 0)
+                        for head_idx in T.serial(VEC_HEAD_TILE):
+                            T.tile.select(
+                                scores_ub[head_idx, :],
+                                valid_mask_ub,
+                                scores_ub[head_idx, :],
+                                -T.infinity(accum_dtype),
+                                "VSEL_TENSOR_SCALAR_MODE",
+                            )
+                        T.pipe_barrier("v")
+                        T.reduce_max(scores_ub, score_max_ub, dim=-1)
+                        T.pipe_barrier("v")
+                        T.tile.mul(score_max_ub, score_max_ub, -softmax_scale)
+                        T.pipe_barrier("v")
+                        T.tile.min(
+                            score_max_ub,
+                            score_max_ub,
+                            previous_score_max_ub,
+                        )
+                        T.pipe_barrier("v")
+                        T.tile.broadcast(score_max_broadcast_ub, score_max_ub)
+                        T.pipe_barrier("v")
+                        T.tile.axpy(
+                            score_max_broadcast_ub,
+                            scores_ub,
+                            softmax_scale,
+                        )
+                        T.pipe_barrier("v")
+                        T.tile.exp(scores_ub, score_max_broadcast_ub)
+                        T.pipe_barrier("v")
+                        T.tile.sub(
+                            previous_score_max_ub,
+                            score_max_ub,
+                            previous_score_max_ub,
+                        )
+                        T.pipe_barrier("v")
+                        T.tile.exp(
+                            previous_score_max_ub,
+                            previous_score_max_ub,
+                        )
+                        T.pipe_barrier("v")
+                        T.copy(scores_ub, probs_bf16_ub)
+                        T.pipe_barrier("v")
+                        T.set_flag("v", "mte3", 1)
+                        T.wait_flag("v", "mte3", 1)
+                        T.copy(
+                            probs_bf16_ub,
+                            workspace_probs[
+                                cid,
+                                vid * VEC_HEAD_TILE : (vid + 1) * VEC_HEAD_TILE,
+                                :,
+                            ],
+                        )
+
+                        T.copy(workspace_probs[cid, :, :], probs_l1)
+                        T.set_flag("mte2", "mte1", 3)
+                        T.wait_flag("mte2", "mte1", 3)
+                        T.gemm_v0(
+                            probs_l1,
+                            k_l1,
+                            output_l0c,
+                            init=True,
+                        )
+                        T.set_flag("m", "fix", 4)
+                        T.wait_flag("m", "fix", 4)
+                        T.copy(output_l0c, workspace_output[cid, :, :])
+
+                        T.copy(
+                            workspace_output[
+                                cid,
+                                vid * VEC_HEAD_TILE : (vid + 1) * VEC_HEAD_TILE,
+                                :,
+                            ],
+                            partial_output_ub,
+                        )
+                        T.set_flag("mte2", "v", 2)
+                        T.wait_flag("mte2", "v", 2)
+                        T.reduce_sum(scores_ub, score_sum_ub, dim=-1)
+                        T.pipe_barrier("v")
+                        T.tile.mul(
+                            normalizer_ub,
+                            normalizer_ub,
+                            previous_score_max_ub,
+                        )
+                        T.pipe_barrier("v")
+                        T.tile.add(normalizer_ub, normalizer_ub, score_sum_ub)
+                        T.pipe_barrier("v")
+                        T.tile.broadcast(
+                            output_scale_broadcast_ub,
+                            previous_score_max_ub,
+                        )
+                        T.pipe_barrier("v")
+                        T.tile.mul(
+                            accumulated_output_ub,
+                            accumulated_output_ub,
+                            output_scale_broadcast_ub,
+                        )
+                        T.pipe_barrier("v")
+                        T.tile.add(
+                            accumulated_output_ub,
+                            accumulated_output_ub,
+                            partial_output_ub,
+                        )
+
+                    T.tile.broadcast(normalizer_broadcast_ub, normalizer_ub)
+                    T.pipe_barrier("v")
+                    T.tile.div(
+                        accumulated_output_ub,
+                        accumulated_output_ub,
+                        normalizer_broadcast_ub,
+                    )
+                    T.pipe_barrier("v")
+                    T.copy(accumulated_output_ub, output_bf16_ub)
+                    T.set_flag("v", "mte3", 9)
+                    T.wait_flag("v", "mte3", 9)
+                    if num_heads <= VEC_HEAD_TILE:
+                        if vid == 0:
+                            T.copy(
+                                output_bf16_ub[0:num_heads, :],
+                                output[query_idx, 0:num_heads, :],
+                            )
+                    else:
+                        T.copy(
+                            output_bf16_ub,
+                            output[
+                                query_idx,
+                                vid * VEC_HEAD_TILE : (vid + 1) * VEC_HEAD_TILE,
+                                :,
+                            ],
+                        )
+
+    return glm52_fp8_sparse_mla_attention_kernel

--- a/xllm/python/models/glm5_2.py
+++ b/xllm/python/models/glm5_2.py
@@ -39,6 +39,7 @@ import torch.nn as nn
 
 from xllm.python import distributed, kernels
 from xllm.python.attention.backend import MlaIndexContext
+from xllm.python.attention.fp8_cache import dequantize_e4m3, quantize_e4m3
 
 # The AICPU tiling of ``aclnnQuantLightningIndexer`` requires
 # ``num_heads_q / num_heads_k == 64``. GLM-5.2 uses ``index_n_heads=32`` and
@@ -682,8 +683,12 @@ class Glm52Indexer(nn.Module):
                 cmp_ratio,
             )
         else:
+            if index_cache.dtype == torch.uint8:
+                k = quantize_e4m3(k)
             ctx.update_index_cache(k, None)
             index_cache, _, block_table = ctx.materialize_index_cache()
+            if index_cache.dtype == torch.uint8:
+                index_cache = dequantize_e4m3(index_cache, torch.bfloat16)
             topk = kernels.lightning_indexer(
                 q,
                 index_cache,


### PR DESCRIPTION


## Description

Store GLM-5.2 KV, RoPE and index caches as raw E4M3 bytes in the Python NPU runtime. Add cache allocation and accounting, graph-safe writes, fused sparse MLA decode and a bounded-memory BF16 fallback.


<!-- What does this PR do? Briefly describe the changes and why they are needed. -->

## Related Issues

<!-- Link related issues here. Use "Fixes #123" when this PR closes an issue. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] Build or CI

## Pull Request Checklist

Thank you for contributing to xLLM. Before requesting review, please make sure the following items are complete.

### PR Title and Commit Messages

- [ ] The PR title and each commit message follow the xLLM commit format: `<type>: <subject>`.

> Allowed types: feat, bugfix, docs, test, refactor, chore, style, revert, perf, model, build, release.
> The subject should use clear English, start with a verb, include at least 4 words, and end with `.`.

### Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` or an equivalent command.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

### Self Review

- [ ] I have self-reviewed the code according to `.agents/skills/code-review/references/custom-code-style.md`, especially code written or assisted by AI.
- [ ] I have rebased this PR onto the latest `main` branch.

### Build and Test Coverage

- [ ] Tests have been added or updated as needed.
- [ ] CUDA: `python setup.py build test` has passed on a CUDA machine.
- [ ] NPU: `python setup.py build test` has passed on an NPU machine.
- [ ] MLU: `python setup.py build test` has passed on an MLU machine.

## Reviewer Notes

<!-- Optional: anything reviewers should focus on, known risks, follow-ups, or validation gaps. -->
